### PR TITLE
Update chargers.mdx

### DIFF
--- a/docs/reference/configuration/chargers.mdx
+++ b/docs/reference/configuration/chargers.mdx
@@ -134,7 +134,7 @@ Firmware 040.0 oder neuer benötigt!
 **Beispiel**:
 
 ```yaml
-  type: cfos
+  type: go-e
   ...
 ```
 


### PR DESCRIPTION
type bei go-e war falsch auf "cfos"