### PR TITLE
Update chargers.mdx

### DIFF
--- a/docs/devices/chargers.mdx
+++ b/docs/devices/chargers.mdx
@@ -233,6 +233,14 @@ Das Öffnen einer Wallbox sollte grundsätzlich nur durch Personen mit einer ent
 
 <Config part="chargers" file="fritzdect" />
 
+:::
+standbypower: 15 # treat as charging above this power. 
+                  # If standbypower is negative the measured power of the switch is ignored, 
+				  # charging (State C) is defined by charge enabled only.
+				  # Typical usecase for negative standbypower: 
+				  # the switch is driving smart grid input of a heatpump, the measured power is zero
+:::
+
 ### Tasmota
 
 <Config part="chargers" file="tasmota" />


### PR DESCRIPTION
Ich habe einen Änderungsvorschlag für den Funkschalter FRITZ!DECT 200/210 bzgl. parameter standbypower.
Das betrifft use cases wenn Funkschalter zur leistungslosen Ansteuerung benutzt werden. Im Moment ist die Änderung nur für die Fritz!dect eingebaut.  Diskussion und Lösung siehe https://github.com/evcc-io/evcc/issues/2408#issue-1115385926
und https://github.com/evcc-io/evcc/pull/2414#issue-1116122008. @thierolm Noch warten mit dem Doku Update?

das hier sollte in etwa so  ergänzt werden:
standbypower: 15 # treat as charging above this power. 
                             # If standbypower is negative the measured power of the switch is ignored,
                             # charging (State C) is defined by charge enabled only.
		             # Typical usecase for negative standbypower: 
		             # the switch is driving smart grid input of a heatpump, the measured power is zero