### PR TITLE
Update linux.mdx

### DIFF
--- a/docs/installation/linux.mdx
+++ b/docs/installation/linux.mdx
@@ -17,7 +17,7 @@ Raspberry Pi 1 (A, B, A+, B+, Zero, Zero W) müssen die [Manuelle Installation](
 - Installiere die benötigten Abhängigkeiten:
 
   ```sh
-  sudo apt install -y debian-keyring debian-archive-keyring apt-transport-https
+  sudo apt install -y debian-keyring debian-archive-keyring apt-transport-https curl
   ```
 
 - Füge den evcc GPG Schlüssel hinzu:


### PR DESCRIPTION
Add curl to the list of dependencies that have to be installed. In regular Linux installations curl is already installed but not in the usual docker linux images.