### PR TITLE
Add info about Sponsortoken for go-e phase switching

### DIFF
--- a/docs/devices/chargers.mdx
+++ b/docs/devices/chargers.mdx
@@ -192,7 +192,7 @@ chargers:
 
 Benötigt mindestens Firmware 052.1 oder neuer. 
 
-Für 1P/3P-Phasenumschaltung muss die HTTP API v2 im Charger aktiviert sein.
+Für 1P/3P-Phasenumschaltung muss die HTTP API v2 im Charger aktiviert sein und es wird ein Sponsortoken benötigt. 💚
 
 ```yaml
 chargers:


### PR DESCRIPTION
In https://github.com/evcc-io/evcc/discussions/3086 wurde aufgebracht dass die Info über den Sponsortoken fehlt