### PR TITLE
hostmode zu manueller Installation

### DIFF
--- a/docs/installation/docker.mdx
+++ b/docs/installation/docker.mdx
@@ -68,10 +68,11 @@ evcc/evcc:latest
 ```
 
   </TabItem>
-  <TabItem value="sma" label="SMA Geräte">
+  <TabItem value="sma" label="SMA Geräte und EEBus">
   Für die Verwendung des SMA Sunny Home Manger 2.0 muss evcc eine eindeutige Geräte-ID erstellen. Unter Linux wird <i>machine-id</i> verwendet. Diese muss dafür in den Container gemounted werden. Zusätzlicher Paramter:
 
 ```
+--network host
 -v /etc/machine-id:/etc/machine-id \
 ```
 


### PR DESCRIPTION
- Der Hinweis für den networkmode ist in #239 raus geflogen. In der compose Variate war der die ganze Zeit.
- Im Manuell Hinweis, dass dies auch für EEBus gilt hinzugefügt. (war bei compose bereits so)