### PR TITLE
vehicle add min/targetsoc

### DIFF
--- a/docs/reference/configuration/vehicles.mdx
+++ b/docs/reference/configuration/vehicles.mdx
@@ -118,10 +118,10 @@ Standardwerte die bei Erkennung des Fahrzeuges angewendet werden sollen:
 **Mögliche Werte**:
 
 * [`mode`](loadpoints#mode)
-* [`minSoc`](loadpoints#min)
-* [`targetSoc`](loadpoints#target)
 * [`minCurrent`](loadpoints#mincurrent)
 * [`maxCurrent`](loadpoints#maxcurrent)
+* `minSoc` es wird sofort mit höchstmöglicher Leistung bis zum angegeben Füllstand geladen, wenn der Modus nicht auf `off` steht
+* `targetSoc` bei Erreichen dieses Füllstandes wird die Ladung gestoppt
 
 **Beispiel**:
 


### PR DESCRIPTION
Erklärung minsoc und targetsoc beim vehicle ergänzt, um die veralteten Parameter soc: min und soc: target beim loadpoint zu löschen