### PR TITLE
Add explanation about not needing smart PV inverters to charge with solar

### DIFF
--- a/docs/guides/meters.mdx
+++ b/docs/guides/meters.mdx
@@ -9,11 +9,11 @@ import SponsorshipRequired from "/docs/_sponsorship_required.mdx";
 
 ### Werden meine Geräte unterstützt?
 
-Hoffentlich. Schau einfach mal unter [Geräte - Hausinstallation](/docs/devices/meters) nach ob du deine Geräte findest. Wenn nicht, versuche es mal mit einer Konfiguration von einem anderen der gleichen Marke.
+Hoffentlich (und relativ wahrscheinlich). Schau einfach mal unter [Geräte - Hausinstallation](/docs/devices/meters) nach ob du deine Geräte findest. Wenn nicht, versuche es mal mit einer Konfiguration mit den generischen Schnittstellen oder einem ähnlichen Gerät der gleichen Marke. Viele Wechselrichter sind z. B. SunSpec-kompatibel und sind daher ohne individuelle Unterstüzung und Benennung als generischer Wechselrichter einbindbar.
 
-### Ich habe eine PV Anlage aber keinen Netzanschluss-Zähler, kann ich evcc trotzdem nutzen?
+### Ich habe eine PV-Anlage aber keinen (auslesbaren) Netzanschluss-Zähler, kann ich evcc trotzdem nutzen?
 
-In dieser Konstellation kann nicht mit PV Überschuss geladen werden, da der dazu notwendige Zähler fehlt. Statt dessen wird in den Lademodi **PV** und **Min+PV** mit der PV Erzeugungsleistung gearbeitet.
+In dieser Konstellation kann nicht mit PV-Überschuss geladen werden, da der dazu notwendige Messpunkt (Zähler) fehlt. Statt dessen wird in den Lademodi **PV** und **Min+PV** mit der PV-Erzeugungsleistung gearbeitet.
 
 Als Optimierung kann über die Einstellung [`residualPower`](/docs/reference/configuration/site#residualpower) ein typischer mittlerer Hausverbrauch angegeben werden.
 
@@ -30,15 +30,14 @@ In dieser Konstellation gibt es nur rudimentäre Nutzungsmöglichkeiten.
 
 Man kann evcc zur Fernsteuerung (start/stop) der Wallbox nutzen.
 
-Notwendig ist auf jeden Fall ein auslesbarer Netzanschlusszähler. 
+Notwendig ist auf jeden Fall ein auslesbarer Netzzähler. 
 
 Ist dieser ebenfalls nicht vorhanden, kann man sich in der Konfiguration mit einem "Dummy-Meter" behelfen. (Beispiel: https://github.com/evcc-io/evcc/discussions/2878) 
 
-Darüberhinaus kann man die Batterie-Ladung eines Fahrzeugs auf einen bestimmten Ladestand (SOC) begrenzen. In diesem Fall ist es aber zwingend notwendig, dass das Fahrzeug in die Konfiguration übernommen wird.
+Darüberhinaus kann man die Ladung einer Fahrzeugbatterie auf einen bestimmten Ladestand (SoC) begrenzen. In diesem Fall ist es aber zwingend notwendig, dass das Fahrzeug in die Konfiguration mit aufgenommen wird.
 
 
-### Ich habe keine PV Anlage, kann ich evcc trotzdem sinnvoll einsetzen?
+### Ich habe einen Netzzähler, aber mein PV-Wehchselrichter ist sehr alt und bietet noch nutzbare Datenschnittstelle die direkt angebunden werden kann. Kann ich evcc trotzdem sinnvoll einsetzen?
 
-Ich habe einen Netzzähler, aber meine PV-Anlage ist zu alt und kann nicht angeschlossen werden. Kann ich EVCC sinnvoll einsetzen?
-
-Ja, wenn Sie einen Netzzähler und ein steuerbares Ladegerät haben, kann EVCC ableiten, wie viel Strom übrig ist, und diesen Strom zum Aufladen eines Autos verwenden
+Ja, wenn ein Netzzähler und eine steuerbare Wallbox vorhanden ist reicht dies für für alle wesentlichen Funktionen von evcc inkl. Überschussladung aus. Es fehlt dann nur die Visualisierung der PV-Erzeugung sowie einige der daraus abgeleiteten Berechnungen und Statistiken.
+Darüber hinaus besteht aber die Möglichkeit die PV-Erzeugungsleistung mit einem nachgerüsteten Erzeugungszähler direkt zu erfassen und somit alle Features wie bei einer direkten Anbindung des PV-Wechselrichters zu nutzen.

--- a/docs/guides/meters.mdx
+++ b/docs/guides/meters.mdx
@@ -37,5 +37,8 @@ Ist dieser ebenfalls nicht vorhanden, kann man sich in der Konfiguration mit ein
 Darüberhinaus kann man die Batterie-Ladung eines Fahrzeugs auf einen bestimmten Ladestand (SOC) begrenzen. In diesem Fall ist es aber zwingend notwendig, dass das Fahrzeug in die Konfiguration übernommen wird.
 
 
+### Ich habe keine PV Anlage, kann ich evcc trotzdem sinnvoll einsetzen?
 
+Ich habe einen Netzzähler, aber meine PV-Anlage ist zu alt und kann nicht angeschlossen werden. Kann ich EVCC sinnvoll einsetzen?
 
+Ja, wenn Sie einen Netzzähler und ein steuerbares Ladegerät haben, kann EVCC ableiten, wie viel Strom übrig ist, und diesen Strom zum Aufladen eines Autos verwenden


### PR DESCRIPTION
Added the fact you don't need a "smart" PV inverter, only a grid meter which is able to detect left over power is enough.