### PR TITLE
Move overview pages to category root

### DIFF
--- a/blog/2021-12-10/version-0-72.md
+++ b/blog/2021-12-10/version-0-72.md
@@ -13,7 +13,7 @@ Es hat sich in den letzten Wochen viel getan, und darüber möchten wir heute et
 
 Der Zugang zu **evcc** erforderte bisher doch einige technische Kenntnisse im Umgang mit dem jeweiligen Betriebssystem. Für Linux (Debian, Ubuntu, Raspberry Pi OS) und macOS gibt es nun eine deutlich vereinfachte Installation. So unterstützt **evcc** nun die Installation über die Paketmanager `apt` unter Linux und [`homebrew`](https://brew.sh) unter macOS.
 
-Hierfür haben wir die Installationsanleitungen nochmals überarbeitet und damit die Installation weiter vereinfacht. Schaut doch mal in der [dazugehörigen Dokumentation](/docs/installation/overview) vorbei.
+Hierfür haben wir die Installationsanleitungen nochmals überarbeitet und damit die Installation weiter vereinfacht. Schaut doch mal in der [dazugehörigen Dokumentation](/docs/installation) vorbei.
 
 ## Einfachere Konfiguration
 

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -2,7 +2,7 @@
 sidebar_position: 1
 ---
 
-# Übersicht
+# Tipps und FAQ
 
 ## Konfiguration
 

--- a/docs/installation/index.md
+++ b/docs/installation/index.md
@@ -2,7 +2,7 @@
 sidebar_position: 1
 ---
 
-# Übersicht
+# Erste Schritte
 
 evcc benötigt eine Konfigurationsdatei `evcc.yaml`, welche beim Start von evcc bereits vorhanden sein muss. In dieser Konfigurationsdatei sind alle Informationen enthalten, damit evcc auf die entsprechenden Geräte zugreifen und das Laden eines Fahrzeugs steuern kann. Gibt es diese Konfigurationsdatei noch nicht, startet evcc im Demo-Modus.
 

--- a/docs/installation/linux.mdx
+++ b/docs/installation/linux.mdx
@@ -87,7 +87,7 @@ Cloudsmith ist ein Service, welcher die Entwicklung von Software und Dienstleist
   Sofern alle Geräte korrekt konfiguriert sind, kannst du mit den nächsten Schritten fortfahren.
 
   :::note
-  Fortgeschrittene Anwender (z.B. mit EVCC Erfahrung oder technischem Know-How) können auch alternativ folgenden Aufruf verwenden:
+  Fortgeschrittene Anwender (z.B. mit evcc Erfahrung oder technischem Know-How) können auch alternativ folgenden Aufruf verwenden:
 
   ```sh
   evcc configure --advanced

--- a/docs/installation/macos.md
+++ b/docs/installation/macos.md
@@ -52,7 +52,7 @@ Es wird mindestens macOS Version 10.12 (Sierra) benötigt, ältere Versionen von
   Sofern alle Geräte korrekt konfiguriert sind, kannst du mit den nächsten Schritten fortfahren.
 
   :::note
-  Fortgeschrittene Anwender (z.B. mit EVCC Erfahrung oder technischem Know-How) können auch alternativ folgenden Aufruf verwenden:
+  Fortgeschrittene Anwender (z.B. mit evcc Erfahrung oder technischem Know-How) können auch alternativ folgenden Aufruf verwenden:
 
   ```sh
   evcc configure --advanced

--- a/docs/reference/configuration/index.md
+++ b/docs/reference/configuration/index.md
@@ -2,7 +2,7 @@
 sidebar_position: 1
 ---
 
-# Grundlagen
+# evcc.yaml
 
 evcc benötigt eine Konfigurationsdatei in der die Installation beschrieben wird. Ohne diese Datei kann evcc nicht genutzt werden. Die Datei selbst ist im [YAML](https://de.wikipedia.org/wiki/YAML) Format geschrieben. Dieses Format definiert eine Syntax wodurch eine strukturierte Datenstruktur in Textform erstellt werden kann.
 
@@ -52,7 +52,7 @@ graph TD;
 
 ```
 
-### Wie funktioniert EVCC? (Ein Blick ins Innere)
+### Wie funktioniert evcc? (Ein Blick ins Innere)
 
 Wichtig für die Funktionalität ist ein Netzanschlusszähler (grid-meter). Dieser ermittelt die aktuelle Überschussleistung.
 Die Messung der Erzeugungsleistung hat in diesem Fall keinen funktionalen Einfluss.

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -2,7 +2,7 @@
 sidebar_position: 1
 ---
 
-# Übersicht
+# Referenz
 
 In diesem Bereich sind die verschiedenen technischen Dokumentationen zu finden.
 

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -10,7 +10,7 @@ In diesem Bereich sind die verschiedenen technischen Dokumentationen zu finden.
 
 Hier werden die verschiedenen möglichen Einstellungen erklärt.
 
-[Weiterlesen...](configuration/home)
+[Weiterlesen...](configuration)
 
 ### Plugins
 


### PR DESCRIPTION
Ich habe die "Übersicht" Seiten in der Navi entfernt. Der Inhalt ist nun in die jeweiligen Knotenseiten (die mit dem Öffnen/Schließen Dreieck) gewandert. Das war damals in Docosaurus nicht möglich, mit der aktuellen Version können die Knotenseiten aber eigenen Inhalt haben. So funktionieren die Links auch wieder.

fixes #319