### PR TITLE
Dummy meter

### DIFF
--- a/docs/guides/meters.mdx
+++ b/docs/guides/meters.mdx
@@ -37,6 +37,15 @@ Darüber hinaus kann man die Ladung einer Fahrzeugbatterie auf einen bestimmten 
 
 Wenn einige Kompoenent  noch nicht vorhanden sind, lassen sich "Dummy" Komponenten einsetzten. Eine gute Quelle für diese ist die [demo.yaml](https://github.com/evcc-io/evcc/blob/master/cmd/demo.yaml),
 
+Eine alternative ist das `const` plugin:
+
+```yaml
+meters:
+  - name: dummymeter
+    type: const
+    value: 123
+```
+
 ### Ich habe einen Netzzähler, aber mein PV-Wechselrichter ist sehr alt und bietet noch nutzbare Datenschnittstelle die direkt angebunden werden kann. Kann ich evcc trotzdem sinnvoll einsetzen?
 
 Ja, wenn ein Netzzähler und eine steuerbare Wallbox vorhanden ist reicht dies für für alle wesentlichen Funktionen von evcc inkl. Überschussladung aus. Es fehlt dann nur die Visualisierung der PV-Erzeugung sowie einige der daraus abgeleiteten Berechnungen und Statistiken.

--- a/docs/guides/meters.mdx
+++ b/docs/guides/meters.mdx
@@ -37,13 +37,13 @@ Darüber hinaus kann man die Ladung einer Fahrzeugbatterie auf einen bestimmten 
 
 Wenn einige Kompoenent  noch nicht vorhanden sind, lassen sich "Dummy" Komponenten einsetzten. Eine gute Quelle für diese ist die [demo.yaml](https://github.com/evcc-io/evcc/blob/master/cmd/demo.yaml),
 
-Eine alternative ist das `const` plugin:
+Eine Alternative ist das `const` plugin:
 
 ```yaml
 meters:
   - name: dummymeter
     type: const
-    value: 123
+    value: 700 # 700 Watt
 ```
 
 ### Ich habe einen Netzzähler, aber mein PV-Wechselrichter ist sehr alt und bietet noch nutzbare Datenschnittstelle die direkt angebunden werden kann. Kann ich evcc trotzdem sinnvoll einsetzen?

--- a/docs/guides/meters.mdx
+++ b/docs/guides/meters.mdx
@@ -31,12 +31,11 @@ Man kann evcc zur Fernsteuerung (start/stop) der Wallbox nutzen.
 
 Notwendig ist auf jeden Fall ein auslesbarer Netzzähler. 
 
-
-Ist dieser ebenfalls nicht vorhanden, kann man sich in der Konfiguration mit einem "Dummy-Meter" behelfen. (Beispiel: https://github.com/evcc-io/evcc/discussions/2878)
-
-
 Darüber hinaus kann man die Ladung einer Fahrzeugbatterie auf einen bestimmten Ladestand (SoC) begrenzen. In diesem Fall ist es aber zwingend notwendig, dass das Fahrzeug in die Konfiguration mit aufgenommen wird.
 
+### Ich bekomme meine Anlage/Auto in einiger Zeit, kann ich schon evcc irgendwie ohne echten Zähler/Auto ausprobieren?
+
+Wenn einige Kompoenent  noch nicht vorhanden sind, lassen sich "Dummy" Komponenten einsetzten. Eine gute Quelle für diese ist die [demo.yaml](https://github.com/evcc-io/evcc/blob/master/cmd/demo.yaml),
 
 ### Ich habe einen Netzzähler, aber mein PV-Wechselrichter ist sehr alt und bietet noch nutzbare Datenschnittstelle die direkt angebunden werden kann. Kann ich evcc trotzdem sinnvoll einsetzen?
 


### PR DESCRIPTION
In https://github.com/evcc-io/evcc/pull/6718 hat @andig sich gewünscht, dass die Doku suggeriert, dass man einen nicht vorhanden meter durch einen den anderen durch irgendein Fake ersetzen sollte und das die demo.yaml eine gute Quelle für dummy meter ist.