### PR TITLE
fix typo

### DIFF
--- a/docs/guides/faq.mdx
+++ b/docs/guides/faq.mdx
@@ -8,7 +8,7 @@ import SponsorshipRequired from "/docs/_sponsorship_required.mdx";
 
 ### Beispiel Konfiguration mit Shelly
 
-In dem Beispiel wird der SG-Ready Kontakt einer Trinkwasserwärmepunpe gesteuert.
+In dem Beispiel wird der SG-Ready Kontakt einer Trinkwasserwärmepumpe gesteuert.
 
 "Vehicle-Soc" dient dabei als Anzeige für die Temperatur.
 


### PR DESCRIPTION
Trinkwasserwärmepumpe muss es wohl heißen