### PR TITLE
Doku Loadpoint: falsche Links und veraltete Parameter korrigiert

### DIFF
--- a/docs/reference/configuration/loadpoints.md
+++ b/docs/reference/configuration/loadpoints.md
@@ -89,11 +89,9 @@ Wobei hier der Wert `renault` dem Wert eines `name` Parameters in der [Fahrzeug 
 
 Definiert, ob beim Abstecken des Ladekabels vom Fahrzeug die Standardeinstellungen für folgende Werte wiederhergestellt werden sollen:
 
-- [`mode`](loadpoints#mode)
-- [`SoC.min`](loadpoints#min) (veraltet)
-- [`SoC.target`](loadpoints#target) (veraltet)
-- [`minCurrent`](loadpoints#mincurrent)
-- [`maxCurrent`](loadpoints#maxcurrent)
+- [`mode`](#mode)
+- [`minCurrent`](#mincurrent)
+- [`maxCurrent`](#maxcurrent)
 
 **Mögliche Werte**:
 


### PR DESCRIPTION
fix #403 