### PR TITLE
Remove note for Raspi 1 requiring manual setup

### DIFF
--- a/docs/installation/linux.mdx
+++ b/docs/installation/linux.mdx
@@ -7,10 +7,6 @@ import TabItem from "@theme/TabItem";
 
 # Debian, Ubuntu, Raspberry Pi
 
-:::note
-Raspberry Pi 1 (A, B, A+, B+, Zero, Zero W) müssen die [Manuelle Installation](manual) verwenden!
-:::
-
 ## Erstinstallation
 
 :::note


### PR DESCRIPTION
Apt install is working, see https://github.com/evcc-io/evcc/discussions/9189