### PR TITLE
i18n: Translate sidebar tab names to EN

### DIFF
--- a/i18n/en/docusaurus-plugin-content-docs/current.json
+++ b/i18n/en/docusaurus-plugin-content-docs/current.json
@@ -1,6 +1,26 @@
 {
   "version.label": {
     "message": "Current",
-    "description": "The label for the current version."
+    "description": "The label for version current"
+  },
+  "sidebar.tutorialSidebar.category.Installation": {
+    "message": "Installation",
+    "description": "The label for category Installation in sidebar"
+  },
+  "sidebar.tutorialSidebar.category.Tipps und FAQ": {
+    "message": "Tips & FAQ",
+    "description": "The label for category Tipps und FAQ in sidebar"
+  },
+  "sidebar.tutorialSidebar.category.Geräte": {
+    "message": "Devices",
+    "description": "The label for category Geräte in sidebar"
+  },
+  "sidebar.tutorialSidebar.category.Referenz": {
+    "message": "Reference",
+    "description": "The label for category Referenz in sidebar"
+  },
+  "sidebar.tutorialSidebar.category.evcc.yaml": {
+    "message": "evcc.yaml",
+    "description": "The label for category evcc.yaml in sidebar"
   }
 }

--- a/i18n/en/docusaurus-plugin-content-docs/current/guides/_category_.json
+++ b/i18n/en/docusaurus-plugin-content-docs/current/guides/_category_.json
@@ -1,4 +1,0 @@
-{
-  "label": "Tips & FAQ",
-  "position": 3
-}

--- a/i18n/en/docusaurus-plugin-content-docs/current/installation/_category_.json
+++ b/i18n/en/docusaurus-plugin-content-docs/current/installation/_category_.json
@@ -1,4 +1,0 @@
-{
-  "label": "Installation",
-  "position": 2
-}


### PR DESCRIPTION
This fixes an issue where sidebar names aren't set as they are in the main docs tree (`_category_.json` isn't used).