### PR TITLE
Fixes typos

### DIFF
--- a/docs/guides/charging.mdx
+++ b/docs/guides/charging.mdx
@@ -10,10 +10,10 @@ import SponsorshipRequired from "/docs/_sponsorship_required.mdx";
 
 | Modus       | Beschreibung                                                                                                                                                                                                                                                                |
 | :---------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Stop**    | Der Ladevorgang wird _sofort_ beendet bzw. kann nicht beginnen.                                                                                                                                                                                                             |
-| **Schnell** | Es wird _sofort_ mit der maximal möglichen Leistung geladen.                                                                                                                                                                                                                |
+| **Aus**     | Der Ladevorgang wird _sofort_ beendet bzw. kann nicht beginnen.                                                                                                                                                                                                             |
+| **PV**      | Der Ladevorgang wird _abhängig_ von der PV Installation zur Verfügung gestellten Leistung gestartet, sofern technisch möglich. Sollte nicht genug Leistung vorhanden sein, wird die Ladung unterbrochen. [Weitere Details](#ich-habe-pv-überschuß-aber-das-auto-lädt-nicht) |
 | **Min+PV**  | Es wird _sofort_ mit der technisch kleinstmöglichen Leistung geladen. Sofern die PV Installation genug Überschuss für eine höhere Leistung hat, wird die Leistung erhöht.                                                                                                   |
-| **Nur PV**  | Der Ladevorgang wird _abhängig_ von der PV Installation zur Verfügung gestellten Leistung gestartet, sofern technisch möglich. Sollte nicht genug Leistung vorhanden sein, wird die Ladung unterbrochen. [Weitere Details](#ich-habe-pv-überschuß-aber-das-auto-lädt-nicht) |
+| **Schnell** | Es wird _sofort_ mit der maximal möglichen Leistung geladen.                                                                                                                                                                                                                |
 
 ### Ich habe PV Überschuss, aber das Auto lädt nicht, warum?
 
@@ -25,9 +25,9 @@ maximal 16 oder 32 Ampere.
 
 Das bedeutet bei
 
-- **1-phasigem Laden** - 1,4 bis 3,6 kW oder 7,2 kW
-- **2-phasigem Laden** - 2,8 bis 7,2 kW oder 14,4 kW
-- **3-phasigem Laden** - 4,2 bis 11 kW oder 22 kW
+- **1-phasigem Laden** - 1,4 bis 3,6 kW (16 A) oder 7,2 kW (32 A)
+- **2-phasigem Laden** - 2,8 bis 7,2 kW (16 A) oder 14,4 kW (32 A)
+- **3-phasigem Laden** - 4,2 bis 11 kW (16 A) oder 22 kW (32 A)
 
 Der neuere Ladestandard [ISO 15118](https://de.wikipedia.org/wiki/ISO_15118) (wird an DC Ladesäulen verwendet, manche Fahrzeuge und Wallboxen unterstützen diesen auch bei AC Laden) erfordert
 
@@ -35,7 +35,7 @@ Der neuere Ladestandard [ISO 15118](https://de.wikipedia.org/wiki/ISO_15118) (wi
 
 Im evcc Modus **Nur PV** muss die jeweilige Leistung als PV Überschuss vorhanden sein, damit der Ladevorgang beginnt. Sollte die Leistung dann eine konfigurierbare Zeit nicht vorhanden sein, wird der Ladevorgang unterbrochen. Ist die Leistung für einen konfigurierbaren Zeitraum vorhanden, wird der Ladevorgang fortgesetzt.
 
-PV-Überschuss wird anhand der Einspeiseleistung am Netzanschluss ermittelt. Überschussladen bzw. der Modus **Nur PV** funktioniert somit bei Anlagen mit abgeregelter Netzeinspeisung („Nulleinspeisung“) nicht.
+PV-Überschuss wird anhand der Einspeiseleistung am Netzanschluss ermittelt. Überschussladen bzw. der Modus **PV** funktioniert somit bei Anlagen mit abgeregelter Netzeinspeisung („Nulleinspeisung“) nicht.
 
 ### Ich habe eine Hausbatterie und diese wird entladen, warum?
 
@@ -51,7 +51,7 @@ Generell kann evcc das Laden und Entladen der Hausbatterie nicht direkt beeinflu
 2. **Hausbatterie wird nicht geladen**:
 
 - Wenn die Hausbatterie voll ist, wird die Batterie nicht geladen.
-- Wenn das HEMS die Fähigkeit von prognosebasiertem Laden (PV Prognose und ein historischen Verbrauch ist vorhanden um die Zukunft abzuschätzen) hat, um nicht voll zu laden wenn vorraussichtlich nicht so viel Strom benötigt wird (z.b. SMA Home Manager 2.0)
+- Wenn das HEMS die Fähigkeit von prognosebasiertem Laden (PV Prognose und ein historischer Verbrauch ist vorhanden, um die Zukunft abzuschätzen) hat, um nicht voll zu laden wenn voraussichtlich nicht so viel Strom benötigt wird (z.b. SMA Home Manager 2.0)
 - Und noch weitere
 
 Mit evcc gibt es nun verschiedene Szenarien:
@@ -65,7 +65,7 @@ Die Hausbatterie wird völlig ignoriert, denn das EV soll ja so schnell wie mög
 - evcc regelt den Ladestrom je nach verfügbarem PV Überschuss
 - Der Ladevorgang wird immer nur dann gestartet, wenn über eine definierte Dauer ([Standard: 1 Minute](/docs/reference/configuration/loadpoints#enable)) der benötigte PV Überschuß vorhanden ist.
 - Der Ladevorgang wird immer unterbrochen, wenn über eine definierte Dauer ([Standard: 1 Minute](/docs/reference/configuration/loadpoints#disable)) nicht genügend Strom für eine [Mindestleistung](#ich-habe-pv-überschuss-aber-das-auto-lädt-nicht-warum) vorhanden ist.
-- Zwischen dem [Invervall des Regelzyklus](/docs/reference/configuration/interval) kann es jedoch zu Schwankungen kommen, so dass weniger Überschuss vorhanden ist als zum Regelzeitpunkt. D.h. falls hier zu wenig PV Überschuss vorhanden ist, muss der "fehlende Strom" irgendwo her kommen. Und wenn die Hausbatterie noch nicht "leer" ist, springt das HEMS ein und zieht Strom aus der Hausbatterie um den Netzschluss Punkt auf 0 auszuregeln. Dies kann nicht verhindert werden!
+- Zwischen dem [Intervall des Regelzyklus](/docs/reference/configuration/interval) kann es jedoch zu Schwankungen kommen, sodass weniger Überschuss vorhanden ist als zum Regelzeitpunkt. D.h. falls hier zu wenig PV Überschuss vorhanden ist, muss der "fehlende Strom" irgendwo her kommen. Und wenn die Hausbatterie noch nicht "leer" ist, springt das HEMS ein und zieht Strom aus der Hausbatterie um den Netzschluss Punkt auf 0 auszuregeln. Dies kann nicht verhindert werden!
 - Zum Zeitpunkt der Regelung in evcc, kann mit
   - [prioritySoC](/docs/reference/configuration/site#prioritysoc) der Hausbatterie bis zu einem definierten SoC Vorrang gegeben werden. Danach wird Ladestrom als verfügbarer PV Überschuss interpretiert.
   - [bufferSoC](/docs/reference/configuration/site#buffersoc) die Hausbatterie oberhalb dieses definierten SoC eine Entladung ignoriert und als PV Überschuss interpretiert.
@@ -74,7 +74,7 @@ Die Hausbatterie wird völlig ignoriert, denn das EV soll ja so schnell wie mög
 
 Das passiert, wenn im Auto ein Ladeziel eingestellt ist, das kleiner oder gleich dem evcc-Ladeziel ist.
 
-Da diesbezüglich kein Datenabgleich zwischen Fahrzeug und evcc stattfindet, lässt sich das nur verhindern, indem das Limit im Auto größer als das evcc-Ladeziel einstellt ist.
+Da diesbezüglich kein Datenabgleich zwischen Fahrzeug und evcc stattfindet, lässt sich das nur verhindern, indem das Limit im Auto größer eingestellt ist als das evcc-Ladeziel.
 
 ### Warum wird mit voller Leistung geladen, wenn der Soc des Fahrzeug nicht erkannt wird?
 
@@ -94,8 +94,8 @@ Dies kann zu ungünstigem Ladeverhalten (z.B. unnötige Einspeisung) führen.
 
 Beispiele:
 
-- Am Loadpoint ist `phases: 3` definiert ist. Das Gastfahrzeug kann aber nur 1-phasig laden. Dann startet die Ladung im PV-Modus trotzdem erst ab 4,2kW Überschuss.
-- Am Loadpoint mit automatischer Phasenumschaltung ist `maxcurrent: 32` definiert. Das Gastfahrzeug kann aber nur maximal mit 16A (3,7kW@1p) laden. Dann findet die Phasenumschaltung von 1p auf 3p erst bei 7,4kW Überschuss statt.
+- Am Loadpoint ist `phases: 3` definiert. Das Gastfahrzeug kann aber nur 1-phasig laden. Dann startet die Ladung im PV-Modus trotzdem erst ab 4,2kW Überschuss.
+- Am Loadpoint mit automatischer Phasenumschaltung ist `maxcurrent: 32` definiert. Das Gastfahrzeug kann aber nur maximal mit 16A (3,7 kW@1p) laden. Dann findet die Phasenumschaltung von 1p auf 3p erst bei 7,4 kW Überschuss statt.
 
 Abhilfe schafft hier die Definition eines (oder mehrerer) Offline-Vehicle. Bei diesen können die entsprechenden Parameter (`phases`, `mincurrent`, `maxcurrent`) definiert werden.
 
@@ -111,7 +111,7 @@ evcc erwartet nach einem Intervallzyklus bereits den neuen korrekten Status.
 
 Wenn manche Geräte etwas zu langsam auf Anweisungen reagieren, kommt es kurzzeitig zu einem undefinierten Zustand, der mit diesen Fehlern quittiert wird.
 
-Sollten ansonsten keine Probleme auftreten, kann das ignoriert werden.
+Sollten ansonsten keine Probleme auftreten, kann die Meldung ignoriert werden.
 
 Abhilfe schafft ein größeres `interval`.
 

--- a/docs/guides/meters.mdx
+++ b/docs/guides/meters.mdx
@@ -37,7 +37,7 @@ Darüber hinaus kann man die Ladung einer Fahrzeugbatterie auf einen bestimmten 
 
 ### Ich bekomme meine Anlage/Wallbox in einiger Zeit, kann ich schon evcc irgendwie ohne echten Zähler/Wallbox ausprobieren?
 
-Wenn einige Komponenten noch nicht vorhanden sind, lassen sich "Dummy" Komponenten einsetzten. Eine gute Quelle für diese ist die [demo.yaml](https://github.com/evcc-io/evcc/blob/master/cmd/demo.yaml),
+Wenn einige Komponenten noch nicht vorhanden sind, lassen sich "Dummy" Komponenten einsetzen. Eine gute Quelle für diese ist die [demo.yaml](https://github.com/evcc-io/evcc/blob/master/cmd/demo.yaml),
 
 Beispiel für einen "Dummy" Zähler mit dem `const` plugin:
 
@@ -72,5 +72,5 @@ chargers:
 
 ### Ich habe einen Netzzähler, aber mein PV-Wechselrichter ist sehr alt und bietet noch keine nutzbare Datenschnittstelle, die direkt angebunden werden kann. Kann ich evcc trotzdem sinnvoll einsetzen?
 
-Ja, wenn ein Netzzähler und eine steuerbare Wallbox vorhanden ist, reicht dies für alle wesentlichen Funktionen von evcc inkl. Überschussladung aus. Es fehlt dann nur die Visualisierung der PV-Erzeugung sowie einige der daraus abgeleiteten Berechnungen und Statistiken.
-Darüber hinaus besteht aber die Möglichkeit die PV-Erzeugungsleistung mit einem nachgerüsteten Erzeugungszähler direkt zu erfassen und somit alle Features wie bei einer direkten Anbindung des PV-Wechselrichters zu nutzen.
+Ja, wenn ein Netzzähler und eine steuerbare Wallbox vorhanden sind, reicht dies für alle wesentlichen Funktionen von evcc inkl. Überschussladung aus. Es fehlt dann nur die Visualisierung der PV-Erzeugung sowie einige der daraus abgeleiteten Berechnungen und Statistiken.
+Darüber hinaus besteht aber die Möglichkeit, die PV-Erzeugungsleistung mit einem nachgerüsteten Erzeugungszähler direkt zu erfassen und somit alle Features wie bei einer direkten Anbindung des PV-Wechselrichters zu nutzen.

--- a/docs/guides/setup.mdx
+++ b/docs/guides/setup.mdx
@@ -36,9 +36,9 @@ Eine schnelle Hilfe bieten yaml-Tester wie z.B. (https://onlineyamltools.com/val
 
 ### Etwas funktioniert nicht. Was nun?
 
-Bei evcc gibt es einen [Community Support](https://github.com/evcc-io/evcc/discussions). Hier helfen sowohl Entwickler als auch Anwender bei verschiedenen Problemen. Es wäre gut dabei möglichst genaue Informationen zu folgenden Bereichen mitzuteilen:
+Bei evcc gibt es einen [Community Support](https://github.com/evcc-io/evcc/discussions). Hier helfen sowohl Entwickler als auch Anwender bei verschiedenen Problemen. Es wäre gut, dabei möglichst genaue Informationen zu folgenden Bereichen mitzuteilen:
 
-- Welche Geräte (Fahrzeug, Hausinstallation, Wallbox) werden verwendet.
+- Welche Geräte (Fahrzeug, Hausinstallation, Wallbox) verwendet werden.
 
 - Die Konfigurationsdatei `evcc.yaml`,
 
@@ -68,7 +68,7 @@ evcc gibt in seiner Standard Konfiguration nur dann Fehlermeldungen aus, wenn ei
 
 Wenn evcc auf der Konsole ausgeführt wird, werden die `log` Nachrichten einfach in die normale Ausgabe geleitet.
 
-Mittels `evcc charger` oder `evcc meter` oder `evcc vehicle` können auf der Kommandozeile die verschiedenen Gerätetype getestet werden. Dabei kommt der in `evcc.yaml` konfigurierte Log-Parameter (siehe oben) zum Einsatz. Will man davon abweichende Tests durchführen, kann der Log-Parameter beim Aufruf entsprechend ergänzt werden.
+Mittels `evcc charger` oder `evcc meter` oder `evcc vehicle` können auf der Kommandozeile die verschiedenen Gerätetypen getestet werden. Dabei kommt der in `evcc.yaml` konfigurierte Log-Parameter (siehe oben) zum Einsatz. Will man davon abweichende Tests durchführen, kann der Log-Parameter beim Aufruf entsprechend ergänzt werden.
 
 `Beispiel: evcc -l debug meter`
 
@@ -78,18 +78,18 @@ Wird evcc als Linux Systemdienst, wie unter [Linux Autostart](/docs/installation
   `sudo journalctl -fau evcc`
 - Anzeige der evcc log Meldungen seit dem letzten Start des evcc Services (Abbruch mit Strg-c)  
   `sudo journalctl -u evcc -q`
-- Speichern der Log-Ausgabe oben in eine Datei im Home-Verzeichnis  
+- Speichern der Log-Ausgabe in eine Datei im Home-Verzeichnis  
   `sudo journalctl -u evcc -q > ~/evcc.log`
-- ergänzend kann auch noch Start- (`-S`) und Endzeitpunkt (`-U`) der Log-Ausgabe bestimmt werden  
+- Ergänzend kann auch noch Start- (`-S`) und Endzeitpunkt (`-U`) der Log-Ausgabe bestimmt werden  
   `sudo journalctl -u evcc -S "2023-03-21 07:00:00" -U "2023-03-21 08:00:00" -q > ~/evcc.log`
 
 Weiterführende Hilfe: [wiki.ubuntuusers.de/systemd/journalctl](https://wiki.ubuntuusers.de/systemd/journalctl/)
 
-Im Falle einer Docker Installation kann man über `docker logs` die Nachrichten anzeigen lassen, siehe [Docker Dokumentation](https://docs.docker.com/config/containers/logging/)
+Im Falle einer Docker Installation kann man über `docker logs` die Nachrichten anzeigen lassen, siehe [Docker Dokumentation](https://docs.docker.com/config/containers/logging/).
 
 ### Weiterführende Hilfe bei der Geräteerkennung
 
-`evcc detect` ist ein spezielles Kommando, welches eine Art Hardwareerkennung und Netzwerksuche für bestimmt Geräte ermöglicht.
+`evcc detect` ist ein spezielles Kommando, welches eine Art Hardwareerkennung und Netzwerksuche für bestimmte Geräte ermöglicht.
 Insbesondere hilft es manchmal bei der ersten Einschätzung von "neuen" SunSpec-kompatiblen Modbus-Geräten und bei der Validierung von IP-Konfigurationen.
 Es ist aber mehr ein Entwickler- und Supporttool zu Diagnosezwecken und erkennt auch nur einen nicht näher definierbaren Gerätetypenkreis.
 
@@ -99,7 +99,7 @@ Es kommt immer wieder vor, dass Fehler in der Konfiguration übersehen werden un
 
 In dem Fall sollte man evcc durch Eingabe von `evcc` auf der Kommandozeile starten. Dort werden dann auch Fehlerhinweise gegeben, die den Start des Service verhindert haben.
 
-Mittels der oben genannten Tests kann man diesen Fehlern auf den Grund gehen und beheben. Erst wenn alles fehlerfrei ist, sollte der Service gestartet werden.
+Mittels der oben genannten Tests kann man diesen Fehlern auf den Grund gehen und sie beheben. Erst wenn alles fehlerfrei ist, sollte der Service gestartet werden.
 
 ### Fehler: `connection refused`
 
@@ -109,8 +109,8 @@ Die Gründe dafür können vielfältig sein. Typisch sind:
 
 - Der am Gerät offene Port stimmt nicht mit dem in der evcc-Konfiguration angegebenen Zielport überein.
 - Der externe Zugriff auf das Gerät ist nicht aktiviert (z.B. bei Solaredge-Wechselrichtern im Auslieferungszustand).
-- Die maximal mögliche Anzahl an parallelen Verbindungen die das Zielgerät verwalten kann ist erschöpft. Andere Verbindungen z. B. von Hausautomationen, Scripten oder weiteren Instanzen von evcc müssen ggf. zunächst beendet werden bevor eine neue Verbindung möglich ist. Im ungünstigsten Fall lässt das Zielsystem nur eine einzige Verbindung zu.
-- Blockade durch eine Firewall
+- Die maximal mögliche Anzahl an parallelen Verbindungen, die das Zielgerät verwalten kann, ist erschöpft. Andere Verbindungen z. B. von Hausautomationen, Skripten oder weiteren Instanzen von evcc müssen ggf. zunächst beendet werden, bevor eine neue Verbindung möglich ist. Im ungünstigsten Fall lässt das Zielsystem nur eine einzige Verbindung zu.
+- Blockade durch eine Firewall.
 
 ### Fehler: `i/o timeout`
 
@@ -165,7 +165,7 @@ Mehr Informationen findest du auch auf unserer [Datenschutzseite](https://sponso
 
 In der evcc Oberfläche wird dir unten rechts angezeigt wieviel Prozent deiner geladenen Energie aus eigenem Sonnenstrom stammt (Beispiel: **85% Sonnenenergie**).
 Beim Klick darauf öffnet sich ein Dialog der mehr Details zur Ladenergie und deinen eingesparten Kosten zeigt.
-Damit diese Werte korrekt sind musst du deinen Energie- und Einspeisepreis in der Konfiguration hinterlegen.
+Damit diese Werte korrekt sind, musst du deinen Energie- und Einspeisepreis in der Konfiguration hinterlegen.
 Hier ein Beispiel:
 
 **Beispiel**:
@@ -196,12 +196,12 @@ Batterieverluste durch die Umwandlung werden nicht berücksichtigt.
 **Berechnung von Ersparnis und effektivem Energiepreis**
 
 Der Algorithmus unterscheidet zwischen Netzstrom und selbst erzeugter Sonnenenergie (PV, Batterie).
-Der Kostenvorteil deiner Sonnenenergie ergibt sich aus der Differenz zwischen deinem Netzbezugspreis (z.B. 30ct/kWh) und deinem Einspeisetarif (z.B. 8ct/kWh).
-Jede geladene kWh selbst produzierter Energie ist in diesem Beispiel 22ct (30ct - 8ct) günstiger als der Netzbezug.
-Hast du 2 kWh eigene Energie geladen entspricht das einer **Ersparnis** von 44ct.
+Der Kostenvorteil deiner Sonnenenergie ergibt sich aus der Differenz zwischen deinem Netzbezugspreis (z.B. 30 ct/kWh) und deinem Einspeisetarif (z.B. 8 ct/kWh).
+Jede geladene kWh selbst produzierter Energie ist in diesem Beispiel 22 ct (30 ct - 8 ct) günstiger als der Netzbezug.
+Hast du 2 kWh eigene Energie geladen entspricht das einer **Ersparnis** von 44 ct.
 
-Würdest du dein Auto zu 100% mit eigener Sonnenenergie laden, entspricht der angezeigte **effektive Energiepreis** deiner, nicht eingenommenen, Einspeisevergütung (bspw. 8ct/kWh).
-Lädst du dein Auto zu 50% aus Sonnenenergie und zu 50% aus Netzstrom passt sich der Energiepreis entsprechend an (bspw. 19ct/kWh).
+Würdest du dein Auto zu 100% mit eigener Sonnenenergie laden, entspricht der angezeigte **effektive Energiepreis** deiner, nicht eingenommenen, Einspeisevergütung (bspw. 8 ct/kWh).
+Lädst du dein Auto zu 50% aus Sonnenenergie und zu 50% aus Netzstrom passt sich der Energiepreis entsprechend an (bspw. 19 ct/kWh).
 
 Wenn du keine Einspeisevergütung erhältst, kannst du den Einspeisepreis auf 0 setzen.
 Die Sonnenenergie wird dann als kostenlos gerechnet.

--- a/docs/guides/vehicles.mdx
+++ b/docs/guides/vehicles.mdx
@@ -12,58 +12,58 @@ Dazu muss man meist den Benutzernamen und das Passwort für die Hersteller-App i
 
 ### Wird mein Auto unterstützt?
 
-Vielleicht. Schau einfach mal unter [Geräte - Fahrzeuge](/docs/devices/vehicles) nach ob du dein Fahrzeug findest. Wenn nicht, versuche es mal mit einer Konfiguration von einem anderen des gleichen Herstellers.
+Vielleicht. Schau einfach mal unter [Geräte - Fahrzeuge](/docs/devices/vehicles) nach ob du dein Fahrzeug findest. Wenn nicht, versuche es mal mit einer Konfiguration von einem anderen Fahrzeug des gleichen Herstellers.
 
 ### Wie wird Klimatisierung unterstützt?
 
 Bei manchen Fahrzeugen kann evcc über die Online-Verbindung ebenfalls erkennen, ob das Fahrzeug gerade ein Vorklimatisierung durchführt.
 In diesem Fall wird die technisch an der Wallbox niedrigste mögliche Leistung freigegeben, damit das Fahrzeug mit dem Strom über die Wallbox klimatisieren kann.
 
-In diesem Fall kann es vorkommen, dass die Klimatisierung im Fahrzeug weniger Leistung als die freigegebene Leistung benötigt.
-Und damit kann es sein, dass das Fahrzeug die restliche verfügbare Leistung verwendet um die Batterie weiter zu laden, auch wenn eine festgelegte Begrenzung des Ladezustandes bereits erreicht wurde.
+Dabei kann es vorkommen, dass die Klimatisierung im Fahrzeug weniger als die freigegebene Leistung benötigt.
+Dann verwendet das Fahrzeug die restliche verfügbare Leistung, um die Batterie weiter zu laden, auch wenn eine festgelegte Begrenzung des Ladezustandes bereits erreicht wurde.
 
-Sobald die Klimatisierung als beendet erkannt wird, wird die Wallbox wieder gesperrt, so dass das Fahrzeug keinen weiteren Strom über die Wallbox beziehen kann falls nicht ohnehin gerade geladen wird.
+Sobald die Klimatisierung als beendet erkannt wird, wird die Wallbox wieder gesperrt, sodass das Fahrzeug keinen weiteren Strom über die Wallbox beziehen kann, falls nicht ohnehin gerade geladen wird.
 
 :::note Anmerkung
-Dies gilt nur für die Kombination von Fahrzeugen und Wallbox, wo diese beiden über den Standard IEC61851 kommunizieren. Dies ist heute die Regel.
+Dies gilt nur für die Kombination von Fahrzeugen und Wallboxen, die über den Standard IEC61851 kommunizieren. Dies ist heute die Regel.
 
-Bei Fahrzeugen und Wallboxen die über ISO15118 kommunizieren, bekommt das Fahrzeug genau die Energiemenge welche es direkt an der Wallbox anfrägt.
+Bei Fahrzeugen und Wallboxen, die über den Standard ISO15118 kommunizieren, bekommt das Fahrzeug genau die Energiemenge, welche es direkt an der Wallbox anfragt.
 :::
 
 ## Erkennung des Fahrzeugs an der Wallbox
 
-Wenn ein oder mehrere Fahrzeuge konfiguriert sind, muss evcc diese unterscheiden können und wissen welches der Fahrzeuge an welcher Wallbox angeschlossen ist. Nur damit ist es möglich die Live-Daten des Fahrzeugs richtig zuzuordnen und anzuzeigen und damit z. B. das Laden auf einen bestimmten Ladestand (SoC) zu begrenzen.
+Wenn ein oder mehrere Fahrzeuge konfiguriert sind, muss evcc diese unterscheiden können und wissen, welches der Fahrzeuge an welcher Wallbox angeschlossen ist. Nur damit ist es möglich, die Live-Daten des Fahrzeugs richtig zuzuordnen und anzuzeigen und damit z. B. das Laden auf einen bestimmten Ladestand (SoC) zu begrenzen.
 
 Hierfür gibt es verschiedene Methoden:
 
-1. Es ist ein Fahrzeug konfiguriert und einem Ladepunkt fest als Standardfahrzeug zugewiesen, dann findet keine automatische Erkennung statt. evcc geht dann immer zunächst davon aus dass dieses Fahrzeug dort angeschlossen ist.
-2. Es sind ein oder mehrere Fahrzeuge konfiguriert die keinem festem Ladepunkt zugewiesenen sind
-   1. Erkennung über das Ladekabel (Plug & Charge)
-   2. Erkennung über RFID-Karten (und andere Token)
-   3. Erkennung über den Ladestatus
+1. Ist ein Fahrzeug konfiguriert und einem Ladepunkt fest als Standardfahrzeug zugewiesen, dann findet keine automatische Erkennung statt. evcc geht dann immer zunächst davon aus, dass dieses Fahrzeug dort angeschlossen ist.
+2. Sind ein oder mehrere Fahrzeuge konfiguriert, die keinem festem Ladepunkt zugewiesenen sind, dann erfolgt die Erkennung
+   1. Über das Ladekabel (Plug & Charge)
+   2. Über RFID-Karten (und andere Token)
+   3. Über den Ladestatus
 
 Die einzelnen Methoden werden nachfolgend näher beschrieben.
 
-Ist keine dieser Varianten verfügbar oder sinnvoll anwendbar erfolgt die Zuordnung eines Fahrzeugs zu einem Ladepunkt manuell über die evcc-Benutzeroberfläche (oder via API). Dort lassen sich auch bei Bedarf Korrekturen vornehmen.
+Ist keine dieser Varianten verfügbar oder sinnvoll anwendbar, erfolgt die Zuordnung eines Fahrzeugs zu einem Ladepunkt manuell über die evcc-Benutzeroberfläche (oder via API). Dort lassen sich auch bei Bedarf Korrekturen vornehmen.
 
-Fahrzeuge die nicht erkannt wurden werden als "Gastfahrzeug" behandelt.
+Fahrzeuge die nicht erkannt wurden, werden als "Gastfahrzeug" behandelt.
 
 :::note
-Die Wallbox muss bereits in evcc eingerichtet und konfiguriert sein
+Die Wallbox muss bereits in evcc eingerichtet und konfiguriert sein.
 :::
 
 :::tip
-In einfachen Fällen ist es empfehlenswert eine direkte Zuordnung von Ladepunkt zu einem Standardfahrzeug vorzunehmen.
+In einfachen Fällen ist es empfehlenswert, eine direkte Zuordnung von Ladepunkt zu einem Standardfahrzeug vorzunehmen.
 (siehe [vehicle](/docs/reference/configuration/loadpoints/#vehicles)
 :::
 
 :::tip
-Für jedes Fahrzeug können individuelle Standardeinstellungen wie z. B. Lademodus, Ladestrombeschränkungen, Ziel-SoC usw. in der evcc-Konfiguration hinterlegt werden (siehe [onIdentify](/docs/reference/configuration/vehicles/#onidentify)). Diese werden jeweils automatisch angewendet wenn das Fahrzeug an einem Ladepunkt erkannt bzw. zugeordnet wird.
+Für jedes Fahrzeug können individuelle Standardeinstellungen wie z. B. Lademodus, Ladestrombeschränkungen, Ziel-SoC usw. in der evcc-Konfiguration hinterlegt werden (siehe [onIdentify](/docs/reference/configuration/vehicles/#onidentify)). Diese werden jeweils automatisch angewendet, wenn das Fahrzeug an einem Ladepunkt erkannt bzw. zugeordnet wird.
 :::
 
 ### Erkennung über das Ladekabel
 
-Voraussetzung: Die Wallbox und das Fahrzeug müssen den Ladestandard ISO15118 unterstützen. In der Praxis ist dies nur mit sehr wenigen Wallbox- und Fahrzeugkombinationen überhaupt möglich.
+Voraussetzung: Die Wallbox und das Fahrzeug unterstützen den Ladestandard ISO15118. In der Praxis ist dies nur mit sehr wenigen Wallbox- und Fahrzeugkombinationen überhaupt möglich.
 
 :::note
 In der Konfiguration der Wallbox, nicht in evcc, muss die sogenannte "PLC-Verbindung zum Fahrzeug" aktiviert sein.
@@ -109,7 +109,7 @@ Voraussetzung: Die Wallbox verfügt über einen RFID-Kartenleser.
 Hierbei ordnet man eine (oder mehrere) RFID-Karten einem bestimmten Fahrzeug zu. D.h. jedes Mal wenn das Fahrzeug wieder an die Wallbox angeschlossen wird, muss der Ladevorgang zunächst mit der entsprechenden RFID-Karte an der Wallbox freigeschaltet werden.
 
 Die Wallbox teilt evcc dann die zur Freischaltung verwendete Kartenkennung mit.
-Oft wird dabei allerdings nicht direkt die Kartennummer selbst von der Wallbox an evcc übermittelt sondern z. B. ein vom Benutzer in der Konfiguration der Wallbox hinterlegter Aliasname oder auch nur eine Zeilennummer der Tabelle der zugelassenen Karten.
+Oft wird dabei allerdings nicht direkt die Kartennummer selbst von der Wallbox an evcc übermittelt, sondern z. B. ein vom Benutzer in der Konfiguration der Wallbox hinterlegter Aliasname oder auch nur eine Zeilennummer der Tabelle der zugelassenen Karten.
 Dies funktioniert leider bei jedem Wallboxtyp im Detail ein bisschen anders. Hier führt daher oft nur Ausprobieren zum Ziel.
 
 :::note
@@ -118,10 +118,10 @@ Die erlaubten RFID-Karten müssen in der Regel zusätzlich in der Wallbox regist
 
 **Vorgehen**:
 
-- Die (ggf. bereits registrierte) RFID-Karte an die Wallbox halten bis die Wallbox meldet dass diese erkannt wurde
+- Die (ggf. bereits registrierte) RFID-Karte an die Wallbox halten, bis die Wallbox meldet, dass diese erkannt wurde
 - evcc beenden (falls noch nicht geschehen)
 - Auf der Kommandozeile `evcc charger` aufrufen
-- Die Ausgabe enthält u. a. den Text `Identifier:` und einen Wert, dieser Wert muss kopiert werden
+- Die Ausgabe enthält u. a. den Text `Identifier:` und einen Wert: dieser Wert muss kopiert werden
 - Nun die `evcc.yaml` Datei in einem Texteditor öffnen
 - Bei der Konfiguration des entsprechenden Fahrzeugs die folgenden Zeilen hinzufügen (identifiers ist eine Liste, mehrere Einträge sind möglich):
 
@@ -136,7 +136,7 @@ Die erlaubten RFID-Karten müssen in der Regel zusätzlich in der Wallbox regist
 - evcc kann nun wieder gestartet werden und erkennt das Fahrzeug
 
 :::tip
-Der grundsätzliche Aufbau der tatsächlich von einer Wallbox übermittelten Identifier kann oft schon beim ersten Durchgang erkannt und dann für weitere Karten abgeleitet werden ohne dass diese vollständige Prozedur für jede Karte erforderlich ist. Im Zweifelsfall ist es aber sinnvoll die mittels `evcc charger` tatsächlich übermittelten Identifier zu verifizieren.
+Der grundsätzliche Aufbau der tatsächlich von einer Wallbox übermittelten Identifier kann oft schon beim ersten Durchgang erkannt und dann für weitere Karten abgeleitet werden, ohne dass diese vollständige Prozedur für jede Karte erforderlich ist. Im Zweifelsfall ist es aber sinnvoll, die mittels `evcc charger` tatsächlich übermittelten Identifier zu verifizieren.
 :::
 
 :::caution
@@ -150,12 +150,12 @@ Mit mehreren Token pro Fahrzeug lassen sich z. B. auch verschiedene Fahrer diffe
 ### Erkennung über den Ladestatus
 
 Hierbei ruft evcc den Ladestatus aller eingebundenen Fahrzeuge über die Online-Schnittstelle ab. Sofern der Hersteller dies anbietet und das Fahrzeug es übermittelt, erhält evcc automatisch den (hoffentlich) aktuellen Ladestatus der Fahrzeuge, also ob ein Fahrzeug an eine Ladesäule angeschlossen ist und ob es derzeit lädt.
-Über den Abgleich dieses Zustands mit dem Zustand der Ladepunkte und bereits zugeordneten Fahrzeugen versucht evcc herauszufinden welches Fahrzeug neu angeschlossen wurde.
-Dies ist ein heuristisches Verfahren und es besteht daher keine hunderprozentige Sicherheit eine automatische Zuordnung immer zu gewährleisten.
+Über den Abgleich dieses Zustands mit dem Zustand der Ladepunkte und bereits zugeordneten Fahrzeugen versucht evcc herauszufinden, welches Fahrzeug neu angeschlossen wurde.
+Dies ist ein heuristisches Verfahren und es besteht daher keine hundertprozentige Sicherheit, dass eine automatische Zuordnung möglich ist.
 Die Geschwindigkeit und Zuverlässigkeit dieses Verfahrens ist stark von der Geschwindigkeit und Zuverlässigkeit der Live-Datenschnittstellen der jeweiligen Fahrzeughersteller und dem Mobilfunkempfang der Fahrzeuge an den Ladepunkten abhängig.
 
 :::info
-Die Erkennung über die Online-Schnittstelle kann aus mehrern Gründen fehlschlagen:
+Die Erkennung über die Online-Schnittstelle kann aus mehreren Gründen fehlschlagen:
 
 - das Fahrzeug ist temporär nicht erreichbar ("Funkloch")
 - der Server des Fahrzeugherstellers ist temporär nicht erreichbar
@@ -168,25 +168,25 @@ Die Erkennung über die Online-Schnittstelle kann aus mehrern Gründen fehlschla
 
 ### PSA: Bei meinem Peugeot/Opel wird der Ladezustand nur aktualisiert wenn ich die Hersteller-App benutze
 
-Das ist leider eine Einschränkung der Herstellerschnittstelle. PSA liefert veraltete Werte aus solange diese nicht über die App erneuert werden. Leider ist bislang noch keine Schnittstelle bekannt, um diese Erneuerung programmatisch anzustoßen.
+Das ist leider eine Einschränkung der Herstellerschnittstelle. PSA liefert veraltete Werte aus, solange diese nicht über die App erneuert werden. Leider ist bislang noch keine Schnittstelle bekannt, um diese Erneuerung programmatisch anzustoßen.
 
 ### Mercedes: Anleitung zur Erstellung von `clientId` und `clientSecret`
 
-Für die Nutzung eines Mercedes Fahrzeuges müssen bei Mercedes zwei Id´s erzeugt und in der Konfigdatei (evcc.yaml) hinterlegt werden.
+Für die Nutzung eines Mercedes Fahrzeuges müssen bei Mercedes zwei Id´s erzeugt und in der Konfigurationsdatei (evcc.yaml) hinterlegt werden.
 
 1. Erstelle einen Mercedes Developer Account
-2. Einloggen und Create a New project klicken
-3. klicke Add Product
-4. Electric Vehicle Status auswählen
-5. Purchase model -> Get For Free -> Package BYOCAR -> Confirm -> Subscribe
-6. Go to Project Page -> Generate Credentials
+2. Einloggen und *Create a New project* klicken
+3. Klicke *Add Product*
+4. *Electric Vehicle Status* auswählen
+5. *Purchase model* &rarr; *Get For Free* &rarr; *Package BYOCAR* &rarr; *Confirm* &rarr; *Subscribe*
+6. Go to Project Page &rarr; *Generate Credentials*
 7. WICHTIG !!! Client ID und Client Secret per copy&paste in einer txt-Datei sichern.
 8. In Project credentials, die entsprechende Redirect URLs hinterlegen.
-   Das ist http://EVCC_IP:7070/oauth/vehicles/1/callback Die IP nutzen, unter der evcc läuft!
+   Das ist http://EVCC_IP:7070/oauth/vehicles/1/callback. Die IP nutzen, unter der evcc läuft!
    Das gilt, wenn evcc im lokalen LAN Netzwerk betrieben wird.
    Bei Zugriff über das Internet muss eine Portweiterleitung für Port: 7070 erfolgen. Dazu braucht es eine feste IP oder Dynamic DNS.
    Achtung: evcc nutzt keine Authentifizierung, somit hat jeder Zugriff auf evcc.
-9. In der Konfigdatei (evcc.yaml) die entsprechenden ID´s hinterlegen
+9. In der Konfigurationsdatei (evcc.yaml) die entsprechenden ID´s hinterlegen
 
 Beispiel:
 

--- a/docs/guides/wallbox.mdx
+++ b/docs/guides/wallbox.mdx
@@ -10,11 +10,11 @@ import SponsorshipRequired from "/docs/_sponsorship_required.mdx";
 
 evcc Idee ist es, günstiges Laden (z.B. über die eigene PV Anlage) zu möglichst vielen Nutzern zu bringen. Viele Wallboxen sind steuerbar, aber es fehlt an den Geräten, um diese dann auch tatsächlich zu steuern.
 
-Die momentan unterstützten Wallboxen findest du unter [Geräte - Wallboxen](/docs/devices/chargers), vielleicht ist sie ja dabei ;)
+Die momentan unterstützten Wallboxen findest du unter [Geräte - Wallboxen](/docs/devices/chargers), vielleicht ist sie ja dabei ;-)
 
 ### Wird die 1P/3P Phasenumschaltung meiner Wallbox unterstützt?
 
-Bei einigen wenigen Wallboxen wird diese Funktionalität von evcc unterstützt. Schau doch in der Liste der unterstützten [Geräte - Wallboxen](/docs/devices/chargers) nach ob deine dabei ist.
+Bei einigen wenigen Wallboxen wird diese Funktionalität von evcc unterstützt. Schau doch in der Liste der unterstützten [Geräte - Wallboxen](/docs/devices/chargers)  deine dabei ist.
 
 <SponsorshipRequired />
 
@@ -22,15 +22,14 @@ Bei einigen wenigen Wallboxen wird diese Funktionalität von evcc unterstützt. 
 
 Bei kleinen PV-Anlagen und/oder im Winter macht es Sinn nur 1-phasig zu laden, um den vorhandenen Überschuss bestmöglich ohne Netzbezug zu nutzen.
 
-Bei Wallboxen die keine automatische Phasenumschaltung beherrschen, kann man in der Zuleitung zur Wallbox mittels eines Lasttrennschalters (z.B. Hager HAB304) die Phasen 2 & 3 abschalten. Wenn die volle Leistung benötiget wird, schaltet man die Phasen wieder zu.
+Bei Wallboxen die keine automatische Phasenumschaltung beherrschen, kann man in der Zuleitung zur Wallbox mittels eines Lasttrennschalters (z.B. Hager HAB304) die Phasen 2 & 3 abschalten. Wenn die volle Leistung benötigt wird, schaltet man die Phasen wieder zu.
 
 Unter Umständen ist auch eine Änderung beim Loadpoint-Parameter `phases` nötig. Details siehe https://docs.evcc.io/docs/reference/configuration/loadpoints#phases
 
 :::danger
-Dieses manuelle Umschalten darf nur erfolgen, wenn das Fahrzeug NICHT mit der Wallbox verbunden ist.
+Dieses manuelle Umschalten darf nur erfolgen, wenn das Fahrzeug **NICHT** mit der Wallbox verbunden ist.
 :::
 
 ### Kann ich mehrere Wallboxen nutzen?
 
-Mehrere Wallboxen und damit Ladepunkte können in evcc verwendet werden.  
-Es ist jedoch heute noch **kein** Lastmanagement möglich. Das ist auf unserer laaaaaangen Liste für die weitere Entwicklung.
+Mehrere Wallboxen und damit Ladepunkte können in evcc verwendet werden. Es ist jedoch heute noch **kein** Lastmanagement möglich. Das ist auf unserer laaaaaangen Liste für die weitere Entwicklung.

--- a/docs/sponsorship.mdx
+++ b/docs/sponsorship.mdx
@@ -6,11 +6,11 @@ import SponsorToken from "/docs/_sponsortoken.mdx";
 
 # Sponsorship
 
-Wir von evcc glauben an Open Source Software. Unser Ziel ist eine Best-in-Class Lösung für das Laden von Elektroautos zu entwickeln die mit bestehender Hardware und Haustechnik zusammenspielt. evcc unterstützt schon heute eine lange Liste an Fahrzeugen, Wallboxen, Energiezählern, Wechselrichtern und Batteriesystemen. Momentan kommen regelmäßig neue Hersteller dazu. Die Entwicklung und Pflege der Software ist zeitaufwändig. Daher sind wir auf eure Unterstützung als Community angewiesen um das Projekt am Laufen zu halten.
+Wir von evcc glauben an Open Source Software. Unser Ziel ist, eine Best-in-Class Lösung für das Laden von Elektroautos zu entwickeln, die mit bestehender Hardware und Haustechnik zusammenspielt. evcc unterstützt schon heute eine lange Liste an Fahrzeugen, Wallboxen, Energiezählern, Wechselrichtern und Batteriesystemen. Momentan kommen regelmäßig neue Hersteller dazu. Die Entwicklung und Pflege der Software ist zeitaufwändig. Daher sind wir auf eure Unterstützung als Community angewiesen, um das Projekt am Laufen zu halten.
 
 evcc ist zwar Open Source, aber wir möchten auch die Hersteller ermutigen, Open-Source-Hardware-Geräte und öffentliche Dokumentation zur Verfügung zu stellen und Open-Source-Projekte wie das unsere zu unterstützen, die einen zusätzlichen Wert für sonst geschlossene Hardware bieten. Wo dies nicht der Fall ist, benötigt evcc _Contributor's & Sponsor-Token_ zur Finanzierung der laufenden Entwicklung und Unterstützung von evcc.
 
-Das persönliche _Contributor's & Sponsor-Token_ erfordert ein [Github-Sponsoring](https://github.com/sponsors/evcc-io). Wir haben diesen Weg gewählt, weil es einfach zu integrieren ist und keine Kommission beinhaltet. Unter [sponsor.evcc.io](https://sponsor.evcc.io) kann das _Contributor's & Sponsor-Token_ beantragt werden. Ein Sponsor-Token so lange gültig wie die Patenschaft aktiv ist und kann jederzeit neu ausgestellt werden. Es kann für beliebig viele Geräte verwendet werden. Trage das Token in deine `evcc.yaml` ein um die damit verbundenen Geräteimplementierungen und das Supporter-Konfetti freizuschalten. Danke für die Unterstützung! 💚 🎉
+Das persönliche _Contributor's & Sponsor-Token_ erfordert ein [Github-Sponsoring](https://github.com/sponsors/evcc-io). Wir haben diesen Weg gewählt, weil es einfach zu integrieren ist und keine Kommission beinhaltet. Unter [sponsor.evcc.io](https://sponsor.evcc.io) kann das _Contributor's & Sponsor-Token_ beantragt werden. Ein Sponsor-Token ist so lange gültig wie die Patenschaft aktiv ist und kann jederzeit neu ausgestellt werden. Es kann für beliebig viele Geräte verwendet werden. Trage das Token in deine `evcc.yaml` ein, um die damit verbundenen Geräteimplementierungen und das Supporter-Konfetti freizuschalten. Danke für die Unterstützung! 💚 🎉
 
 :::info
 
@@ -22,6 +22,6 @@ Wer keine Kredit-/Debitkarte verwenden möchte, kann sich diesbezüglich per Mai
 
 Alle Wallboxen, die in der Dokumentation mit 💚 gekennzeichnet sind, erfordern ein Sponsor-Token.
 Open-Hardware Wallboxen und Produkte mit gutem Community-Karma sind tokenfrei nutzbar.
-Gleiches gilt für Hersteller, die die evcc Entwicklung aktiv unterstützen.
+Gleiches gilt für Hersteller, welche die evcc Entwicklung aktiv unterstützen.
 
 <SponsorToken />


### PR DESCRIPTION
Noch mehr Typos, Zeichensetzungs- und Rechtschreibfehler behoben.

In der UI lauten die angezeigten Modi derzeit:
- Aus
- PV
- Min+PV
- Schnell
daher habe ich diese Bezeichnungen übernommen.