### PR TITLE
docs: add info that only older NRGkicks are supported for the moment

### DIFF
--- a/docs/devices/chargers.mdx
+++ b/docs/devices/chargers.mdx
@@ -1305,7 +1305,7 @@ chargers:
 
 <!-- AUTO-GENERATED FROM TEMPLATE - PLEASE EDIT HERE https://github.com/evcc-io/evcc/tree/master/templates/definition/charger  -->
 
-## NRGKick
+## NRGKick (älter als 2022/2023)
 
 ### Bluetooth
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/devices/chargers.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/devices/chargers.mdx
@@ -1306,7 +1306,7 @@ chargers:
 
 <!-- AUTO-GENERATED FROM TEMPLATE - PLEASE EDIT HERE https://github.com/evcc-io/evcc/tree/master/templates/definition/charger  -->
 
-## NRGKick
+## NRGKick (older than 2022/2023)
 
 ### Bluetooth
 

--- a/templates/de/charger/nrgkick-bluetooth_0.yaml
+++ b/templates/de/charger/nrgkick-bluetooth_0.yaml
@@ -1,5 +1,5 @@
 product:
-  brand: NRGKick
+  brand: "NRGKick (älter als 2022/2023)"
   description: Bluetooth
 render:
   - default: |

--- a/templates/de/charger/nrgkick-connect_0.yaml
+++ b/templates/de/charger/nrgkick-connect_0.yaml
@@ -1,5 +1,5 @@
 product:
-  brand: NRGKick
+  brand: "NRGKick (älter als 2022/2023)"
   description: Connect
 render:
   - default: |

--- a/templates/en/charger/nrgkick-bluetooth_0.yaml
+++ b/templates/en/charger/nrgkick-bluetooth_0.yaml
@@ -1,5 +1,5 @@
 product:
-  brand: NRGKick
+  brand: "NRGKick (older than 2022/2023)"
   description: Bluetooth
 render:
   - default: |

--- a/templates/en/charger/nrgkick-connect_0.yaml
+++ b/templates/en/charger/nrgkick-connect_0.yaml
@@ -1,5 +1,5 @@
 product:
-  brand: NRGKick
+  brand: "NRGKick (older than 2022/2023)"
   description: Connect
 render:
   - default: |


### PR DESCRIPTION
The list of supported charging cables has been updated to include only older NRGkick charging cables.

Currently, DiniTech GmbH refuses to publish the specification of the current communication protocol. According to discussions with NRGkick Support, it is also not guaranteed that a release is planned.

Further info::
- https://github.com/evcc-io/evcc/pull/10558
- https://github.com/evcc-io/evcc/discussions/4048