### PR TITLE
removed root folder from volume suggestion

### DIFF
--- a/docs/installation/docker.mdx
+++ b/docs/installation/docker.mdx
@@ -59,7 +59,7 @@ sudo docker run \
 -d \
 --name evcc \
 -v $(pwd)/evcc.yaml:/etc/evcc.yaml \
--v $(pwd)/.evcc:/root/.evcc \
+-v $(pwd)/.evcc:/.evcc \
 -p 7070:7070 \
 -p 8887:8887 \
 -p 7090:7090/udp \
@@ -121,7 +121,7 @@ Entsprechend der passenden Komponenten-Konstellation kopiert man eine der folgen
           - 9522:9522/udp
         volumes:
           - /etc/evcc.yaml:/etc/evcc.yaml
-          - /home/[user]/.evcc:/root/.evcc
+          - /home/[user]/.evcc:/.evcc
         restart: unless-stopped
 
   </TabItem>


### PR DESCRIPTION
Since the default description is not matching the actual docker/container environment anymore, the root folder needed to be cut out.

According to log, the evcc.db is expected at /.evcc level. over /root/.evcc level