### PR TITLE
Improve instructions for Victron EV charging station

### DIFF
--- a/docs/devices/chargers.mdx
+++ b/docs/devices/chargers.mdx
@@ -2072,7 +2072,7 @@ chargers:
 
 <DeviceFeatures features="" />
 
-Wallbox muss sich im Modus "Manual" befinden und Modbus ID 100 konfiguriert sein.
+Die Verbindung wird per Modbus-TCP zum GX-Gerät aufgebaut (nicht zur EV Charging Station selbst). Modbus-TCP muss vor der Verwendung im Settings-Menü unter "services" aktiviert werden, dort ist anschließend auch die Modbus-ID (z.B. 100) ersichtlich. Die Wallbox muss sich zudem im Modus "Manual" befinden.
 
 ```yaml
 chargers:
@@ -2083,7 +2083,7 @@ chargers:
     # Modbus TCP
     modbus: tcpip
     id: 100
-    host: 192.0.2.2 # Hostname
+    host: 192.0.2.2 # Hostname GX-Gerät
     port: 502 # Port 
 ```
 


### PR DESCRIPTION
I tested the evcc today with a Victron Energy ESS and Victron Energy EV Charging Station and want to propose the following  clearifications. 

As both the GX device and the EV Charging Station have a Modbus server, initially it wasn't clear to me which of the devices had to be specified. With regard to the Modbus ID, I'm not sure where the limitation of ID `100` should come from – I have tested it successfully with the Modbus ID 40 displayed on the GX device.