### PR TITLE
Site: residualPower

### DIFF
--- a/docs/reference/configuration/site.mdx
+++ b/docs/reference/configuration/site.mdx
@@ -257,7 +257,7 @@ residualPower: 100
 **Beispiel "Netzbezugsanteil"**:
 
 Die Ladung soll im PV-Modus mit mindestens 6A (einphasig) auch bereits mit nur 50% PV-Anteil beginnen (Rest Netzbezug)
-Mindestladeleistung: 1 Phase _ 6A _ 230V = 1380 W, davon 50%: 690 W
+Mindestladeleistung: 1 Phase _ 6A _ 230V = 1380 W, davon 50%: 690 W. Siehe auch die [Alternative mittels enable/disable um anteilig PV und Netzbezug zu erlauben](https://docs.evcc.io/docs/guides/charging/#pv-erzeugung-im-winter-nutzen).
 
 ```yaml
 residualPower: -690

--- a/docs/reference/configuration/site.mdx
+++ b/docs/reference/configuration/site.mdx
@@ -226,7 +226,7 @@ bufferStartSoc: 90 # hat die Hausbatterie Soc 90& erreicht, startet der Ladevorg
 ### `residualPower`
 
 Legt den Soll-Arbeitspunkt der Überschussregelung am Netzübergang (Gridmeter) fest. Der Standardwert ist 0 (Watt).
-Negative Werte verschieben den Sollwert in Richtung Netzeinspeisung, positive Werte in Richtung Netzbezug.
+Positive Werte verschieben den Sollwert in Richtung Netzeinspeisung, negative Werte in Richtung Netzbezug.
 Mit diesem Wert wird der durch die Steuerung einzustellende "Ruhezustand" des Regelkreises eingestellt.
 
 Insbesondere im Zusammenspiel mit weiteren unabhängigen Überschussausregelungen wie z. B. der eines Batteriespeichers ist es obligatorisch, diesen Wert anzupassen, um ein definiertes Systemverhalten mit klaren Prioritäten zu erzielen.


### PR DESCRIPTION
Das ist doch genau umgekehrt also "Positive Werte verschieben den Sollwert in Richtung Netzeinspeisung, negative Werte in Richtung Netzbezug." oder?

Also wenn ich bei PV Überschussladen Netzbezug erlaube muss ich doch den negativen Wert eintragen für die erlaubte Watt-Zahl.

Ich füge auch gleich noch einen Link zur Alternative mittels loadpoint enable/disable hinzu. Dann sieht wer sich zu residualPower liest gleich auch die andere Möglichkeit.