### PR TITLE
Update wrong Path in docker.mdx

### DIFF
--- a/docs/installation/docker.mdx
+++ b/docs/installation/docker.mdx
@@ -59,7 +59,7 @@ sudo docker run \
 -d \
 --name evcc \
 -v $(pwd)/evcc.yaml:/etc/evcc.yaml \
--v $(pwd)/.evcc:/.evcc \
+-v $(pwd)/.evcc:/root/.evcc \
 -p 7070:7070 \
 -p 8887:8887 \
 -p 7090:7090/udp \
@@ -121,7 +121,7 @@ Entsprechend der passenden Komponenten-Konstellation kopiert man eine der folgen
           - 9522:9522/udp
         volumes:
           - /etc/evcc.yaml:/etc/evcc.yaml
-          - /home/[user]/.evcc:/.evcc
+          - /home/[user]/.evcc:/root/.evcc
         restart: unless-stopped
 
   </TabItem>


### PR DESCRIPTION
Fix wrong Path in Docker-Container.

Musste bei der Erstellung des Containers den Pfad anpassen, damit auf eine bereits bestehende DB zugegriffen werden konnte.
Bei 3. im Block darüber ist es richtig beschrieben gewesen.

> `Erstelle ein lokales Verzeichnis (bspw. ~/.evcc) in dem evcc's interne SQLite Datenbank /root/.evcc abgelegt werden kann.`