### PR TITLE
Fix Pushover API URL, part 2

### DIFF
--- a/docs/reference/configuration/messaging.md
+++ b/docs/reference/configuration/messaging.md
@@ -251,7 +251,7 @@ services:
 
 ### `pushover`
 
-`pushover` verwendet den Dienst [Pushover](https://pushover.net/). Details siehe [Pushover API](https://https://pushover.net/api).
+`pushover` verwendet den Dienst [Pushover](https://pushover.net/). Details siehe [Pushover API](https://pushover.net/api).
 
 **Beispiel**:
 


### PR DESCRIPTION
Realized that my PR in #467 didn't lead to <https://docs.evcc.io/docs/reference/configuration/messaging/#pushover> being updated. I guess I don't fully understand how documentation generation works.