### PR TITLE
Removed delay parameter from sofarsolar-g3

### DIFF
--- a/templates/de/meter/sofarsolar-g3_0.yaml
+++ b/templates/de/meter/sofarsolar-g3_0.yaml
@@ -51,7 +51,6 @@ render:
       id: 1
       host: 192.0.2.2 # Hostname
       port: 8899 # Port
-      delay: '0s' # optional
       minsoc: 25 # Ladung mit maximaler Geschwindigkeit bis zu dem angegeben Ladestand unabhängig PV-Erzeugung, wenn der Lademodus nicht auf 'Aus' steht (optional)
       maxsoc: # optional
   - usage: pv
@@ -101,7 +100,6 @@ render:
       id: 1
       host: 192.0.2.2 # Hostname
       port: 8899 # Port
-      delay: '0s' # optional
       minsoc: 25 # Ladung mit maximaler Geschwindigkeit bis zu dem angegeben Ladestand unabhängig PV-Erzeugung, wenn der Lademodus nicht auf 'Aus' steht (optional)
       maxsoc: # optional
   - usage: battery
@@ -151,7 +149,6 @@ render:
       id: 1
       host: 192.0.2.2 # Hostname
       port: 8899 # Port
-      delay: '0s' # optional
       capacity: 50 # Akkukapazität in kWh (optional)
       minsoc: 25 # Ladung mit maximaler Geschwindigkeit bis zu dem angegeben Ladestand unabhängig PV-Erzeugung, wenn der Lademodus nicht auf 'Aus' steht (optional)
       maxsoc: # optional

--- a/templates/de/meter/sofarsolar-g3_1.yaml
+++ b/templates/de/meter/sofarsolar-g3_1.yaml
@@ -51,7 +51,6 @@ render:
       id: 1
       host: 192.0.2.2 # Hostname
       port: 8899 # Port
-      delay: '0s' # optional
       minsoc: 25 # Ladung mit maximaler Geschwindigkeit bis zu dem angegeben Ladestand unabhängig PV-Erzeugung, wenn der Lademodus nicht auf 'Aus' steht (optional)
       maxsoc: # optional
   - usage: pv
@@ -101,7 +100,6 @@ render:
       id: 1
       host: 192.0.2.2 # Hostname
       port: 8899 # Port
-      delay: '0s' # optional
       minsoc: 25 # Ladung mit maximaler Geschwindigkeit bis zu dem angegeben Ladestand unabhängig PV-Erzeugung, wenn der Lademodus nicht auf 'Aus' steht (optional)
       maxsoc: # optional
   - usage: battery
@@ -151,7 +149,6 @@ render:
       id: 1
       host: 192.0.2.2 # Hostname
       port: 8899 # Port
-      delay: '0s' # optional
       capacity: 50 # Akkukapazität in kWh (optional)
       minsoc: 25 # Ladung mit maximaler Geschwindigkeit bis zu dem angegeben Ladestand unabhängig PV-Erzeugung, wenn der Lademodus nicht auf 'Aus' steht (optional)
       maxsoc: # optional

--- a/templates/de/meter/sofarsolar-g3_2.yaml
+++ b/templates/de/meter/sofarsolar-g3_2.yaml
@@ -51,7 +51,6 @@ render:
       id: 1
       host: 192.0.2.2 # Hostname
       port: 8899 # Port
-      delay: '0s' # optional
       minsoc: 25 # Ladung mit maximaler Geschwindigkeit bis zu dem angegeben Ladestand unabhängig PV-Erzeugung, wenn der Lademodus nicht auf 'Aus' steht (optional)
       maxsoc: # optional
   - usage: pv
@@ -101,7 +100,6 @@ render:
       id: 1
       host: 192.0.2.2 # Hostname
       port: 8899 # Port
-      delay: '0s' # optional
       minsoc: 25 # Ladung mit maximaler Geschwindigkeit bis zu dem angegeben Ladestand unabhängig PV-Erzeugung, wenn der Lademodus nicht auf 'Aus' steht (optional)
       maxsoc: # optional
   - usage: battery
@@ -151,7 +149,6 @@ render:
       id: 1
       host: 192.0.2.2 # Hostname
       port: 8899 # Port
-      delay: '0s' # optional
       capacity: 50 # Akkukapazität in kWh (optional)
       minsoc: 25 # Ladung mit maximaler Geschwindigkeit bis zu dem angegeben Ladestand unabhängig PV-Erzeugung, wenn der Lademodus nicht auf 'Aus' steht (optional)
       maxsoc: # optional

--- a/templates/de/meter/sofarsolar-g3_3.yaml
+++ b/templates/de/meter/sofarsolar-g3_3.yaml
@@ -51,7 +51,6 @@ render:
       id: 1
       host: 192.0.2.2 # Hostname
       port: 8899 # Port
-      delay: '0s' # optional
       minsoc: 25 # Ladung mit maximaler Geschwindigkeit bis zu dem angegeben Ladestand unabhängig PV-Erzeugung, wenn der Lademodus nicht auf 'Aus' steht (optional)
       maxsoc: # optional
   - usage: pv
@@ -101,7 +100,6 @@ render:
       id: 1
       host: 192.0.2.2 # Hostname
       port: 8899 # Port
-      delay: '0s' # optional
       minsoc: 25 # Ladung mit maximaler Geschwindigkeit bis zu dem angegeben Ladestand unabhängig PV-Erzeugung, wenn der Lademodus nicht auf 'Aus' steht (optional)
       maxsoc: # optional
   - usage: battery
@@ -151,7 +149,6 @@ render:
       id: 1
       host: 192.0.2.2 # Hostname
       port: 8899 # Port
-      delay: '0s' # optional
       capacity: 50 # Akkukapazität in kWh (optional)
       minsoc: 25 # Ladung mit maximaler Geschwindigkeit bis zu dem angegeben Ladestand unabhängig PV-Erzeugung, wenn der Lademodus nicht auf 'Aus' steht (optional)
       maxsoc: # optional

--- a/templates/en/meter/sofarsolar-g3_0.yaml
+++ b/templates/en/meter/sofarsolar-g3_0.yaml
@@ -51,7 +51,6 @@ render:
       id: 1
       host: 192.0.2.2 # Hostname
       port: 8899 # Port
-      delay: '0s' # optional
       minsoc: 25 # Immediate charging with maximum power up to the defined state of charge independently from solar production if the charge mode is not set to 'Off' (optional)
       maxsoc: # optional
   - usage: pv
@@ -101,7 +100,6 @@ render:
       id: 1
       host: 192.0.2.2 # Hostname
       port: 8899 # Port
-      delay: '0s' # optional
       minsoc: 25 # Immediate charging with maximum power up to the defined state of charge independently from solar production if the charge mode is not set to 'Off' (optional)
       maxsoc: # optional
   - usage: battery
@@ -151,7 +149,6 @@ render:
       id: 1
       host: 192.0.2.2 # Hostname
       port: 8899 # Port
-      delay: '0s' # optional
       capacity: 50 # Battery capacity in kWh (optional)
       minsoc: 25 # Immediate charging with maximum power up to the defined state of charge independently from solar production if the charge mode is not set to 'Off' (optional)
       maxsoc: # optional

--- a/templates/en/meter/sofarsolar-g3_1.yaml
+++ b/templates/en/meter/sofarsolar-g3_1.yaml
@@ -51,7 +51,6 @@ render:
       id: 1
       host: 192.0.2.2 # Hostname
       port: 8899 # Port
-      delay: '0s' # optional
       minsoc: 25 # Immediate charging with maximum power up to the defined state of charge independently from solar production if the charge mode is not set to 'Off' (optional)
       maxsoc: # optional
   - usage: pv
@@ -101,7 +100,6 @@ render:
       id: 1
       host: 192.0.2.2 # Hostname
       port: 8899 # Port
-      delay: '0s' # optional
       minsoc: 25 # Immediate charging with maximum power up to the defined state of charge independently from solar production if the charge mode is not set to 'Off' (optional)
       maxsoc: # optional
   - usage: battery
@@ -151,7 +149,6 @@ render:
       id: 1
       host: 192.0.2.2 # Hostname
       port: 8899 # Port
-      delay: '0s' # optional
       capacity: 50 # Battery capacity in kWh (optional)
       minsoc: 25 # Immediate charging with maximum power up to the defined state of charge independently from solar production if the charge mode is not set to 'Off' (optional)
       maxsoc: # optional

--- a/templates/en/meter/sofarsolar-g3_2.yaml
+++ b/templates/en/meter/sofarsolar-g3_2.yaml
@@ -51,7 +51,6 @@ render:
       id: 1
       host: 192.0.2.2 # Hostname
       port: 8899 # Port
-      delay: '0s' # optional
       minsoc: 25 # Immediate charging with maximum power up to the defined state of charge independently from solar production if the charge mode is not set to 'Off' (optional)
       maxsoc: # optional
   - usage: pv
@@ -101,7 +100,6 @@ render:
       id: 1
       host: 192.0.2.2 # Hostname
       port: 8899 # Port
-      delay: '0s' # optional
       minsoc: 25 # Immediate charging with maximum power up to the defined state of charge independently from solar production if the charge mode is not set to 'Off' (optional)
       maxsoc: # optional
   - usage: battery
@@ -151,7 +149,6 @@ render:
       id: 1
       host: 192.0.2.2 # Hostname
       port: 8899 # Port
-      delay: '0s' # optional
       capacity: 50 # Battery capacity in kWh (optional)
       minsoc: 25 # Immediate charging with maximum power up to the defined state of charge independently from solar production if the charge mode is not set to 'Off' (optional)
       maxsoc: # optional

--- a/templates/en/meter/sofarsolar-g3_3.yaml
+++ b/templates/en/meter/sofarsolar-g3_3.yaml
@@ -51,7 +51,6 @@ render:
       id: 1
       host: 192.0.2.2 # Hostname
       port: 8899 # Port
-      delay: '0s' # optional
       minsoc: 25 # Immediate charging with maximum power up to the defined state of charge independently from solar production if the charge mode is not set to 'Off' (optional)
       maxsoc: # optional
   - usage: pv
@@ -101,7 +100,6 @@ render:
       id: 1
       host: 192.0.2.2 # Hostname
       port: 8899 # Port
-      delay: '0s' # optional
       minsoc: 25 # Immediate charging with maximum power up to the defined state of charge independently from solar production if the charge mode is not set to 'Off' (optional)
       maxsoc: # optional
   - usage: battery
@@ -151,7 +149,6 @@ render:
       id: 1
       host: 192.0.2.2 # Hostname
       port: 8899 # Port
-      delay: '0s' # optional
       capacity: 50 # Battery capacity in kWh (optional)
       minsoc: 25 # Immediate charging with maximum power up to the defined state of charge independently from solar production if the charge mode is not set to 'Off' (optional)
       maxsoc: # optional


### PR DESCRIPTION
Removed superfluous delay from Sofar G3 inverters, if properly connected.
See evcc-io/evcc#12335