### PR TITLE
Add Mercedes templates

### DIFF
--- a/templates/de/vehicle/mercedes_0.yaml
+++ b/templates/de/vehicle/mercedes_0.yaml
@@ -1,0 +1,34 @@
+product:
+  brand: Mercedes-Benz
+description: |
+  Die Konfiguration der Mercedes-Benz Integration nur im yaml Modus möglich.
+  Ablauf:
+    1. Hinzufügen der Konfiguration in die evcc.yaml (ohne Token)
+      ```
+      vehicles:
+        - name: my_car
+          type: mercedes
+          account: # Mercedes Me Nutzer-Id (email)
+          region: # MB me Region (EMEA, APAC, NORAM)
+          vin: W... # Erforderlich
+          capacity: 50 # Akkukapazität in kWh (optional)
+      ```
+    2. Ausführen von "./evcc token mercedes" zur Token Generierung
+    3. Einfügen der Tokens in die evcc.yaml
+      ```
+      vehicles:
+        - name: my_car
+          type: mercedes
+          account: # Mercedes Me Nutzer-Id (email)
+          region: # MB me Region (EMEA, APAC, NORAM)
+          vin: W... # Erforderlich
+          capacity: 50 # Akkukapazität in kWh (optional)
+          tokens:
+            access: token...
+            refresh: token...
+      ```
+
+render:
+  - default: |
+      type: template
+      template: mercedes

--- a/templates/de/vehicle/mercedes_0.yaml
+++ b/templates/de/vehicle/mercedes_0.yaml
@@ -30,5 +30,3 @@ description: |
 
 render:
   - default: |
-      type: template
-      template: mercedes

--- a/templates/en/vehicle/mercedes_0.yaml
+++ b/templates/en/vehicle/mercedes_0.yaml
@@ -30,5 +30,4 @@ description: |
 
 render:
   - default: |
-      type: template
-      template: mercedes
+

--- a/templates/en/vehicle/mercedes_0.yaml
+++ b/templates/en/vehicle/mercedes_0.yaml
@@ -1,0 +1,34 @@
+product:
+  brand: Mercedes-Benz
+description: |
+  The configuration of the Mercedes-Benz integration is only possible in yaml mode.
+  Procedure:
+    1. add the configuration to evcc.yaml (without token)
+      ```
+      vehicles:
+        - name: my_car
+          type: mercedes
+          account: # Mercedes Me Nutzer-Id (email)
+          region: # MB me Region (EMEA, APAC, NORAM)
+          vin: W... # Erforderlich
+          capacity: 50 # Akkukapazität in kWh (optional)
+      ```
+    2. execute "./evcc token mercedes" for token generation
+    3. insert the tokens into evcc.yaml
+      ```
+      vehicles:
+        - name: my_car
+          type: mercedes
+          account: # Mercedes Me Nutzer-Id (email)
+          region: # MB me Region (EMEA, APAC, NORAM)
+          vin: W... # Required
+          capacity: 50 # capacity in kWh (optional)
+          tokens:
+            access: token...
+            refresh: token...
+      ```
+
+render:
+  - default: |
+      type: template
+      template: mercedes


### PR DESCRIPTION
This PR adds the templates for the new vehicle type mercedes.

depends on: https://github.com/evcc-io/evcc/pull/12403

Question: Should I include the vehicle.mdx too or is this auto-generated in the build process?