### PR TITLE
Update plugins.md

### DIFF
--- a/docs/reference/plugins.md
+++ b/docs/reference/plugins.md
@@ -35,7 +35,7 @@ Für den Schreibzugriff werden die Daten mit dem Attribut `payload` bereitgestel
 ```yaml
 source: mqtt
 topic: mbmd/charger/maxcurrent
-payload: ${var:%d}
+payload: ${maxcurrent:%d}
 ```
 
 ## HTTP (lesen/schreiben)


### PR DESCRIPTION
Verwenden des realen Variablennamen aus dem Beispiel. Also wenn in topic anstatt "var" der Variablenname "maxcurrent" verwendet wird dann auch in payload anstatt ${var:%d} --> ${maxcurrent:%d} verwendet werden.