### PR TITLE
Update modbusproxy.md

### DIFF
--- a/docs/reference/configuration/modbusproxy.md
+++ b/docs/reference/configuration/modbusproxy.md
@@ -50,10 +50,23 @@ Der lokale TCP/IP-Port unter dem eine Verbindung als Proxyserver bereitstellt wi
 **Beispiel**:
 
 ```yaml
-port: 5021
+- port: 5021
 ```
 
 ## Optionale Parameter
+
+### `uri`
+
+Die IP-Adresse und der Port des Zielgerätes nach allgemeinem URI-Schema.
+
+Jeder bereitgestellte Port muss eindeutig und noch nicht von einer anderen Anwendung auf dem evcc Host belegt sein, muss sich aber nicht zwingend vom ausgehenden Port unterscheiden. Es ist somit problemlos möglich eine Freigabe für Port 502 zu definieren, die ihrerseits auf Port 502 des Zielgerätes verweist.
+
+**Beispiel**:
+
+```yaml
+- port: 502
+  uri: 192.0.2.2:502
+```
 
 ### `rtu`
 
@@ -70,7 +83,13 @@ rtu: true
 
 ### `readonly`
 
-Durch `readonly: true` lassen sich Modbus-Schreibzugriffe durch Drittsysteme pauschal unterbinden.
+Durch diesen Parameter lassen sich Modbus-Schreibzugriffe durch Drittsysteme pauschal unterbinden.
+
+**Mögliche Werte**:
+
+- `true`: Schreibzugriffe werden ohne Antwort blockiert
+- `deny`: Schreibzugriffe werden mit einem Modbusfehler als Antwort blockiert
+- `false`: Schreibzugriffe werden weitergeleitet
 
 **Beispiel**:
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/reference/configuration/modbusproxy.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/reference/configuration/modbusproxy.md
@@ -44,7 +44,7 @@ For more information about evcc sponsorship, please visit [the sponsorship page]
 
 ### `port`
 
-The local TCP/IP port under which a connection is provided as a proxy server, and from which incoming Modbus TCP connections from third-party systems are accepted.
+The local TCP/IP port under which a connection is provided as a proxy server, and from which incoming Modbus TCP connections from third-party systems are accepted. 
 
 **For example**:
 
@@ -53,6 +53,19 @@ port: 5021
 ```
 
 ## Optional Parameters
+
+### `uri`
+
+The IP address and the port of the target device in common URI Scheme. 
+
+Every provided port must be unique and not already in use by another application on the same host, however, it must not be different from the port of the target device. Therefore it is valid to define a configuration for port 502, which refers to port 502 on the target device.
+
+**For example**:
+
+```yaml
+- port: 502
+  uri: 192.0.2.2:502
+```
 
 ### `rtu`
 
@@ -66,7 +79,13 @@ rtu: true
 
 ### `readonly`
 
-By setting `readonly: true`, you can prevent Modbus write accesses by third-party systems.
+By setting this parameter, you can prevent Modbus write accesses by third-party systems.
+
+**Possible values**:
+
+- `true`: Write access is blocked without response
+- `deny`: Write access is blocked with a modbus error as response
+- `false`: Write access is forwarded
 
 **For example**:
 


### PR DESCRIPTION
Fix für https://github.com/evcc-io/docs/issues/538

Ich habe noch den Parameter uri hinzugefügt, um an einem Beispiel zeigen zu können, dass der vom modbusproxy bereitgestellte Port und der Port des Zielgerätes auch identisch sein können. In vielen Diskussionen und Beispielen wird für den bereitgestellten Port stets ein anderer Port wie z.B. 5020 verwendet. 