### PR TITLE
feat: enhance advanced plugin documentation

### DIFF
--- a/docs/reference/plugins.md
+++ b/docs/reference/plugins.md
@@ -6,7 +6,7 @@ sidebar_position: 3
 
 Plugins können verwendet werden, um verschiedene Geräte und externe Datenquellen in evcc zu integrieren. Diese können über den Wert `custom` des Parameters `type` in [`meter`](/docs/reference/configuration/meters#custom) (Strommessgeräte), [`charger`](/docs/reference/configuration/chargers#type) (Wallboxen) oder [`vehicle`](/docs/devices/vehicles#manuell) (Fahrzeuge) verwendet werden.
 
-Plugins erlauben sowohl _Schreibenzugriff_ also auch _Lesezugriff_. Wenn das Plugin zum _Schreiben_ verwendet wird, werden die Daten in Form von `${var[:format]}` zur Verfügung gestellt. Wenn `format` nicht angegeben wird, werden die Daten im Standard `%v` [Go Format](https://golang.org/pkg/fmt/) bereitgestellt. Die Variablen werden mit dem entsprechenden Wert ersetzt, bevor das Plugin ausgeführt wird.
+Plugins erlauben sowohl _Schreibenzugriff_ also auch _Lesezugriff_. Wenn das Plugin zum _Schreiben_ verwendet wird, werden die Daten in Form von `${var[:format]}` zur Verfügung gestellt. Wenn `format` nicht angegeben wird, werden die Daten im Standard `%v` [Go Format](https://golang.org/pkg/fmt/) bereitgestellt. Die Variablen werden mit dem entsprechenden Wert ersetzt, bevor das Plugin ausgeführt wird. Zusätzlich können sämtliche Funktionen der [Go Template library](https://pkg.go.dev/text/template) verwendet werden um komplexere Datentransformationen durchzuführen.
 
 ## Modbus (lesen/schreiben)
 
@@ -40,7 +40,7 @@ payload: ${var:%d}
 
 ## HTTP (lesen/schreiben)
 
-Das `http` Plugin führt HTTP Aufrufe durch um Daten zu lesen oder zu aktualisieren. Es beinhaltet auch die Fähigkeit JSON-Datenstrukturen über jq-Abfragen (z. B. für REST-APIs) zu lesen oder zu parsen.
+Das `http` Plugin führt HTTP Aufrufe durch um Daten zu lesen oder zu aktualisieren. Es beinhaltet auch die Fähigkeit JSON-Datenstrukturen über jq-Abfragen (z. B. für REST-APIs) zu lesen oder einfache transformationen durchzuführen. Der volle Funktionsumfang ist in der [offiziellen jq Dokumentation](https://jqlang.github.io/jq/manual/) zu finden.
 
 Methoden der Authentifizierung sind `basic`, `bearer` und `digest`. Die Namen der jeweiligen Parameter finden sich [hier](https://github.com/evcc-io/evcc/blob/master/provider/http.go#L140).
 
@@ -49,7 +49,7 @@ XML-Dokumente werden intern automatisch in JSON-Form überführt, welche dann mi
 :::
 
 :::tip
-Für den Test von jq-Abfragen bietet sich z. B. das Online-Tool https://www.jsonquerytool.com/ und für Regex-Tests z. B. das Online-Tool https://regex101.com/ an.
+Für den Test von jq-Abfragen bietet sich z. B. das Online-Tool https://jqplay.org/ und für Regex-Tests z. B. das Online-Tool https://regex101.com/ an.
 :::
 
 **Beispiel Lesen**:
@@ -70,10 +70,22 @@ scale: 0.001 # floating point factor applied to result, e.g. for kW to W convers
 timeout: 10s # timeout in golang duration format, see https://golang.org/pkg/time/#ParseDuration
 ```
 
+```yaml
+source: http
+uri: http://charger/status
+jq: .total_power > 10 # Converts a json integer to a boolean value
+```
+
 **Beispiel Schreiben**:
 
 ```yaml
 body: %v # only applicable for PUT or POST requests
+```
+
+```yaml
+enable:
+  source: http
+  uri: "http://charger/relay/0?turn={{if .enable}}on{{else}}off{{end}}"
 ```
 
 ## Websocket (nur lesen)

--- a/i18n/en/docusaurus-plugin-content-docs/current/reference/plugins.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/reference/plugins.md
@@ -6,7 +6,7 @@ sidebar_position: 3
 
 Plugins can be used to integrate various devices and external data sources into evcc. These can be used through the `custom` value of the `type` parameter in [`meter`](/docs/reference/configuration/meters#custom) (power meters), [`charger`](/docs/reference/configuration/chargers#type) (charging stations), or [`vehicle`](/docs/devices/vehicles/#custom) (vehicles).
 
-Plugins allow both _write access_ and _read access_. When the plugin is used for _writing_, the data is provided in the `${var[:format]}` format. If `format` is not specified, the data is provided in the default `%v` [Go Format](https://golang.org/pkg/fmt/). The variables are replaced with their corresponding values before the plugin is executed.
+Plugins allow both _write access_ and _read access_. When the plugin is used for _writing_, the data is provided in the `${var[:format]}` format. If `format` is not specified, the data is provided in the default `%v` [Go Format](https://golang.org/pkg/fmt/). The variables are replaced with their corresponding values before the plugin is executed. Additionally the full functionality of the [Go template library](https://pkg.go.dev/text/template) can be used to implement more complex data transformations.
 
 ## Modbus (read/write)
 
@@ -40,14 +40,14 @@ payload: ${var:%d}
 
 ## HTTP (read/write)
 
-The `http` plugin performs HTTP calls to read or update data. It also includes the ability to read or parse JSON data structures using jq queries (e.g., for REST APIs).
+The `http` plugin performs HTTP calls to read or update data. It also includes the ability to read or transform JSON data structures using jq queries (e.g., for REST APIs). The full set of functionalities can be found in the [official jq documentation](https://jqlang.github.io/jq/manual/).
 
 :::important
 XML documents are automatically converted to JSON format internally, which can then be filtered like a native JSON response using jq. Attributes are prefixed with `attr`.
 :::
 
 :::tip
-For testing jq queries, tools like https://www.jsonquerytool.com/ for JSON queries and https://regex101.com/ for regular expression tests can be helpful.
+For testing jq queries, tools like https://jqplay.org/ for JSON queries and https://regex101.com/ for regular expression tests can be helpful.
 :::
 
 **Example of reading from a device**:
@@ -68,10 +68,22 @@ scale: 0.001 # floating point factor applied to result, e.g. for converting kW t
 timeout: 10s # timeout in golang duration format, see https://golang.org/pkg/time/#ParseDuration
 ```
 
+```yaml
+source: http
+uri: http://charger/status
+jq: .total_power > 10 # Converts a json integer to a boolean value
+```
+
 **Example of writing to a device**:
 
 ```yaml
 body: %v # only applicable for PUT or POST requests
+```
+
+```yaml
+enable:
+  source: http
+  uri: "http://charger/relay/0?turn={{if .enable}}on{{else}}off{{end}}"
 ```
 
 ## Websocket (read only)


### PR DESCRIPTION
Nachdem ich heute einen halben Tag damit verbracht habe mich via Reverse Engineering in die Details der Templating Sprachen einzuarbeiten (um einen custom charger zu erstellen (siehe https://github.com/evcc-io/evcc/pull/13233)) ergänzt dieser PR folgende Informationen:
- Referenz auf die Möglichkeit die Go Template library zu verwenden
- Referenz auf die JQ Dokumentation und den möglichen Funktionsumfang
- Update des JQ Playground Tools auf das in den offiziellen JQ Docs genannte Tool
- Ergänzung zweier Beispiele wie diese erweiterten Funktionen verwendet werden können