### PR TITLE
Add tariff templates

### DIFF
--- a/docs/devices/tariffs.mdx
+++ b/docs/devices/tariffs.mdx
@@ -1,0 +1,337 @@
+---
+sidebar_position: 4
+---
+
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
+
+# Stromtarife
+
+Indem du Stromtarife für Netzbezug, Einspeisung und CO₂-Intensität konfigurierst kann evcc deine Ersparnis berechnen und Ladevorgänge automatisch auf günstige Zeiten verschieben.
+
+## Fester Strompreis
+
+Der einfachste Fall sind feste Werte für Netzbezug (`grid`) und Einspeisung (`feedin`).
+
+```yaml
+tariffs:
+  currency: EUR # (default EUR)
+  grid:
+    type: fixed
+    price: 0.294 # 29,4 ct/kWh
+  feedin:
+    type: fixed
+    price: 0.08 # 8 ct/kWh
+  co2:
+    ...
+```
+
+## Zeitabhängiger Strompreis
+
+Stromtarife mit festen zeitabhängigen Preisen können ebenfalls definiert werden.
+
+```yaml
+tariffs:
+  grid:
+    type: fixed
+    price: 0.294 # EUR/kWh (default)
+    zones:
+      - days: Mo-Fr
+        hours: 2-5
+        price: 0.2 # EUR/kWh
+      - days: Sa,So
+        price: 0.15 # EUR/kWh
+```
+
+Unter `zones` kann eine Liste von Preiszonen definiert werden.
+Der Geltungszeitraum wird durch `days` und/oder `hours` definiert.
+Ist für einen Zeitpunkt keine Preiszone definiert, wird der Standardpreis verwendet.
+
+Der Befehl `evcc tariff` zeigt die Preisliste der kommenden Stunden an.
+
+```
+$ ./evcc tariff
+
+grid:
+From                   To                     Price/Cost
+2026-05-03 00:00:00    2026-05-03 01:00:00    0.399
+...
+
+feedin:
+From                   To                     Price/Cost
+2026-05-03 00:00:00    2026-05-03 01:00:00    0.080
+...
+```
+
+<!-- AUTO-GENERATED CONTENT BELOW THIS LINE -->
+
+<!-- AUTO-GENERATED FROM TEMPLATE - PLEASE EDIT HERE https://github.com/evcc-io/evcc/tree/master/templates/definition/tariff  -->
+
+## CO₂ Vorhersage
+
+### Electricity Maps Commercial API
+
+CO₂-Daten für viele Länder von https://electricitymaps.com/. Der 'Free Personal Tier' beinhaltet leider keine Prognosedaten. Dafür benötigen Sie einen kommerziellen Account von https://api-portal.electricitymaps.com/. Kostenloser Testmonat verfügbar.
+
+```yaml
+tariffs:
+  co2:
+    type: template
+    template: electricitymaps
+    uri: https://api-access.electricitymaps.com/2w...1g/ # HTTP(S) Adresse
+    token:
+    zone: DE # siehe https://api.electricitymap.org/v3/zones 
+```
+
+<!-- AUTO-GENERATED FROM TEMPLATE - PLEASE EDIT HERE https://github.com/evcc-io/evcc/tree/master/templates/definition/tariff  -->
+
+### Grünstromindex 
+
+Regionale Emissionsdaten von https://gruenstromindex.de. Nur für Deutschland verfügbar.
+
+```yaml
+tariffs:
+  co2:
+    type: template
+    template: grünstromindex
+    zip: 
+```
+
+<!-- AUTO-GENERATED FROM TEMPLATE - PLEASE EDIT HERE https://github.com/evcc-io/evcc/tree/master/templates/definition/tariff  -->
+
+### National Grid ESO 
+
+Nur für Großbritannien verfügbar.
+
+```yaml
+tariffs:
+  co2:
+    type: template
+    template: ngeso
+    region: 1 # Ungenauer als die Verwendung eines Postleitzahl. Siehe https://carbon-intensity.github.io/api-definitions/#region-list (optional)
+    postalcode: SW1 # Postleitzahl z.B. RG41 oder SW1 oder TF8. Nicht die vollständige Postleitzahl, nur die ersten Stellen. (optional) 
+```
+
+<!-- AUTO-GENERATED FROM TEMPLATE - PLEASE EDIT HERE https://github.com/evcc-io/evcc/tree/master/templates/definition/tariff  -->
+
+## Dynamischer Strompreis
+
+### Eigenes Plugin
+
+Das Plugin muss eine JSON-Struktur zurückgeben, welches eine Liste von Zeiträumen und Preisen enthält. Die Zeiträume müssen in der Form `YYYY-MM-DDTHH:MM:SSZ` sein. Die Preise müssen in Cent angegeben werden.
+
+```json
+[
+  {
+    "start": "2025-01-01T00:00:00Z",
+    "end": "2025-01-01T01:00:00Z",
+    "price": 25.0
+  },
+  {
+    "start": "2025-01-01T01:00:00Z",
+    "end": "2025-01-01T02:00:00Z",
+    "price": 30.0
+  }
+]
+```
+
+Hier ein Beispiel:
+
+```yaml
+tariffs:
+  grid:
+    type: custom
+    forecast:
+      source: http
+      uri: https://api.allinpower.nl/troodon/api/p/spot_market/prices/?product_type=ELK
+      jq: '[.timestamps, .prices] | transpose | map({ "start": (.[0] | strptime("%Y-%m-%dT%H:%M:%S.%f%z") | strftime("%Y-%m-%dT%H:%M:%SZ")), "end": (.[0] | strptime("%Y-%m-%dT%H:%M:%S.%f%z") | mktime + 3600 | strftime("%Y-%m-%dT%H:%M:%SZ")), "price": .[1] }) | tostring'
+```
+
+### All in Power 
+
+Nur für die Niederlande verfügbar.
+
+```yaml
+tariffs:
+  grid:
+    type: template
+    template: allinpower
+    costs: # Zusätzlicher fester Aufschlag pro kWh (z.B. 0.05 für 5 Cent) (optional)
+    tax: # Zusätzlicher prozentualer Aufschlag (z.B. 0.2 für 20%) (optional) 
+```
+
+<!-- AUTO-GENERATED FROM TEMPLATE - PLEASE EDIT HERE https://github.com/evcc-io/evcc/tree/master/templates/definition/tariff  -->
+
+### Amber Electric 
+
+Nur für Australien verfügbar.
+
+```yaml
+tariffs:
+  grid:
+    type: template
+    template: amber
+    token: # optional
+    siteid: # optional
+    channel: # optional
+    costs: # Zusätzlicher fester Aufschlag pro kWh (z.B. 0.05 für 5 Cent) (optional)
+    tax: # Zusätzlicher prozentualer Aufschlag (z.B. 0.2 für 20%) (optional) 
+```
+
+<!-- AUTO-GENERATED FROM TEMPLATE - PLEASE EDIT HERE https://github.com/evcc-io/evcc/tree/master/templates/definition/tariff  -->
+
+### Awattar 
+
+Nur für Deutschland und Österreich verfügbar.
+
+```yaml
+tariffs:
+  grid:
+    type: template
+    template: awattar
+    region: AT # optional
+    costs: # Zusätzlicher fester Aufschlag pro kWh (z.B. 0.05 für 5 Cent) (optional)
+    tax: # Zusätzlicher prozentualer Aufschlag (z.B. 0.2 für 20%) (optional) 
+```
+
+<!-- AUTO-GENERATED FROM TEMPLATE - PLEASE EDIT HERE https://github.com/evcc-io/evcc/tree/master/templates/definition/tariff  -->
+
+### Energinet 
+
+Nur für Dänemark verfügbar.
+
+```yaml
+tariffs:
+  grid:
+    type: template
+    template: energinet
+    region: dk1 # optional
+    costs: # Zusätzlicher fester Aufschlag pro kWh (z.B. 0.05 für 5 Cent) (optional)
+    tax: # Zusätzlicher prozentualer Aufschlag (z.B. 0.2 für 20%) (optional) 
+```
+
+<!-- AUTO-GENERATED FROM TEMPLATE - PLEASE EDIT HERE https://github.com/evcc-io/evcc/tree/master/templates/definition/tariff  -->
+
+### ENTSO-E 
+
+Day-ahead-Preise für den europäischen Strommarkt. Siehe https://transparency.entsoe.eu für weitere Informationen.
+Basis für viele dynamische Tarife.
+
+```yaml
+tariffs:
+  grid:
+    type: template
+    template: entsoe
+    securitytoken: # Registrierung und anschließende Helpdesk-Anfrage erforderlich. Details zum Ablauf gibts hier https://transparency.entsoe.eu/content/static_content/Static%20content/web%20api/Guide.html#_authentication_and_authorisation (optional)
+    domain: BZN|DE-LU # siehe https://transparency.entsoe.eu/content/static_content/Static%20content/web%20api/Guide.html#_areas (optional)
+    costs: # Zusätzlicher fester Aufschlag pro kWh (z.B. 0.05 für 5 Cent) (optional)
+    tax: # Zusätzlicher prozentualer Aufschlag (z.B. 0.2 für 20%) (optional) 
+```
+
+<!-- AUTO-GENERATED FROM TEMPLATE - PLEASE EDIT HERE https://github.com/evcc-io/evcc/tree/master/templates/definition/tariff  -->
+
+### Groupe E Vario Plus
+
+Nur für die Schweiz verfügbar.
+
+```yaml
+tariffs:
+  grid:
+    type: template
+    template: groupe-e
+    costs: # Zusätzlicher fester Aufschlag pro kWh (z.B. 0.05 für 5 Cent) (optional)
+    tax: # Zusätzlicher prozentualer Aufschlag (z.B. 0.2 für 20%) (optional) 
+```
+
+<!-- AUTO-GENERATED FROM TEMPLATE - PLEASE EDIT HERE https://github.com/evcc-io/evcc/tree/master/templates/definition/tariff  -->
+
+### Nordpool Elering
+
+Nur für Estland verfügbar.
+
+```yaml
+tariffs:
+  grid:
+    type: template
+    template: elering
+    region: ee # optional
+    costs: # Zusätzlicher fester Aufschlag pro kWh (z.B. 0.05 für 5 Cent) (optional)
+    tax: # Zusätzlicher prozentualer Aufschlag (z.B. 0.2 für 20%) (optional) 
+```
+
+<!-- AUTO-GENERATED FROM TEMPLATE - PLEASE EDIT HERE https://github.com/evcc-io/evcc/tree/master/templates/definition/tariff  -->
+
+### Octopus Energy
+
+#### API
+
+Den API-Key bekommst du im Octopus Portal https://octopus.energy/dashboard/new/accounts/personal-details/api-access
+
+```yaml
+tariffs:
+  grid:
+    type: template
+    template: octopus-api
+    apiKey: # Octopus Energy API Key. 
+```
+
+<!-- AUTO-GENERATED FROM TEMPLATE - PLEASE EDIT HERE https://github.com/evcc-io/evcc/tree/master/templates/definition/tariff  -->
+
+#### Product Code
+
+```yaml
+tariffs:
+  grid:
+    type: template
+    template: octopus-productcode
+    productCode: AGILE-FLEX-22-11-25 # Der Tarifcode für Ihren Energievertrag. Stellen Sie sicher, dass dieser auf Ihren Importtarifcode eingestellt ist.
+    region: # Die DNO-Region, in der Sie sich befinden. Weitere Informationen: https://www.energy-stats.uk/dno-region-codes-explained/ 
+```
+
+<!-- AUTO-GENERATED FROM TEMPLATE - PLEASE EDIT HERE https://github.com/evcc-io/evcc/tree/master/templates/definition/tariff  -->
+
+### PUN Orario 
+
+Preisdaten von https://www.mercatoelettrico.org/it/. Wird oft zur Einspeisung ins Netz verwendet. Nur für Italien verfügbar.
+
+```yaml
+tariffs:
+  grid:
+    type: template
+    template: pun
+    costs: # Zusätzlicher fester Aufschlag pro kWh (z.B. 0.05 für 5 Cent) (optional)
+    tax: # Zusätzlicher prozentualer Aufschlag (z.B. 0.2 für 20%) (optional) 
+```
+
+<!-- AUTO-GENERATED FROM TEMPLATE - PLEASE EDIT HERE https://github.com/evcc-io/evcc/tree/master/templates/definition/tariff  -->
+
+### SmartEnergy smartCONTROL
+
+Nur für Österreich verfügbar.
+
+```yaml
+tariffs:
+  grid:
+    type: template
+    template: smartenergy
+    costs: # Zusätzlicher fester Aufschlag pro kWh (z.B. 0.05 für 5 Cent) (optional)
+    tax: # Zusätzlicher prozentualer Aufschlag (z.B. 0.2 für 20%) (optional) 
+```
+
+<!-- AUTO-GENERATED FROM TEMPLATE - PLEASE EDIT HERE https://github.com/evcc-io/evcc/tree/master/templates/definition/tariff  -->
+
+### Tibber 
+
+Hol dir deinen API-Token aus dem Tibber-Entwicklerportal: https://developer.tibber.com/
+
+```yaml
+tariffs:
+  grid:
+    type: template
+    template: tibber
+    token: 476c477d8a039529478ebd690d35ddd80e3308ffc49b59c65b142321aee963a4
+    homeid: cc83e83e-8cbf-4595-9bf7-c3cf192f7d9c # Nur erforderlich, wenn du mehrere Häuser in deinem Tibber-Konto hast. (optional)
+    costs: # Zusätzlicher fester Aufschlag pro kWh (z.B. 0.05 für 5 Cent) (optional)
+    tax: # Zusätzlicher prozentualer Aufschlag (z.B. 0.2 für 20%) (optional) 
+```
+

--- a/docs/devices/tariffs.mdx
+++ b/docs/devices/tariffs.mdx
@@ -18,10 +18,10 @@ tariffs:
   currency: EUR # (default EUR)
   grid:
     type: fixed
-    price: 0.294 # 29,4 ct/kWh
+    price: 0.294 # EUR/kWh
   feedin:
     type: fixed
-    price: 0.08 # 8 ct/kWh
+    price: 0.08 # EUR/kWh
   co2:
     ...
 ```

--- a/docs/devices/tariffs.mdx
+++ b/docs/devices/tariffs.mdx
@@ -118,24 +118,22 @@ tariffs:
 
 ### Eigenes Plugin
 
-Das Plugin muss eine JSON-Struktur zurückgeben, welches eine Liste von Zeiträumen und Preisen enthält. Die Zeiträume müssen in der Form `YYYY-MM-DDTHH:MM:SSZ` sein. Die Preise müssen in Cent angegeben werden.
+Über mit dem Plugin Mechanismus kann eine eigene Tarif-Quelle angebunden werden.
 
-```json
-[
-  {
-    "start": "2025-01-01T00:00:00Z",
-    "end": "2025-01-01T01:00:00Z",
-    "price": 25.0
-  },
-  {
-    "start": "2025-01-01T01:00:00Z",
-    "end": "2025-01-01T02:00:00Z",
-    "price": 30.0
-  }
-]
+**Beispiel: Aktueller Preis via HTTP**
+
+```yaml
+tariffs:
+  grid:
+    type: custom
+    price:
+      source: http
+      uri: https://example.com/api/price
 ```
 
-Hier ein Beispiel:
+Der vom Endpunkt zurückgegebene Wert wird als Netzbezugspreis verwendet.
+
+**Beispiel: Vorhersagen via HTTP**
 
 ```yaml
 tariffs:
@@ -147,6 +145,15 @@ tariffs:
       jq: '[.timestamps, .prices] | transpose | map({ "start": (.[0] | strptime("%Y-%m-%dT%H:%M:%S.%f%z") | strftime("%Y-%m-%dT%H:%M:%SZ")), "end": (.[0] | strptime("%Y-%m-%dT%H:%M:%S.%f%z") | mktime + 3600 | strftime("%Y-%m-%dT%H:%M:%SZ")), "price": .[1] }) | tostring'
 ```
 
+Das Plugin muss eine JSON-Struktur zurückgeben, welches eine Liste von Zeiträumen und Preisen enthält. Die Zeiträume müssen in der Form `YYYY-MM-DDTHH:MM:SSZ` sein.
+Die Preise müssen in der angegebenen Währungseinheit sein (bspw. EUR).
+
+```js
+[
+  { "start": "2025-01-01T00:00:00Z", "end": "2025-01-01T01:00:00Z", "price": 25.0 },
+  { "start": "2025-01-01T01:00:00Z", "end": "2025-01-01T02:00:00Z", "price": 30.0 },
+]
+```
 ### All in Power 
 
 Nur für die Niederlande verfügbar.
@@ -224,6 +231,22 @@ tariffs:
     template: entsoe
     securitytoken: # Registrierung und anschließende Helpdesk-Anfrage erforderlich. Details zum Ablauf gibts hier https://transparency.entsoe.eu/content/static_content/Static%20content/web%20api/Guide.html#_authentication_and_authorisation (optional)
     domain: BZN|DE-LU # siehe https://transparency.entsoe.eu/content/static_content/Static%20content/web%20api/Guide.html#_areas (optional)
+    costs: # Zusätzlicher fester Aufschlag pro kWh (z.B. 0.05 für 5 Cent) (optional)
+    tax: # Zusätzlicher prozentualer Aufschlag (z.B. 0.2 für 20%) (optional) 
+```
+
+<!-- AUTO-GENERATED FROM TEMPLATE - PLEASE EDIT HERE https://github.com/evcc-io/evcc/tree/master/templates/definition/tariff  -->
+
+### Fraunhofer ISE 
+
+Day-ahead Energiepreise (je kWh) an der Börse. Kann ohne vorherige Anmeldung auf https://api.energy-charts.info/ abgerufen werden. Nutzbar u.a. für dynamische Stromtarife, wo der Anbieter bis dato auf der Kundenschnittstelle noch kein Preis-Vorhersagen anbietet.
+
+```yaml
+tariffs:
+  grid:
+    type: template
+    template: energy-charts-api
+    bzn: DE-LU
     costs: # Zusätzlicher fester Aufschlag pro kWh (z.B. 0.05 für 5 Cent) (optional)
     tax: # Zusätzlicher prozentualer Aufschlag (z.B. 0.2 für 20%) (optional) 
 ```

--- a/docs/devices/tariffs/_category_.json
+++ b/docs/devices/tariffs/_category_.json
@@ -1,0 +1,3 @@
+{
+  "label": "Tarife"
+}

--- a/docs/devices/tariffs/_dynamischer_strompreis.mdx
+++ b/docs/devices/tariffs/_dynamischer_strompreis.mdx
@@ -1,0 +1,30 @@
+### Eigenes Plugin
+
+Das Plugin muss eine JSON-Struktur zurückgeben, welches eine Liste von Zeiträumen und Preisen enthält. Die Zeiträume müssen in der Form `YYYY-MM-DDTHH:MM:SSZ` sein. Die Preise müssen in Cent angegeben werden.
+
+```json
+[
+  {
+    "start": "2025-01-01T00:00:00Z",
+    "end": "2025-01-01T01:00:00Z",
+    "price": 25.0
+  },
+  {
+    "start": "2025-01-01T01:00:00Z",
+    "end": "2025-01-01T02:00:00Z",
+    "price": 30.0
+  }
+]
+```
+
+Hier ein Beispiel:
+
+```yaml
+tariffs:
+  grid:
+    type: custom
+    forecast:
+      source: http
+      uri: https://api.allinpower.nl/troodon/api/p/spot_market/prices/?product_type=ELK
+      jq: '[.timestamps, .prices] | transpose | map({ "start": (.[0] | strptime("%Y-%m-%dT%H:%M:%S.%f%z") | strftime("%Y-%m-%dT%H:%M:%SZ")), "end": (.[0] | strptime("%Y-%m-%dT%H:%M:%S.%f%z") | mktime + 3600 | strftime("%Y-%m-%dT%H:%M:%SZ")), "price": .[1] }) | tostring'
+```

--- a/docs/devices/tariffs/_dynamischer_strompreis.mdx
+++ b/docs/devices/tariffs/_dynamischer_strompreis.mdx
@@ -1,23 +1,21 @@
 ### Eigenes Plugin
 
-Das Plugin muss eine JSON-Struktur zurückgeben, welches eine Liste von Zeiträumen und Preisen enthält. Die Zeiträume müssen in der Form `YYYY-MM-DDTHH:MM:SSZ` sein. Die Preise müssen in Cent angegeben werden.
+Über mit dem Plugin Mechanismus kann eine eigene Tarif-Quelle angebunden werden.
 
-```json
-[
-  {
-    "start": "2025-01-01T00:00:00Z",
-    "end": "2025-01-01T01:00:00Z",
-    "price": 25.0
-  },
-  {
-    "start": "2025-01-01T01:00:00Z",
-    "end": "2025-01-01T02:00:00Z",
-    "price": 30.0
-  }
-]
+**Beispiel: Aktueller Preis via HTTP**
+
+```yaml
+tariffs:
+  grid:
+    type: custom
+    price:
+      source: http
+      uri: https://example.com/api/price
 ```
 
-Hier ein Beispiel:
+Der vom Endpunkt zurückgegebene Wert wird als Netzbezugspreis verwendet.
+
+**Beispiel: Vorhersagen via HTTP**
 
 ```yaml
 tariffs:
@@ -28,3 +26,16 @@ tariffs:
       uri: https://api.allinpower.nl/troodon/api/p/spot_market/prices/?product_type=ELK
       jq: '[.timestamps, .prices] | transpose | map({ "start": (.[0] | strptime("%Y-%m-%dT%H:%M:%S.%f%z") | strftime("%Y-%m-%dT%H:%M:%SZ")), "end": (.[0] | strptime("%Y-%m-%dT%H:%M:%S.%f%z") | mktime + 3600 | strftime("%Y-%m-%dT%H:%M:%SZ")), "price": .[1] }) | tostring'
 ```
+
+Das Plugin muss eine JSON-Struktur zurückgeben, welches eine Liste von Zeiträumen und Preisen enthält.
+Die Datumsfelder müssen in der Form `YYYY-MM-DDTHH:MM:SSZ` und der Preis in der korrekten Währungseinheit (bspw. EUR) angegeben werden.
+Siehe nachfolgendes Beispiel:
+
+```js
+[
+  { "start": "2025-01-01T00:00:00Z", "end": "2025-01-01T01:00:00Z", "price": 25.0 },
+  { "start": "2025-01-01T01:00:00Z", "end": "2025-01-01T02:00:00Z", "price": 30.0 },
+]
+```
+
+Das Plugin wird einmal pro Stunde aktualisiert.

--- a/docs/faq.mdx
+++ b/docs/faq.mdx
@@ -326,7 +326,7 @@ tariffs:
     price: 0.08 # [currency]/kWh
 ```
 
-Mehr Details zur Konfiguration findest du in [`tariffs`](/docs/reference/configuration/tariffs).
+Mehr Details zur Konfiguration findest du in [`tariffs`](/docs/devices/tariffs).
 
 Für die Berechnung der Einsparungen erfasst evcc grob die Gesamtmenge der geladenen Energie und die verwendeten Energiequellen (Netz, Batterie, PV).
 

--- a/docs/features/co2.mdx
+++ b/docs/features/co2.mdx
@@ -26,7 +26,7 @@ tariffs:
 ```
 
 In diesem Beispiel verwenden wir die Daten von [GrünstromIndex](https://www.gruenstromindex.de/).
-Unter [tariffs](../reference/configuration/tariffs#co2) findest du eine Liste aller unterstützten Datenquellen.
+Unter [tariffs](../devices/tariffs) findest du eine Liste aller unterstützten Datenquellen.
 
 ## Sauberes Netzladen
 

--- a/docs/features/dynamic-prices.mdx
+++ b/docs/features/dynamic-prices.mdx
@@ -57,7 +57,7 @@ tariffs:
     token: "..." # Access Token
 ```
 
-Unter [tariffs](../reference/configuration/tariffs/) findest du eine Liste aller unterstützten Tarife.
+Unter [tariffs](../devices/tariffs) findest du eine Liste aller unterstützten Tarife.
 Wenn dein Anbieter eine Schnittstelle hat, aber noch nicht von evcc unterstützt wird, dann mach gerne einen [Feature Request](https://github.com/evcc-io/evcc/issues/new/choose) auf.
 
 ## Günstiges Netzladen

--- a/docs/features/dynamic-prices.mdx
+++ b/docs/features/dynamic-prices.mdx
@@ -23,7 +23,7 @@ tariffs:
   currency: EUR
   grid:
     type: fixed
-    price: 0.32 # 32ct/kWh
+    price: 0.32 # EUR/kWh
 ```
 
 ### Zeitabhängiger Strompreis
@@ -36,13 +36,13 @@ tariffs:
   currency: EUR
   grid:
     type: fixed
-    price: 0.32 # 32ct/kWh (default)
+    price: 0.32 # EUR/kWh (default)
     zones:
       - days: Mo-Fr
         hours: 2-6
-        price: 0.22 # 20ct/kWh (werkstags 2-6 Uhr)
+        price: 0.22 # EUR/kWh (werkstags 2-6 Uhr)
       - days: Sa,So
-        price: 0.12 # 12ct/kWh (Wochenende)
+        price: 0.12 # EUR/kWh (Wochenende)
 ```
 
 ### Dynamischer Strompreis via API

--- a/i18n/en/docusaurus-plugin-content-docs/current/devices/tariffs.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/devices/tariffs.mdx
@@ -19,10 +19,10 @@ tariffs:
   currency: EUR # (default EUR)
   grid:
     type: fixed
-    price: 0.294 # 29,4 ct/kWh
+    price: 0.294 # EUR/kWh
   feedin:
     type: fixed
-    price: 0.08 # 8 ct/kWh
+    price: 0.08 # EUR/kWh
   co2:
     ...
 ```

--- a/i18n/en/docusaurus-plugin-content-docs/current/devices/tariffs.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/devices/tariffs.mdx
@@ -1,0 +1,338 @@
+---
+sidebar_position: 4
+---
+
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
+
+# Tariffs
+
+You can configure electricity tariffs for grid consumption, feed-in and CO₂ intensity. This allows evcc to calculate your savings and automatically shift charging to cheaper times.
+
+## Fixed Electricity Price
+
+The simplest case is fixed values for grid consumption (`grid`) and feed-in (`feedin`).
+
+
+```yaml
+tariffs:
+  currency: EUR # (default EUR)
+  grid:
+    type: fixed
+    price: 0.294 # 29,4 ct/kWh
+  feedin:
+    type: fixed
+    price: 0.08 # 8 ct/kWh
+  co2:
+    ...
+```
+
+## Time-based Electricity Price
+
+Electricity tariffs with fixed time-based prices can also be defined.
+
+```yaml
+tariffs:
+  grid:
+    type: fixed
+    price: 0.294 # EUR/kWh (default)
+    zones:
+      - days: Mo-Fr
+        hours: 2-5
+        price: 0.2 # EUR/kWh
+      - days: Sa,So
+        price: 0.15 # EUR/kWh
+```
+
+You can also define a list of price zones under `zones`.
+The validity period is defined by `days` and/or `hours`.
+If no price zone is defined for a time, the default price is used.
+
+The `evcc tariff` command shows the price list for the upcoming hours.
+
+```
+$ ./evcc tariff
+
+grid:
+From                   To                     Price/Cost
+2026-05-03 00:00:00    2026-05-03 01:00:00    0.399
+...
+
+feedin:
+From                   To                     Price/Cost
+2026-05-03 00:00:00    2026-05-03 01:00:00    0.080
+...
+```
+
+<!-- AUTO-GENERATED CONTENT BELOW THIS LINE -->
+
+<!-- AUTO-GENERATED FROM TEMPLATE - PLEASE EDIT HERE https://github.com/evcc-io/evcc/tree/master/templates/definition/tariff  -->
+
+## CO₂ forecast
+
+### Electricity Maps Commercial API
+
+CO₂ data for many countries from https://electricitymaps.com/. The 'Free Personal Tier' unfortunately does not include forecast data. You'll need a commercial account from https://api-portal.electricitymaps.com/. Free trial available.
+
+```yaml
+tariffs:
+  co2:
+    type: template
+    template: electricitymaps
+    uri: https://api-access.electricitymaps.com/2w...1g/ # HTTP(S) address
+    token:
+    zone: DE # see https://api.electricitymap.org/v3/zones 
+```
+
+<!-- AUTO-GENERATED FROM TEMPLATE - PLEASE EDIT HERE https://github.com/evcc-io/evcc/tree/master/templates/definition/tariff  -->
+
+### Grünstromindex 
+
+Regional emission data from https://gruenstromindex.de. Only available for Germany.
+
+```yaml
+tariffs:
+  co2:
+    type: template
+    template: grünstromindex
+    zip: 
+```
+
+<!-- AUTO-GENERATED FROM TEMPLATE - PLEASE EDIT HERE https://github.com/evcc-io/evcc/tree/master/templates/definition/tariff  -->
+
+### National Grid ESO 
+
+Only available for the United Kingdom.
+
+```yaml
+tariffs:
+  co2:
+    type: template
+    template: ngeso
+    region: 1 # Coarser than using a postcode. See https://carbon-intensity.github.io/api-definitions/#region-list (optional)
+    postalcode: SW1 # Outward postcode i.e. RG41 or SW1 or TF8. Do not include full postcode, outward postcode only. (optional) 
+```
+
+<!-- AUTO-GENERATED FROM TEMPLATE - PLEASE EDIT HERE https://github.com/evcc-io/evcc/tree/master/templates/definition/tariff  -->
+
+## Dynamic electricity price
+
+### Custom plugin
+
+The plugin must return a JSON structure containing a list of time periods and prices. The time periods must be in the form `YYYY-MM-DDTHH:MM:SSZ`. The prices must be given in cents.
+
+```json
+[
+  {
+    "start": "2025-01-01T00:00:00Z",
+    "end": "2025-01-01T01:00:00Z",
+    "price": 25.0
+  },
+  {
+    "start": "2025-01-01T01:00:00Z",
+    "end": "2025-01-01T02:00:00Z",
+    "price": 30.0
+  }
+]
+```
+
+Here is an example:
+
+```yaml
+tariffs:
+  grid:
+    type: custom
+    forecast:
+      source: http
+      uri: https://api.allinpower.nl/troodon/api/p/spot_market/prices/?product_type=ELK
+      jq: '[.timestamps, .prices] | transpose | map({ "start": (.[0] | strptime("%Y-%m-%dT%H:%M:%S.%f%z") | strftime("%Y-%m-%dT%H:%M:%SZ")), "end": (.[0] | strptime("%Y-%m-%dT%H:%M:%S.%f%z") | mktime + 3600 | strftime("%Y-%m-%dT%H:%M:%SZ")), "price": .[1] }) | tostring'
+```
+
+### All in Power 
+
+Only available for the Netherlands.
+
+```yaml
+tariffs:
+  grid:
+    type: template
+    template: allinpower
+    costs: # Additional fixed charge per kWh (e.g. 0.05 for 5 cents) (optional)
+    tax: # Additional percentage charge (e.g. 0.2 for 20%) (optional) 
+```
+
+<!-- AUTO-GENERATED FROM TEMPLATE - PLEASE EDIT HERE https://github.com/evcc-io/evcc/tree/master/templates/definition/tariff  -->
+
+### Amber Electric 
+
+Only available for Australia.
+
+```yaml
+tariffs:
+  grid:
+    type: template
+    template: amber
+    token: # optional
+    siteid: # optional
+    channel: # optional
+    costs: # Additional fixed charge per kWh (e.g. 0.05 for 5 cents) (optional)
+    tax: # Additional percentage charge (e.g. 0.2 for 20%) (optional) 
+```
+
+<!-- AUTO-GENERATED FROM TEMPLATE - PLEASE EDIT HERE https://github.com/evcc-io/evcc/tree/master/templates/definition/tariff  -->
+
+### Awattar 
+
+Only available for Germany and Austria.
+
+```yaml
+tariffs:
+  grid:
+    type: template
+    template: awattar
+    region: AT # optional
+    costs: # Additional fixed charge per kWh (e.g. 0.05 for 5 cents) (optional)
+    tax: # Additional percentage charge (e.g. 0.2 for 20%) (optional) 
+```
+
+<!-- AUTO-GENERATED FROM TEMPLATE - PLEASE EDIT HERE https://github.com/evcc-io/evcc/tree/master/templates/definition/tariff  -->
+
+### Energinet 
+
+Only available for Denmark.
+
+```yaml
+tariffs:
+  grid:
+    type: template
+    template: energinet
+    region: dk1 # optional
+    costs: # Additional fixed charge per kWh (e.g. 0.05 for 5 cents) (optional)
+    tax: # Additional percentage charge (e.g. 0.2 for 20%) (optional) 
+```
+
+<!-- AUTO-GENERATED FROM TEMPLATE - PLEASE EDIT HERE https://github.com/evcc-io/evcc/tree/master/templates/definition/tariff  -->
+
+### ENTSO-E 
+
+Day-ahead prices for the European electricity market. See https://transparency.entsoe.eu for more information.
+Basis for many dynamic tariffs.
+
+```yaml
+tariffs:
+  grid:
+    type: template
+    template: entsoe
+    securitytoken: # Registration and subsequent helpdesk request required. Details on the process can be found here https://transparency.entsoe.eu/content/static_content/Static%20content/web%20api/Guide.html#_authentication_and_authorisation (optional)
+    domain: BZN|DE-LU # see https://transparency.entsoe.eu/content/static_content/Static%20content/web%20api/Guide.html#_areas (optional)
+    costs: # Additional fixed charge per kWh (e.g. 0.05 for 5 cents) (optional)
+    tax: # Additional percentage charge (e.g. 0.2 for 20%) (optional) 
+```
+
+<!-- AUTO-GENERATED FROM TEMPLATE - PLEASE EDIT HERE https://github.com/evcc-io/evcc/tree/master/templates/definition/tariff  -->
+
+### Groupe E Vario Plus
+
+Only available for Switzerland.
+
+```yaml
+tariffs:
+  grid:
+    type: template
+    template: groupe-e
+    costs: # Additional fixed charge per kWh (e.g. 0.05 for 5 cents) (optional)
+    tax: # Additional percentage charge (e.g. 0.2 for 20%) (optional) 
+```
+
+<!-- AUTO-GENERATED FROM TEMPLATE - PLEASE EDIT HERE https://github.com/evcc-io/evcc/tree/master/templates/definition/tariff  -->
+
+### Nordpool Elering
+
+Only available for Estonia.
+
+```yaml
+tariffs:
+  grid:
+    type: template
+    template: elering
+    region: ee # optional
+    costs: # Additional fixed charge per kWh (e.g. 0.05 for 5 cents) (optional)
+    tax: # Additional percentage charge (e.g. 0.2 for 20%) (optional) 
+```
+
+<!-- AUTO-GENERATED FROM TEMPLATE - PLEASE EDIT HERE https://github.com/evcc-io/evcc/tree/master/templates/definition/tariff  -->
+
+### Octopus Energy
+
+#### API
+
+You can get the API key in the Octopus portal https://octopus.energy/dashboard/new/accounts/personal-details/api-access
+
+```yaml
+tariffs:
+  grid:
+    type: template
+    template: octopus-api
+    apiKey: # Octopus Energy API Key. 
+```
+
+<!-- AUTO-GENERATED FROM TEMPLATE - PLEASE EDIT HERE https://github.com/evcc-io/evcc/tree/master/templates/definition/tariff  -->
+
+#### Product Code
+
+```yaml
+tariffs:
+  grid:
+    type: template
+    template: octopus-productcode
+    productCode: AGILE-FLEX-22-11-25 # The tariff code for your energy contract. Make sure this is set to your import tariff code.
+    region: # The DNO region you are located in. More information: https://www.energy-stats.uk/dno-region-codes-explained/ 
+```
+
+<!-- AUTO-GENERATED FROM TEMPLATE - PLEASE EDIT HERE https://github.com/evcc-io/evcc/tree/master/templates/definition/tariff  -->
+
+### PUN Orario 
+
+Price data from https://www.mercatoelettrico.org/it/. Often used for feeding into the grid. Only available for Italy.
+
+```yaml
+tariffs:
+  grid:
+    type: template
+    template: pun
+    costs: # Additional fixed charge per kWh (e.g. 0.05 for 5 cents) (optional)
+    tax: # Additional percentage charge (e.g. 0.2 for 20%) (optional) 
+```
+
+<!-- AUTO-GENERATED FROM TEMPLATE - PLEASE EDIT HERE https://github.com/evcc-io/evcc/tree/master/templates/definition/tariff  -->
+
+### SmartEnergy smartCONTROL
+
+Only available for Austria.
+
+```yaml
+tariffs:
+  grid:
+    type: template
+    template: smartenergy
+    costs: # Additional fixed charge per kWh (e.g. 0.05 for 5 cents) (optional)
+    tax: # Additional percentage charge (e.g. 0.2 for 20%) (optional) 
+```
+
+<!-- AUTO-GENERATED FROM TEMPLATE - PLEASE EDIT HERE https://github.com/evcc-io/evcc/tree/master/templates/definition/tariff  -->
+
+### Tibber 
+
+Get your API token from the Tibber developer portal: https://developer.tibber.com/
+
+```yaml
+tariffs:
+  grid:
+    type: template
+    template: tibber
+    token: 476c477d8a039529478ebd690d35ddd80e3308ffc49b59c65b142321aee963a4
+    homeid: cc83e83e-8cbf-4595-9bf7-c3cf192f7d9c # Only required if you have multiple homes in your Tibber account. (optional)
+    costs: # Additional fixed charge per kWh (e.g. 0.05 for 5 cents) (optional)
+    tax: # Additional percentage charge (e.g. 0.2 for 20%) (optional) 
+```
+

--- a/i18n/en/docusaurus-plugin-content-docs/current/devices/tariffs.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/devices/tariffs.mdx
@@ -231,6 +231,22 @@ tariffs:
 
 <!-- AUTO-GENERATED FROM TEMPLATE - PLEASE EDIT HERE https://github.com/evcc-io/evcc/tree/master/templates/definition/tariff  -->
 
+### Fraunhofer ISE 
+
+Day-ahead forecast of energy prices (per kWh) on the exchange. No prior registration for https://api.energy-charts.info/ necessary. Can be used for dynamic electricity tariffs, for example, where the supplier does not yet offer a price forecast on the customer interface.
+
+```yaml
+tariffs:
+  grid:
+    type: template
+    template: energy-charts-api
+    bzn: DE-LU
+    costs: # Additional fixed charge per kWh (e.g. 0.05 for 5 cents) (optional)
+    tax: # Additional percentage charge (e.g. 0.2 for 20%) (optional) 
+```
+
+<!-- AUTO-GENERATED FROM TEMPLATE - PLEASE EDIT HERE https://github.com/evcc-io/evcc/tree/master/templates/definition/tariff  -->
+
 ### Groupe E Vario Plus
 
 Only available for Switzerland.

--- a/i18n/en/docusaurus-plugin-content-docs/current/devices/tariffs/_dynamic_electricity_price.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/devices/tariffs/_dynamic_electricity_price.mdx
@@ -1,23 +1,21 @@
-### Custom plugin
+### Custom Plugin
 
-The plugin must return a JSON structure containing a list of time periods and prices. The time periods must be in the form `YYYY-MM-DDTHH:MM:SSZ`. The prices must be given in cents.
+Use the plugin mechanism to connect a custom tariff source.
 
-```json
-[
-  {
-    "start": "2025-01-01T00:00:00Z",
-    "end": "2025-01-01T01:00:00Z",
-    "price": 25.0
-  },
-  {
-    "start": "2025-01-01T01:00:00Z",
-    "end": "2025-01-01T02:00:00Z",
-    "price": 30.0
-  }
-]
+**Example: Current price via HTTP**
+
+```yaml
+tariffs:
+  grid:
+    type: custom
+    price:
+      source: http
+      uri: https://example.com/api/price
 ```
 
-Here is an example:
+The value returned by the endpoint is used as the grid price.
+
+**Example: Forecasts via HTTP**
 
 ```yaml
 tariffs:
@@ -28,3 +26,16 @@ tariffs:
       uri: https://api.allinpower.nl/troodon/api/p/spot_market/prices/?product_type=ELK
       jq: '[.timestamps, .prices] | transpose | map({ "start": (.[0] | strptime("%Y-%m-%dT%H:%M:%S.%f%z") | strftime("%Y-%m-%dT%H:%M:%SZ")), "end": (.[0] | strptime("%Y-%m-%dT%H:%M:%S.%f%z") | mktime + 3600 | strftime("%Y-%m-%dT%H:%M:%SZ")), "price": .[1] }) | tostring'
 ```
+
+The plugin must return a JSON structure containing a list of time periods and prices.
+The date fields must be in the form `YYYY-MM-DDTHH:MM:SSZ` and the price in the correct currency unit (e.g. EUR).
+See the following example:
+
+```js
+[
+  { "start": "2025-01-01T00:00:00Z", "end": "2025-01-01T01:00:00Z", "price": 25.0 },
+  { "start": "2025-01-01T01:00:00Z", "end": "2025-01-01T02:00:00Z", "price": 30.0 },
+]
+```
+
+The plugin is updated once per hour.

--- a/i18n/en/docusaurus-plugin-content-docs/current/devices/tariffs/_dynamic_electricity_price.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/devices/tariffs/_dynamic_electricity_price.mdx
@@ -1,0 +1,30 @@
+### Custom plugin
+
+The plugin must return a JSON structure containing a list of time periods and prices. The time periods must be in the form `YYYY-MM-DDTHH:MM:SSZ`. The prices must be given in cents.
+
+```json
+[
+  {
+    "start": "2025-01-01T00:00:00Z",
+    "end": "2025-01-01T01:00:00Z",
+    "price": 25.0
+  },
+  {
+    "start": "2025-01-01T01:00:00Z",
+    "end": "2025-01-01T02:00:00Z",
+    "price": 30.0
+  }
+]
+```
+
+Here is an example:
+
+```yaml
+tariffs:
+  grid:
+    type: custom
+    forecast:
+      source: http
+      uri: https://api.allinpower.nl/troodon/api/p/spot_market/prices/?product_type=ELK
+      jq: '[.timestamps, .prices] | transpose | map({ "start": (.[0] | strptime("%Y-%m-%dT%H:%M:%S.%f%z") | strftime("%Y-%m-%dT%H:%M:%SZ")), "end": (.[0] | strptime("%Y-%m-%dT%H:%M:%S.%f%z") | mktime + 3600 | strftime("%Y-%m-%dT%H:%M:%SZ")), "price": .[1] }) | tostring'
+```

--- a/i18n/en/docusaurus-plugin-content-docs/current/faq.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/faq.mdx
@@ -334,7 +334,7 @@ tariffs:
     price: 0.08 # [currency]/kWh
 ```
 
-More details, including on how to use variable rate tariffs (such as those from Octopus Energy) can be found in [Configuration - Tariffs](/docs/reference/configuration/tariffs).
+More details, including on how to use variable rate tariffs (such as those from Octopus Energy) can be found in [Configuration - Tariffs](/docs/devices/tariffs).
 
 _Please note that these statistics are rough and shouldn't be treated as perfectly accurate._
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/features/co2.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/features/co2.mdx
@@ -25,7 +25,7 @@ tariffs:
     zip: 12349 # ZIP code
 ```
 
-In this example, we'll use data from GrünstromIndex. See tariffs for a list of all [supported data sources](../reference/configuration/tariffs#co2).
+In this example, we'll use data from GrünstromIndex. See tariffs for a list of all [supported data sources](../devices/tariffs).
 
 ## Clean web charging
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/features/dynamic-prices.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/features/dynamic-prices.mdx
@@ -61,7 +61,7 @@ tariffs:
     token: "..." # Access Token
 ```
 
-Unter [tariffs](../reference/configuration/tariffs/) findest du eine Liste aller unterstützten Tarife.
+Unter [tariffs](../devices/tariffs) findest du eine Liste aller unterstützten Tarife.
 Wenn dein Anbieter eine Schnittstelle hat, aber noch nicht von evcc unterstützt wird, dann mach gerne einen [Feature Request](https://github.com/evcc-io/evcc/issues/new/choose) auf.
 
 ## Günstiges Netzladen

--- a/i18n/en/docusaurus-plugin-content-docs/current/features/dynamic-prices.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/features/dynamic-prices.mdx
@@ -27,7 +27,7 @@ tariffs:
   currency: EUR
   grid:
     type: fixed
-    price: 0.32 # 32ct/kWh
+    price: 0.32 # EUR/kWh
 ```
 
 ### Zeitabhängiger Strompreis
@@ -40,13 +40,13 @@ tariffs:
   currency: EUR
   grid:
     type: fixed
-    price: 0.32 # 32ct/kWh (default)
+    price: 0.32 # EUR/kWh (default)
     zones:
       - days: Mo-Fr
         hours: 2-6
-        price: 0.22 # 20ct/kWh (werkstags 2-6 Uhr)
+        price: 0.22 # EUR/kWh (werkstags 2-6 Uhr)
       - days: Sa,So
-        price: 0.12 # 12ct/kWh (Wochenende)
+        price: 0.12 # EUR/kWh (Wochenende)
 ```
 
 ### Dynamischer Strompreis via API

--- a/templates/release/de/tariff/allinpower_0.yaml
+++ b/templates/release/de/tariff/allinpower_0.yaml
@@ -1,12 +1,11 @@
 product:
-  brand: Awattar
+  brand: All in Power
   group: Dynamischer Strompreis
 description: |
-  Nur für Deutschland und Österreich verfügbar.
+  Nur für die Niederlande verfügbar.
 render:
   - default: |
       type: template
-      template: awattar
-      region: AT # optional
+      template: allinpower
       costs: # Zusätzlicher fester Aufschlag pro kWh (z.B. 0.05 für 5 Cent) (optional)
       tax: # Zusätzlicher prozentualer Aufschlag (z.B. 0.2 für 20%) (optional)

--- a/templates/release/de/tariff/amber_0.yaml
+++ b/templates/release/de/tariff/amber_0.yaml
@@ -1,5 +1,8 @@
 product:
-  brand: Amber Electric (AU)
+  brand: Amber Electric
+  group: Dynamischer Strompreis
+description: |
+  Nur für Australien verfügbar.
 render:
   - default: |
       type: template
@@ -7,11 +10,5 @@ render:
       token: # optional
       siteid: # optional
       channel: # optional
-    advanced: |
-      type: template
-      template: amber
-      costs: # optional
-      tax: # optional
-      token: # optional
-      siteid: # optional
-      channel: # optional
+      costs: # Zusätzlicher fester Aufschlag pro kWh (z.B. 0.05 für 5 Cent) (optional)
+      tax: # Zusätzlicher prozentualer Aufschlag (z.B. 0.2 für 20%) (optional)

--- a/templates/release/de/tariff/electricitymaps_0.yaml
+++ b/templates/release/de/tariff/electricitymaps_0.yaml
@@ -1,0 +1,13 @@
+product:
+  brand: Electricity Maps
+  description: Commercial API
+  group: CO₂ Vorhersage
+description: |
+  CO₂-Daten für viele Länder von https://electricitymaps.com/. Der 'Free Personal Tier' beinhaltet leider keine Prognosedaten. Dafür benötigen Sie einen kommerziellen Account von https://api-portal.electricitymaps.com/. Kostenloser Testmonat verfügbar.
+render:
+  - default: |
+      type: template
+      template: electricitymaps
+      uri: https://api-access.electricitymaps.com/2w...1g/ # HTTP(S) Adresse
+      token:
+      zone: DE # siehe https://api.electricitymap.org/v3/zones

--- a/templates/release/de/tariff/electricitymaps_0.yaml
+++ b/templates/release/de/tariff/electricitymaps_0.yaml
@@ -3,7 +3,7 @@ product:
   description: Commercial API
   group: CO₂ Vorhersage
 description: |
-  CO₂-Daten für viele Länder von https://electricitymaps.com/. Der 'Free Personal Tier' beinhaltet leider keine Prognosedaten. Dafür benötigen Sie einen kommerziellen Account von https://api-portal.electricitymaps.com/. Kostenloser Testmonat verfügbar.
+  CO₂-Daten für viele Länder von https://electricitymaps.com/. Der 'Free Personal Tier' beinhaltet leider keine Prognosedaten. Dafür benötigst du einen kommerziellen Account von https://api-portal.electricitymaps.com/. Kostenloser Testmonat verfügbar.
 render:
   - default: |
       type: template

--- a/templates/release/de/tariff/elering_0.yaml
+++ b/templates/release/de/tariff/elering_0.yaml
@@ -1,12 +1,13 @@
 product:
-  brand: Awattar
+  brand: Nordpool
+  description: Elering
   group: Dynamischer Strompreis
 description: |
-  Nur für Deutschland und Österreich verfügbar.
+  Nur für Estland verfügbar.
 render:
   - default: |
       type: template
-      template: awattar
-      region: AT # optional
+      template: elering
+      region: ee # optional
       costs: # Zusätzlicher fester Aufschlag pro kWh (z.B. 0.05 für 5 Cent) (optional)
       tax: # Zusätzlicher prozentualer Aufschlag (z.B. 0.2 für 20%) (optional)

--- a/templates/release/de/tariff/energinet_0.yaml
+++ b/templates/release/de/tariff/energinet_0.yaml
@@ -1,12 +1,12 @@
 product:
-  brand: Awattar
+  brand: Energinet
   group: Dynamischer Strompreis
 description: |
-  Nur für Deutschland und Österreich verfügbar.
+  Nur für Dänemark verfügbar.
 render:
   - default: |
       type: template
-      template: awattar
-      region: AT # optional
+      template: energinet
+      region: dk1 # optional
       costs: # Zusätzlicher fester Aufschlag pro kWh (z.B. 0.05 für 5 Cent) (optional)
       tax: # Zusätzlicher prozentualer Aufschlag (z.B. 0.2 für 20%) (optional)

--- a/templates/release/de/tariff/energy-charts-api_0.yaml
+++ b/templates/release/de/tariff/energy-charts-api_0.yaml
@@ -1,0 +1,12 @@
+product:
+  brand: Fraunhofer ISE
+  group: Dynamischer Strompreis
+description: |
+  Day-ahead Energiepreise (je kWh) an der Börse. Kann ohne vorherige Anmeldung auf https://api.energy-charts.info/ abgerufen werden. Nutzbar u.a. für dynamische Stromtarife, wo der Anbieter bis dato auf der Kundenschnittstelle noch kein Preis-Vorhersagen anbietet.
+render:
+  - default: |
+      type: template
+      template: energy-charts-api
+      bzn: DE-LU
+      costs: # Zusätzlicher fester Aufschlag pro kWh (z.B. 0.05 für 5 Cent) (optional)
+      tax: # Zusätzlicher prozentualer Aufschlag (z.B. 0.2 für 20%) (optional)

--- a/templates/release/de/tariff/entsoe_0.yaml
+++ b/templates/release/de/tariff/entsoe_0.yaml
@@ -1,0 +1,15 @@
+product:
+  brand: ENTSO-E
+  group: Dynamischer Strompreis
+description: |
+  Day-ahead-Preise für den europäischen Strommarkt. Siehe https://transparency.entsoe.eu für weitere Informationen.
+  Basis für viele dynamische Tarife.
+
+render:
+  - default: |
+      type: template
+      template: entsoe
+      securitytoken: # Registrierung und anschließende Helpdesk-Anfrage erforderlich. Details zum Ablauf gibts hier https://transparency.entsoe.eu/content/static_content/Static%20content/web%20api/Guide.html#_authentication_and_authorisation (optional)
+      domain: BZN|DE-LU # siehe https://transparency.entsoe.eu/content/static_content/Static%20content/web%20api/Guide.html#_areas (optional)
+      costs: # Zusätzlicher fester Aufschlag pro kWh (z.B. 0.05 für 5 Cent) (optional)
+      tax: # Zusätzlicher prozentualer Aufschlag (z.B. 0.2 für 20%) (optional)

--- a/templates/release/de/tariff/fixed_0.yaml
+++ b/templates/release/de/tariff/fixed_0.yaml
@@ -1,7 +1,0 @@
-product:
-  brand: Standard
-render:
-  - default: |
-      type: template
-      template: fixed
-      price: # optional

--- a/templates/release/de/tariff/groupe-e_0.yaml
+++ b/templates/release/de/tariff/groupe-e_0.yaml
@@ -1,12 +1,12 @@
 product:
-  brand: Groupe E (CH)
+  brand: Groupe E
   description: Vario Plus
+  group: Dynamischer Strompreis
+description: |
+  Nur für die Schweiz verfügbar.
 render:
   - default: |
       type: template
       template: groupe-e
-    advanced: |
-      type: template
-      template: groupe-e
-      costs: # optional
-      tax: # optional
+      costs: # Zusätzlicher fester Aufschlag pro kWh (z.B. 0.05 für 5 Cent) (optional)
+      tax: # Zusätzlicher prozentualer Aufschlag (z.B. 0.2 für 20%) (optional)

--- a/templates/release/de/tariff/grünstromindex_0.yaml
+++ b/templates/release/de/tariff/grünstromindex_0.yaml
@@ -1,7 +1,10 @@
 product:
   brand: Grünstromindex
+  group: CO₂ Vorhersage
+description: |
+  Regionale Emissionsdaten von https://gruenstromindex.de. Nur für Deutschland verfügbar.
 render:
   - default: |
       type: template
       template: grünstromindex
-      zip: # optional
+      zip:

--- a/templates/release/de/tariff/ngeso_0.yaml
+++ b/templates/release/de/tariff/ngeso_0.yaml
@@ -1,0 +1,11 @@
+product:
+  brand: National Grid ESO
+  group: CO₂ Vorhersage
+description: |
+  Nur für Großbritannien verfügbar.
+render:
+  - default: |
+      type: template
+      template: ngeso
+      region: 1 # Ungenauer als die Verwendung eines Postleitzahl. Siehe https://carbon-intensity.github.io/api-definitions/#region-list (optional)
+      postalcode: SW1 # Postleitzahl z.B. RG41 oder SW1 oder TF8. Nicht die vollständige Postleitzahl, nur die ersten Stellen. (optional)

--- a/templates/release/de/tariff/octopus-api_0.yaml
+++ b/templates/release/de/tariff/octopus-api_0.yaml
@@ -1,7 +1,11 @@
 product:
   brand: Octopus Energy
+  description: API
+  group: Dynamischer Strompreis
+description: |
+  Den API-Key bekommst du im Octopus Portal https://octopus.energy/dashboard/new/accounts/personal-details/api-access
 render:
   - default: |
       type: template
       template: octopus-api
-      apiKey:
+      apiKey: # Octopus Energy API Key.

--- a/templates/release/de/tariff/octopus-productcode_0.yaml
+++ b/templates/release/de/tariff/octopus-productcode_0.yaml
@@ -1,8 +1,10 @@
 product:
   brand: Octopus Energy
+  description: Product Code
+  group: Dynamischer Strompreis
 render:
   - default: |
       type: template
       template: octopus-productcode
-      productCode:
-      region:
+      productCode: AGILE-FLEX-22-11-25 # Der Tarifcode für Ihren Energievertrag. Stellen Sie sicher, dass dieser auf Ihren Importtarifcode eingestellt ist.
+      region: # Die DNO-Region, in der Sie sich befinden. Weitere Informationen: https://www.energy-stats.uk/dno-region-codes-explained/

--- a/templates/release/de/tariff/pun_0.yaml
+++ b/templates/release/de/tariff/pun_0.yaml
@@ -1,11 +1,11 @@
 product:
-  brand: PUN Orario (IT)
+  brand: PUN Orario
+  group: Dynamischer Strompreis
+description: |
+  Preisdaten von https://www.mercatoelettrico.org/it/. Wird oft zur Einspeisung ins Netz verwendet. Nur für Italien verfügbar.
 render:
   - default: |
       type: template
       template: pun
-    advanced: |
-      type: template
-      template: pun
-      costs: # optional
-      tax: # optional
+      costs: # Zusätzlicher fester Aufschlag pro kWh (z.B. 0.05 für 5 Cent) (optional)
+      tax: # Zusätzlicher prozentualer Aufschlag (z.B. 0.2 für 20%) (optional)

--- a/templates/release/de/tariff/smartenergy_0.yaml
+++ b/templates/release/de/tariff/smartenergy_0.yaml
@@ -1,12 +1,12 @@
 product:
-  brand: SmartEnergy (AT)
+  brand: SmartEnergy
   description: smartCONTROL
+  group: Dynamischer Strompreis
+description: |
+  Nur für Österreich verfügbar.
 render:
   - default: |
       type: template
       template: smartenergy
-    advanced: |
-      type: template
-      template: smartenergy
-      costs: # optional
-      tax: # optional
+      costs: # Zusätzlicher fester Aufschlag pro kWh (z.B. 0.05 für 5 Cent) (optional)
+      tax: # Zusätzlicher prozentualer Aufschlag (z.B. 0.2 für 20%) (optional)

--- a/templates/release/de/tariff/tibber_0.yaml
+++ b/templates/release/de/tariff/tibber_0.yaml
@@ -1,15 +1,13 @@
 product:
   brand: Tibber
+  group: Dynamischer Strompreis
+description: |
+  Hol dir deinen API-Token aus dem Tibber-Entwicklerportal: https://developer.tibber.com/
 render:
   - default: |
       type: template
       template: tibber
-      token: # optional
-      homeid: # optional
-    advanced: |
-      type: template
-      template: tibber
-      costs: # optional
-      tax: # optional
-      token: # optional
-      homeid: # optional
+      token: 476c477d8a039529478ebd690d35ddd80e3308ffc49b59c65b142321aee963a4
+      homeid: cc83e83e-8cbf-4595-9bf7-c3cf192f7d9c # Nur erforderlich, wenn du mehrere Häuser in deinem Tibber-Konto hast. (optional)
+      costs: # Zusätzlicher fester Aufschlag pro kWh (z.B. 0.05 für 5 Cent) (optional)
+      tax: # Zusätzlicher prozentualer Aufschlag (z.B. 0.2 für 20%) (optional)

--- a/templates/release/en/tariff/allinpower_0.yaml
+++ b/templates/release/en/tariff/allinpower_0.yaml
@@ -1,11 +1,11 @@
 product:
-  brand: PUN Orario
+  brand: All in Power
   group: Dynamic electricity price
 description: |
-  Price data from https://www.mercatoelettrico.org/it/. Often used for feeding into the grid. Only available for Italy.
+  Only available for the Netherlands.
 render:
   - default: |
       type: template
-      template: pun
+      template: allinpower
       costs: # Additional fixed charge per kWh (e.g. 0.05 for 5 cents) (optional)
       tax: # Additional percentage charge (e.g. 0.2 for 20%) (optional)

--- a/templates/release/en/tariff/amber_0.yaml
+++ b/templates/release/en/tariff/amber_0.yaml
@@ -1,5 +1,8 @@
 product:
-  brand: Amber Electric (AU)
+  brand: Amber Electric
+  group: Dynamic electricity price
+description: |
+  Only available for Australia.
 render:
   - default: |
       type: template
@@ -7,11 +10,5 @@ render:
       token: # optional
       siteid: # optional
       channel: # optional
-    advanced: |
-      type: template
-      template: amber
-      costs: # optional
-      tax: # optional
-      token: # optional
-      siteid: # optional
-      channel: # optional
+      costs: # Additional fixed charge per kWh (e.g. 0.05 for 5 cents) (optional)
+      tax: # Additional percentage charge (e.g. 0.2 for 20%) (optional)

--- a/templates/release/en/tariff/awattar_0.yaml
+++ b/templates/release/en/tariff/awattar_0.yaml
@@ -1,13 +1,12 @@
 product:
   brand: Awattar
+  group: Dynamic electricity price
+description: |
+  Only available for Germany and Austria.
 render:
   - default: |
       type: template
       template: awattar
-      region: # optional
-    advanced: |
-      type: template
-      template: awattar
-      costs: # optional
-      tax: # optional
-      region: # optional
+      region: AT # optional
+      costs: # Additional fixed charge per kWh (e.g. 0.05 for 5 cents) (optional)
+      tax: # Additional percentage charge (e.g. 0.2 for 20%) (optional)

--- a/templates/release/en/tariff/electricitymaps_0.yaml
+++ b/templates/release/en/tariff/electricitymaps_0.yaml
@@ -1,0 +1,13 @@
+product:
+  brand: Electricity Maps
+  description: Commercial API
+  group: CO₂ forecast
+description: |
+  CO₂ data for many countries from https://electricitymaps.com/. The 'Free Personal Tier' unfortunately does not include forecast data. You'll need a commercial account from https://api-portal.electricitymaps.com/. Free trial available.
+render:
+  - default: |
+      type: template
+      template: electricitymaps
+      uri: https://api-access.electricitymaps.com/2w...1g/ # HTTP(S) address
+      token:
+      zone: DE # see https://api.electricitymap.org/v3/zones

--- a/templates/release/en/tariff/elering_0.yaml
+++ b/templates/release/en/tariff/elering_0.yaml
@@ -1,11 +1,13 @@
 product:
-  brand: PUN Orario
+  brand: Nordpool
+  description: Elering
   group: Dynamic electricity price
 description: |
-  Price data from https://www.mercatoelettrico.org/it/. Often used for feeding into the grid. Only available for Italy.
+  Only available for Estonia.
 render:
   - default: |
       type: template
-      template: pun
+      template: elering
+      region: ee # optional
       costs: # Additional fixed charge per kWh (e.g. 0.05 for 5 cents) (optional)
       tax: # Additional percentage charge (e.g. 0.2 for 20%) (optional)

--- a/templates/release/en/tariff/energinet_0.yaml
+++ b/templates/release/en/tariff/energinet_0.yaml
@@ -1,11 +1,12 @@
 product:
-  brand: PUN Orario
+  brand: Energinet
   group: Dynamic electricity price
 description: |
-  Price data from https://www.mercatoelettrico.org/it/. Often used for feeding into the grid. Only available for Italy.
+  Only available for Denmark.
 render:
   - default: |
       type: template
-      template: pun
+      template: energinet
+      region: dk1 # optional
       costs: # Additional fixed charge per kWh (e.g. 0.05 for 5 cents) (optional)
       tax: # Additional percentage charge (e.g. 0.2 for 20%) (optional)

--- a/templates/release/en/tariff/energy-charts-api_0.yaml
+++ b/templates/release/en/tariff/energy-charts-api_0.yaml
@@ -1,0 +1,12 @@
+product:
+  brand: Fraunhofer ISE
+  group: Dynamic electricity price
+description: |
+  Day-ahead forecast of energy prices (per kWh) on the exchange. No prior registration for https://api.energy-charts.info/ necessary. Can be used for dynamic electricity tariffs, for example, where the supplier does not yet offer a price forecast on the customer interface.
+render:
+  - default: |
+      type: template
+      template: energy-charts-api
+      bzn: DE-LU
+      costs: # Additional fixed charge per kWh (e.g. 0.05 for 5 cents) (optional)
+      tax: # Additional percentage charge (e.g. 0.2 for 20%) (optional)

--- a/templates/release/en/tariff/entsoe_0.yaml
+++ b/templates/release/en/tariff/entsoe_0.yaml
@@ -1,0 +1,15 @@
+product:
+  brand: ENTSO-E
+  group: Dynamic electricity price
+description: |
+  Day-ahead prices for the European electricity market. See https://transparency.entsoe.eu for more information.
+  Basis for many dynamic tariffs.
+
+render:
+  - default: |
+      type: template
+      template: entsoe
+      securitytoken: # Registration and subsequent helpdesk request required. Details on the process can be found here https://transparency.entsoe.eu/content/static_content/Static%20content/web%20api/Guide.html#_authentication_and_authorisation (optional)
+      domain: BZN|DE-LU # see https://transparency.entsoe.eu/content/static_content/Static%20content/web%20api/Guide.html#_areas (optional)
+      costs: # Additional fixed charge per kWh (e.g. 0.05 for 5 cents) (optional)
+      tax: # Additional percentage charge (e.g. 0.2 for 20%) (optional)

--- a/templates/release/en/tariff/fixed_0.yaml
+++ b/templates/release/en/tariff/fixed_0.yaml
@@ -1,7 +1,0 @@
-product:
-  brand: Standard
-render:
-  - default: |
-      type: template
-      template: fixed
-      price: # optional

--- a/templates/release/en/tariff/groupe-e_0.yaml
+++ b/templates/release/en/tariff/groupe-e_0.yaml
@@ -1,12 +1,12 @@
 product:
-  brand: Groupe E (CH)
+  brand: Groupe E
   description: Vario Plus
+  group: Dynamic electricity price
+description: |
+  Only available for Switzerland.
 render:
   - default: |
       type: template
       template: groupe-e
-    advanced: |
-      type: template
-      template: groupe-e
-      costs: # optional
-      tax: # optional
+      costs: # Additional fixed charge per kWh (e.g. 0.05 for 5 cents) (optional)
+      tax: # Additional percentage charge (e.g. 0.2 for 20%) (optional)

--- a/templates/release/en/tariff/grünstromindex_0.yaml
+++ b/templates/release/en/tariff/grünstromindex_0.yaml
@@ -1,7 +1,10 @@
 product:
   brand: Grünstromindex
+  group: CO₂ forecast
+description: |
+  Regional emission data from https://gruenstromindex.de. Only available for Germany.
 render:
   - default: |
       type: template
       template: grünstromindex
-      zip: # optional
+      zip:

--- a/templates/release/en/tariff/ngeso_0.yaml
+++ b/templates/release/en/tariff/ngeso_0.yaml
@@ -1,0 +1,11 @@
+product:
+  brand: National Grid ESO
+  group: CO₂ forecast
+description: |
+  Only available for the United Kingdom.
+render:
+  - default: |
+      type: template
+      template: ngeso
+      region: 1 # Coarser than using a postcode. See https://carbon-intensity.github.io/api-definitions/#region-list (optional)
+      postalcode: SW1 # Outward postcode i.e. RG41 or SW1 or TF8. Do not include full postcode, outward postcode only. (optional)

--- a/templates/release/en/tariff/octopus-api_0.yaml
+++ b/templates/release/en/tariff/octopus-api_0.yaml
@@ -1,8 +1,11 @@
 product:
   brand: Octopus Energy
-  description: Octopus Energy - API
+  description: API
+  group: Dynamic electricity price
+description: |
+  You can get the API key in the Octopus portal https://octopus.energy/dashboard/new/accounts/personal-details/api-access
 render:
   - default: |
       type: template
       template: octopus-api
-      apiKey:
+      apiKey: # Octopus Energy API Key.

--- a/templates/release/en/tariff/octopus-productcode_0.yaml
+++ b/templates/release/en/tariff/octopus-productcode_0.yaml
@@ -1,9 +1,10 @@
 product:
   brand: Octopus Energy
-  description: Octopus Energy - Product Code
+  description: Product Code
+  group: Dynamic electricity price
 render:
   - default: |
       type: template
       template: octopus-productcode
-      productCode:
-      region:
+      productCode: AGILE-FLEX-22-11-25 # The tariff code for your energy contract. Make sure this is set to your import tariff code.
+      region: # The DNO region you are located in. More information: https://www.energy-stats.uk/dno-region-codes-explained/

--- a/templates/release/en/tariff/smartenergy_0.yaml
+++ b/templates/release/en/tariff/smartenergy_0.yaml
@@ -1,12 +1,12 @@
 product:
-  brand: SmartEnergy (AT)
+  brand: SmartEnergy
   description: smartCONTROL
+  group: Dynamic electricity price
+description: |
+  Only available for Austria.
 render:
   - default: |
       type: template
       template: smartenergy
-    advanced: |
-      type: template
-      template: smartenergy
-      costs: # optional
-      tax: # optional
+      costs: # Additional fixed charge per kWh (e.g. 0.05 for 5 cents) (optional)
+      tax: # Additional percentage charge (e.g. 0.2 for 20%) (optional)

--- a/templates/release/en/tariff/tibber_0.yaml
+++ b/templates/release/en/tariff/tibber_0.yaml
@@ -1,15 +1,13 @@
 product:
   brand: Tibber
+  group: Dynamic electricity price
+description: |
+  Get your API token from the Tibber developer portal: https://developer.tibber.com/
 render:
   - default: |
       type: template
       template: tibber
-      token: # optional
-      homeid: # optional
-    advanced: |
-      type: template
-      template: tibber
-      costs: # optional
-      tax: # optional
-      token: # optional
-      homeid: # optional
+      token: 476c477d8a039529478ebd690d35ddd80e3308ffc49b59c65b142321aee963a4
+      homeid: cc83e83e-8cbf-4595-9bf7-c3cf192f7d9c # Only required if you have multiple homes in your Tibber account. (optional)
+      costs: # Additional fixed charge per kWh (e.g. 0.05 for 5 cents) (optional)
+      tax: # Additional percentage charge (e.g. 0.2 for 20%) (optional)


### PR DESCRIPTION
Fixes https://github.com/evcc-io/docs/issues/558, https://github.com/evcc-io/docs/issues/550

Depends on https://github.com/evcc-io/evcc/pull/13756 (docs templates copied manually once for testing)

- introduced a separate tariff page
- content is based on core templates (similar to chargers, vehicles, ...)
- added forecast plugin example

Screenshots of English and German version:

![german](https://github.com/evcc-io/docs/assets/152287/1b9b07a6-3dd1-4df3-a2d4-4d3b33fb4e79)

---

![english](https://github.com/evcc-io/docs/assets/152287/31b84aed-6e95-40b0-be0b-fc7efc33bdaf)

\\cc @VolkerK62