### PR TITLE
Update Doc vehicles.mdx with info about net capacity

### DIFF
--- a/docs/reference/configuration/vehicles.mdx
+++ b/docs/reference/configuration/vehicles.mdx
@@ -65,7 +65,9 @@ Dies ist der evcc Schnittstellen-Typ, mit Hilfe dessen mit dem Fahrzeug kommuniz
 
 ### `capacity`
 
-Die Kapazität der Batterie des Fahrzeugs in kWh.
+Die Kapazität der Batterie des Fahrzeugs in kWh (netto).
+
+Dieser Wert wird nur als Startwert angenommen. `evcc` kalkuliert und korrigiert die tatsächlichen Werte anhand der folgenden SOC-Abfragen selbst. 
 
 **Beispiel**:
 


### PR DESCRIPTION
It was unclear, whether to choose gross or net values for capacity. According a comment from maintainer, it should be the net value.