### PR TITLE
hint on LAN vs. WLAN with Sungrow Hybrid inverter and Winet-S Dongle

### DIFF
--- a/templates/release/de/meter/sungrow-hybrid_0.yaml
+++ b/templates/release/de/meter/sungrow-hybrid_0.yaml
@@ -3,7 +3,7 @@ product:
   description: SH Series Hybrid Inverter
 capabilities: ["battery-control"]
 description: |
-  Verbindungen über das WiNet-S-Dongle (WiFi oder LAN) funktionieren nur mit aktueller Firmware.
+  Verbindungen über das WiNet-S-Dongle (WiFi oder LAN) funktionieren nur mit aktueller Firmware. Über WiFi bekommst du sonst z.B. keine Watt-Angabe von der Batterie, das siehst du im UI und [auch in den Logs an "battery power: 0W"](https://github.com/evcc-io/evcc/discussions/7747#discussioncomment-5773931).
 render:
   - usage: grid
     default: |

--- a/templates/release/en/meter/sungrow-hybrid_0.yaml
+++ b/templates/release/en/meter/sungrow-hybrid_0.yaml
@@ -3,7 +3,7 @@ product:
   description: SH Series Hybrid Inverter
 capabilities: ["battery-control"]
 description: |
-  Connections via the WiNet-S dongle (WiFi or LAN) only work with the latest firmware.
+  Connections via the WiNet-S dongle (WiFi or LAN) only work with the latest firmware. Otherwise via WiFi, you receive no power in Watt for the battery, you can see this in the UI and [also in Logs as "battery power: 0W"](https://github.com/evcc-io/evcc/discussions/7747#discussioncomment-5773931).
 render:
   - usage: grid
     default: |


### PR DESCRIPTION
provided en/de translation

Verified also in my own home installation, I first connected via WLAN, did not receive battery power value and then saw that this has been discussed previously. If you want I can additionally link https://github.com/evcc-io/docs/issues/548

I think it might help also others if we provide this information here.