### PR TITLE
Fix docker setup

### DIFF
--- a/docs/installation/docker.mdx
+++ b/docs/installation/docker.mdx
@@ -108,7 +108,6 @@ Entsprechend der passenden Komponenten-Konstellation kopiert man eine der folgen
   <TabItem value="default" label="Standard" default>
 
 ```yaml
-version: "3"
 services:
   evcc:
     command:
@@ -130,18 +129,12 @@ services:
   <TabItem value="sma" label="SMA Geräte und EEBus">
 
 ```yaml
-version: "3"
 services:
   evcc:
     command:
       - evcc
     container_name: evcc
     image: evcc/evcc:latest
-    ports:
-      - 7070:7070/tcp
-      - 8887:8887/tcp
-      - 7090:7090/udp
-      - 9522:9522/udp
     volumes:
       - /etc/evcc.yaml:/etc/evcc.yaml
       - /home/[user]/.evcc:/root/.evcc

--- a/i18n/en/docusaurus-plugin-content-docs/current/installation/docker.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/installation/docker.mdx
@@ -113,7 +113,6 @@ Simply copy the following configuration into a `docker-compose.yaml` in your wor
   <TabItem value="default" label="Standard" default>
 
 ```yaml
-version: "3"
 services:
   evcc:
     command:
@@ -135,7 +134,6 @@ services:
   <TabItem value="sma" label="SMA Geräte und EEBus">
 
 ```yaml
-version: "3"
 services:
   evcc:
     command:

--- a/i18n/en/docusaurus-plugin-content-docs/current/installation/docker.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/installation/docker.mdx
@@ -140,11 +140,6 @@ services:
       - evcc
     container_name: evcc
     image: evcc/evcc:latest
-    ports:
-      - 7070:7070/tcp
-      - 8887:8887/tcp
-      - 7090:7090/udp
-      - 9522:9522/udp
     volumes:
       - /etc/evcc.yaml:/etc/evcc.yaml
       - /home/[user]/.evcc:/root/.evcc


### PR DESCRIPTION
- Remove obsolete version from docker-compose.yaml sample
- Remove **ports** setting from docker-compose.yaml sample, because this conflicts with **network_mode: host** and newer docker-compose versions throw an error if both exists in the docker-compose.yaml file