### PR TITLE
bessere Beschreibung der Parameter für SAJ-H2 aktive Batteriesteuerung

### DIFF
--- a/templates/release/de/meter/saj-h2_0.yaml
+++ b/templates/release/de/meter/saj-h2_0.yaml
@@ -49,9 +49,9 @@ render:
       id: 1
       host: 192.0.2.2 # Hostname
       port: 502 # Port
-      defaultmode: 2 # optional
-      minsoc: 20 # Ladung mit maximaler Geschwindigkeit bis zu dem angegeben Ladestand unabhängig PV-Erzeugung, wenn der Lademodus nicht auf 'Aus' steht (optional)
-      maxsoc: 95 # optional
+      defaultmode: 2 # backup_mode, Wert bitte nicht ändern, erforderlich für die aktive Batteriesteuerung - Laden aus dem Netz
+      minsoc: 20 # Notstromkapazität, auf diesen Wert wird der Speicher eingestellt bei "Entladesperre aus" bzw. "Entladesperre nicht aktiv" (optional)
+      maxsoc: 95 # Notstromkapazität, ab diesem SOC-Wert und kleiner wird die Entladesperre aktiv bei "Entladesperre ein" (optional)
   - usage: pv
     default: |
       type: template
@@ -99,9 +99,9 @@ render:
       id: 1
       host: 192.0.2.2 # Hostname
       port: 502 # Port
-      defaultmode: 2 # optional
-      minsoc: 20 # Ladung mit maximaler Geschwindigkeit bis zu dem angegeben Ladestand unabhängig PV-Erzeugung, wenn der Lademodus nicht auf 'Aus' steht (optional)
-      maxsoc: 95 # optional
+      defaultmode: 2 # backup_mode, Wert bitte nicht ändern, erforderlich für die aktive Batteriesteuerung - Laden aus dem Netz
+      minsoc: 20 # Notstromkapazität, auf diesen Wert wird der Speicher eingestellt bei "Entladesperre aus" bzw. "Entladesperre nicht aktiv" (optional)
+      maxsoc: 95 # Notstromkapazität, ab diesem SOC-Wert und kleiner wird die Entladesperre aktiv bei "Entladesperre ein" (optional)
   - usage: battery
     default: |
       type: template
@@ -150,6 +150,6 @@ render:
       host: 192.0.2.2 # Hostname
       port: 502 # Port
       capacity: 50 # Akkukapazität in kWh (optional)
-      defaultmode: 2 # optional
-      minsoc: 20 # Ladung mit maximaler Geschwindigkeit bis zu dem angegeben Ladestand unabhängig PV-Erzeugung, wenn der Lademodus nicht auf 'Aus' steht (optional)
-      maxsoc: 95 # optional
+      defaultmode: 2 # backup_mode, Wert bitte nicht ändern, erforderlich für die aktive Batteriesteuerung - Laden aus dem Netz
+      minsoc: 20 # Notstromkapazität, auf diesen Wert wird der Speicher eingestellt bei "Entladesperre aus" bzw. "Entladesperre nicht aktiv" (optional)
+      maxsoc: 95 # Notstromkapazität, ab diesem SOC-Wert und kleiner wird die Entladesperre aktiv bei "Entladesperre ein" (optional)

--- a/templates/release/de/meter/saj-h2_1.yaml
+++ b/templates/release/de/meter/saj-h2_1.yaml
@@ -49,9 +49,9 @@ render:
       id: 1
       host: 192.0.2.2 # Hostname
       port: 502 # Port
-      defaultmode: 2 # optional
-      minsoc: 20 # Ladung mit maximaler Geschwindigkeit bis zu dem angegeben Ladestand unabhängig PV-Erzeugung, wenn der Lademodus nicht auf 'Aus' steht (optional)
-      maxsoc: 95 # optional
+      defaultmode: 2 # backup_mode, Wert bitte nicht ändern, erforderlich für die aktive Batteriesteuerung - Laden aus dem Netz
+      minsoc: 20 # Notstromkapazität, auf diesen Wert wird der Speicher eingestellt bei "Entladesperre aus" bzw. "Entladesperre nicht aktiv" (optional)
+      maxsoc: 95 # Notstromkapazität, ab diesem SOC-Wert und kleiner wird die Entladesperre aktiv bei "Entladesperre ein" (optional)	
   - usage: pv
     default: |
       type: template
@@ -99,9 +99,9 @@ render:
       id: 1
       host: 192.0.2.2 # Hostname
       port: 502 # Port
-      defaultmode: 2 # optional
-      minsoc: 20 # Ladung mit maximaler Geschwindigkeit bis zu dem angegeben Ladestand unabhängig PV-Erzeugung, wenn der Lademodus nicht auf 'Aus' steht (optional)
-      maxsoc: 95 # optional
+      defaultmode: 2 # backup_mode, Wert bitte nicht ändern, erforderlich für die aktive Batteriesteuerung - Laden aus dem Netz
+      minsoc: 20 # Notstromkapazität, auf diesen Wert wird der Speicher eingestellt bei "Entladesperre aus" bzw. "Entladesperre nicht aktiv" (optional)
+      maxsoc: 95 # Notstromkapazität, ab diesem SOC-Wert und kleiner wird die Entladesperre aktiv bei "Entladesperre ein" (optional)	
   - usage: battery
     default: |
       type: template
@@ -150,6 +150,6 @@ render:
       host: 192.0.2.2 # Hostname
       port: 502 # Port
       capacity: 50 # Akkukapazität in kWh (optional)
-      defaultmode: 2 # optional
-      minsoc: 20 # Ladung mit maximaler Geschwindigkeit bis zu dem angegeben Ladestand unabhängig PV-Erzeugung, wenn der Lademodus nicht auf 'Aus' steht (optional)
-      maxsoc: 95 # optional
+      defaultmode: 2 # backup_mode, Wert bitte nicht ändern, erforderlich für die aktive Batteriesteuerung - Laden aus dem Netz
+      minsoc: 20 # Notstromkapazität, auf diesen Wert wird der Speicher eingestellt bei "Entladesperre aus" bzw. "Entladesperre nicht aktiv" (optional)
+      maxsoc: 95 # Notstromkapazität, ab diesem SOC-Wert und kleiner wird die Entladesperre aktiv bei "Entladesperre ein" (optional)	

--- a/templates/release/en/meter/saj-h2_0.yaml
+++ b/templates/release/en/meter/saj-h2_0.yaml
@@ -49,9 +49,9 @@ render:
       id: 1
       host: 192.0.2.2 # Hostname
       port: 502 # Port
-      defaultmode: 2 # optional
-      minsoc: 20 # Immediate charging with maximum power up to the defined state of charge independently from solar production if the charge mode is not set to 'Off' (optional)
-      maxsoc: 95 # optional
+	    defaultmode: 2 # backup_mode, please do not change the value, required for active battery control - charging from grid
+	    minsoc: 20 # emergency power capacity, the system is set to this value when "discharge lock off" or "discharge lock not active" (optional)
+      maxsoc: 95 # Emergency power capacity, from this SOC value and lower, the discharge lock becomes active with "discharge lock on" (optional)
   - usage: pv
     default: |
       type: template
@@ -99,9 +99,9 @@ render:
       id: 1
       host: 192.0.2.2 # Hostname
       port: 502 # Port
-      defaultmode: 2 # optional
-      minsoc: 20 # Immediate charging with maximum power up to the defined state of charge independently from solar production if the charge mode is not set to 'Off' (optional)
-      maxsoc: 95 # optional
+	    defaultmode: 2 # backup_mode, please do not change the value, required for active battery control - charging from grid
+	    minsoc: 20 # emergency power capacity, the system is set to this value when "discharge lock off" or "discharge lock not active" (optional)
+      maxsoc: 95 # Emergency power capacity, from this SOC value and lower, the discharge lock becomes active with "discharge lock on" (optional)
   - usage: battery
     default: |
       type: template
@@ -150,6 +150,6 @@ render:
       host: 192.0.2.2 # Hostname
       port: 502 # Port
       capacity: 50 # Battery capacity in kWh (optional)
-      defaultmode: 2 # optional
-      minsoc: 20 # Immediate charging with maximum power up to the defined state of charge independently from solar production if the charge mode is not set to 'Off' (optional)
-      maxsoc: 95 # optional
+	    defaultmode: 2 # backup_mode, please do not change the value, required for active battery control - charging from grid
+	    minsoc: 20 # emergency power capacity, the system is set to this value when "discharge lock off" or "discharge lock not active" (optional)
+      maxsoc: 95 # Emergency power capacity, from this SOC value and lower, the discharge lock becomes active with "discharge lock on" (optional)

--- a/templates/release/en/meter/saj-h2_1.yaml
+++ b/templates/release/en/meter/saj-h2_1.yaml
@@ -49,9 +49,9 @@ render:
       id: 1
       host: 192.0.2.2 # Hostname
       port: 502 # Port
-      defaultmode: 2 # optional
-      minsoc: 20 # Immediate charging with maximum power up to the defined state of charge independently from solar production if the charge mode is not set to 'Off' (optional)
-      maxsoc: 95 # optional
+	    defaultmode: 2 # backup_mode, please do not change the value, required for active battery control - charging from grid
+	    minsoc: 20 # emergency power capacity, the system is set to this value when "discharge lock off" or "discharge lock not active" (optional)
+      maxsoc: 95 # Emergency power capacity, from this SOC value and lower, the discharge lock becomes active with "discharge lock on" (optional)
   - usage: pv
     default: |
       type: template
@@ -99,9 +99,9 @@ render:
       id: 1
       host: 192.0.2.2 # Hostname
       port: 502 # Port
-      defaultmode: 2 # optional
-      minsoc: 20 # Immediate charging with maximum power up to the defined state of charge independently from solar production if the charge mode is not set to 'Off' (optional)
-      maxsoc: 95 # optional
+	    defaultmode: 2 # backup_mode, please do not change the value, required for active battery control - charging from grid
+	    minsoc: 20 # emergency power capacity, the system is set to this value when "discharge lock off" or "discharge lock not active" (optional)
+      maxsoc: 95 # Emergency power capacity, from this SOC value and lower, the discharge lock becomes active with "discharge lock on" (optional)
   - usage: battery
     default: |
       type: template
@@ -150,6 +150,6 @@ render:
       host: 192.0.2.2 # Hostname
       port: 502 # Port
       capacity: 50 # Battery capacity in kWh (optional)
-      defaultmode: 2 # optional
-      minsoc: 20 # Immediate charging with maximum power up to the defined state of charge independently from solar production if the charge mode is not set to 'Off' (optional)
-      maxsoc: 95 # optional
+	    defaultmode: 2 # backup_mode, please do not change the value, required for active battery control - charging from grid
+	    minsoc: 20 # emergency power capacity, the system is set to this value when "discharge lock off" or "discharge lock not active" (optional)
+      maxsoc: 95 # Emergency power capacity, from this SOC value and lower, the discharge lock becomes active with "discharge lock on" (optional)


### PR DESCRIPTION
Die aktuelle Beschreibung der Parameter entspricht nicht der aktuellen Funktion der Parameter. Die Beschreibungen hier entsprechen der tatsächlichen Funktion.