### PR TITLE
remove mix of docker/compose commands for upgrades

### DIFF
--- a/docs/installation/docker.mdx
+++ b/docs/installation/docker.mdx
@@ -197,27 +197,17 @@ Ersetze `127.0.0.1` mit der IP Adresse oder dem Hostnamen des Computers, falls d
 
 Um auf eine neue Version von evcc zu aktualisieren, führe folgende Schritte durch:
 
-- Öffne ein Terminal/Eingabeaufforderung
+- Öffne ein Terminal/Eingabeaufforderung 
+
+- Navigiere in das Verzeichnis, das die `docker-compose.yml` Datei von evcc enthält.
 
 - Aktualisiere auf das neuste evcc Image:
 
   ```sh
-  sudo docker pull evcc/evcc:latest
+  sudo docker-compose  pull
   ```
 
-- Stoppe den evcc Container:
-
-  ```sh
-  sudo docker stop evcc
-  ```
-
-- Lösche den evcc Container:
-
-  ```sh
-  sudo docker rm evcc
-  ```
-
-- Starte den evcc Container mit dem aktualisierten Image:
+- Falls ein neues Image vorhanden ist, startet das folgende Kommando den Container neu - ansonsten läuft der Alte einfach weiter:
 
   ```sh
   sudo docker-compose up -d

--- a/i18n/en/docusaurus-plugin-content-docs/current/installation/docker.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/installation/docker.mdx
@@ -204,22 +204,17 @@ To update to the latest version of evcc, follow this guide:
 
 - Open a Terminal
 
-- Get the latest release of evcc (changing the tag if appropriate):
+- Navigate to the directory that contains the `docker-compose.yml` file of your evcc.
 
+- Get the latest release of evcc
   ```sh
-  docker pull evcc/evcc:latest
+  docker-compose pull
   ```
 
-- Stop and remove the evcc container:
-
+- Restart the container if there was new version pulled (former container will just continue to run in case there was no upgrade).
   ```sh
-  docker stop evcc
-  docker rm evcc
-  # or
-  docker-compose down
+  docker-compose up -d
   ```
-
-- Restart the container using the appropriate incantation above.
 
 ## NAS systems
 


### PR DESCRIPTION
Especially for beginners it does not make sense to deep dive into docker commands when it would make more sense to stay with docker-compose commands. Especially upgrades are so streamline if you stay in one command world.