### PR TITLE
Korrektur Beispielkonfiguration

### DIFF
--- a/docs/faq.mdx
+++ b/docs/faq.mdx
@@ -388,7 +388,7 @@ chargers:
     type: template
     template: shelly # Shelly 1 für SG-Kontakt
     host: 192.168.178.29
-    standbypower: 15
+    standbypower: -1
     integrateddevice: true
     heating: true
 


### PR DESCRIPTION
weil positive standbypower i.V.m. externem Meter nicht funktioniert.