### PR TITLE
Updated HomeBrew upgrade command

### DIFF
--- a/docs/installation/macos.md
+++ b/docs/installation/macos.md
@@ -112,7 +112,7 @@ Um auf eine neue Version von evcc zu aktualisieren, führe folgende Schritte dur
 - Installiere evcc:
 
   ```sh
-  brew install evcc
+  brew upgrade evcc
   ```
 
 ## Weitere Befehle

--- a/i18n/en/docusaurus-plugin-content-docs/current/installation/macos.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/installation/macos.md
@@ -106,7 +106,7 @@ To upgrade to a new version of evcc, perform the following steps:
 - Upgrade evcc:
 
   ```sh
-  brew install evcc
+  brew upgrade evcc
   ```
 
 ## Additional Commands


### PR DESCRIPTION
Hi! I'm new to evcc.

_So Sorry if I haven't applied the correct GitHub standards._

I started with the HomeBrew installation and noticed that the `install` command was applied in the upgrade section. This is incorrect.

**Before**

```shell
brew install evcc
```

```shell
==> Auto-updating Homebrew...
==> Auto-updated Homebrew!

Warning: evcc-io/tap/evcc 0.131.8 is already installed and up-to-date.
To reinstall 0.131.8, run:
  brew reinstall evcc
```

**After**

```shell
brew upgrade evcc
```

```shell
Warning: evcc-io/tap/evcc 0.131.8 already installed
```