### PR TITLE
Update livo charger documentation about eebus

### DIFF
--- a/templates/nightly/en/charger/livo_0.yaml
+++ b/templates/nightly/en/charger/livo_0.yaml
@@ -3,7 +3,7 @@ product:
   description: Livo
 requirements: ["eebus"]
 description: |
-  The device requires a fixed IP addres.
+  The device requires a fixed IP addres. It's important to set up eebus first. After this the charger will recognize EVCC as a HEMS device on the network. Please use the installer tool to select EVCC as HEMS. After this has been done, copy the given SKI from the Install app and add it to your yaml. 
 render:
   - default: |
       type: template


### PR DESCRIPTION
More information on correctly connecting the Livo to EVCC. by setting up eebus first. 