### PR TITLE
Add note about leading zero on Fiat pin

### DIFF
--- a/docs/devices/vehicles.mdx
+++ b/docs/devices/vehicles.mdx
@@ -261,7 +261,7 @@ Benötigt `access` und `refresh` Tokens. Diese können über den Befehl `evcc to
       vin: ZFAE... # Erforderlich, wenn mehrere Fahrzeuge des Herstellers vorhanden sind (optional)
       title: # Wird in der Benutzeroberfläche angezeigt (optional)
       capacity: 50 # Akkukapazität in kWh (optional)
-      pin: # Benötigt zur Aktualisierung des Ladestands während der Ladung. (optional)`} advanced={`vehicles:
+      pin: # Benötigt zur Aktualisierung des Ladestands während der Ladung. (optional, bei führenden Nullen bitte in einfache Hochkommata setzen)`} advanced={`vehicles:
     - name: my_car
       type: template
       template: fiat


### PR DESCRIPTION
Related to https://github.com/evcc-io/evcc/discussions/12404

If the pin starts with a zero, it may not function properly.