### PR TITLE
Update docker compose commands

### DIFF
--- a/docs/installation/docker.mdx
+++ b/docs/installation/docker.mdx
@@ -188,8 +188,8 @@ Springe zum Abschnitt [Testen](#test) um zu prüfen, ob die Installation erfolgr
 [docker-compose](https://docs.docker.com/compose) hat einige Vorteile gegenüber der direkten Ausführung in der Kommandozeile
 Alle Parameter werden in einer Datei hinterlegt.
 Zudem kannst du weitere Programme wie Traefik in Verbindung mit evcc konfigurieren und gemeinsam starten.
-Im aktiven Verzeichnis legt man dazu einfach eine Konfigurationsdatei mit dem Namen `docker-compose.yml` an.  
-Entsprechend der passenden Komponenten-Konstellation kopiert man eine der folgenden Konfigurationen in die `docker-compose.yml` und speichert diese ab:
+Im aktiven Verzeichnis legt man dazu einfach eine Konfigurationsdatei mit dem Namen `compose.yml` an.  
+Entsprechend der passenden Komponenten-Konstellation kopiert man eine der folgenden Konfigurationen in die `compose.yml` und speichert diese ab:
 
 <Tabs groupId="compose">
   <TabItem value="default" label="Standard" default>
@@ -246,23 +246,23 @@ Details findest du im Abschnitt [Ports](#ports).
 Starte den Container mit:
 
 ```sh
-sudo docker-compose up -d
+sudo docker compose up -d
 ```
 
 #### Aktualisierung
 
-Navigiere in das Verzeichnis, das die `docker-compose.yml` Datei von evcc enthält.
+Navigiere in das Verzeichnis, das die `compose.yml` Datei von evcc enthält.
 
 Aktualisiere auf das neuste evcc Image:
 
 ```sh
-sudo docker-compose pull
+sudo docker compose pull
 ```
 
 Falls ein neues Image vorhanden ist, startet das folgende Kommando den Container neu - ansonsten läuft der Alte einfach weiter:
 
 ```sh
-sudo docker-compose up -d
+sudo docker compose up -d
 ```
 
 ## Testen {#test}

--- a/i18n/en/docusaurus-plugin-content-docs/current/installation/docker.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/installation/docker.mdx
@@ -158,8 +158,8 @@ Please refer to the [Ports](#ports) section and add additional ports as needed.
 [docker-compose](https://docs.docker.com/compose) has several advantages over direct command line execution.
 All parameters are stored in a file.
 Additionally, you can configure and start other programs like Traefik in conjunction with evcc.
-Simply create a configuration file named `docker-compose.yml` in your active directory.
-Copy one of the following configurations matching your component setup into `docker-compose.yml` and save it:
+Simply create a configuration file named `compose.yml` in your active directory.
+Copy one of the following configurations matching your component setup into `compose.yml` and save it:
 
 <Tabs groupId="compose">
   <TabItem value="default" label="Standard" default>
@@ -216,17 +216,17 @@ Please refer to the [Ports](#ports) section and add additional ports as needed.
 Start the container with:
 
 ```sh
-sudo docker-compose up -d
+sudo docker compose up -d
 ```
 
 #### Updates
 
-Navigate to the directory containing the evcc `docker-compose.yml` file.
+Navigate to the directory containing the evcc `compose.yml` file.
 
 Update to the latest evcc image:
 
 ```sh
-sudo docker-compose pull
+sudo docker compose pull
 ```
 
 If a new image is available, the following command will restart the container - otherwise, the existing one will continue running:


### PR DESCRIPTION
Hi,

the default shipped docker compose version is V2 now, which changes some commands (e.g. `docker-compose` changes to `docker compose`), also the correct filename for compose files is now `compose.yml`, not `docker-compose.yml`.

I updated the docs accordingly.