### PR TITLE
Rest-API: Hide Table of Contents

### DIFF
--- a/docs/integrations/rest-api.mdx
+++ b/docs/integrations/rest-api.mdx
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 1
+hide_table_of_contents: true
 ---
 
 import SwaggerUiWrapper from "../../src/components/SwaggerUiWrapper";

--- a/i18n/en/docusaurus-plugin-content-docs/current/integrations/rest-api.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/integrations/rest-api.mdx
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 1
+hide_table_of_contents: true
 ---
 
 import SwaggerUiWrapper from "../../../../../src/components/SwaggerUiWrapper";


### PR DESCRIPTION
Hi,
mich stört es sehr, dass die nicht zu sehende TOC so viel Platz für die Dokumentation wegnimmt:
![with_toc](https://github.com/user-attachments/assets/de73244f-ed24-4382-bb24-62f2b2f44a46)

Deswegen schlage ich vor, diese zu entfernen, sodass sich die Dokumentation auf die gesamte Breite des Bildschirms ausstrecken kann:
![without_toc](https://github.com/user-attachments/assets/97d90994-7ae2-4717-a94e-e95f9916d500)
