### PR TITLE
REST API: crawler fallback, spec link, wider content

### DIFF
--- a/docs/integrations/rest-api.mdx
+++ b/docs/integrations/rest-api.mdx
@@ -1,12 +1,15 @@
 ---
 sidebar_position: 1
+hide_table_of_contents: true
 ---
 
 import SwaggerUiWrapper from "../../src/components/SwaggerUiWrapper";
 
 # REST API
 
-The HTTP REST API is a simple interface for automatically changing settings.
-This interface is also used by the web interface.
+Die HTTP REST API ist eine einfache Schnittstelle zur automatischen Änderung von Einstellungen.
+Diese Schnittstelle wird auch von der Weboberfläche verwendet.
+
+Die komplette API-Spezifikation im OpenAPI-Format findest du [hier](/rest-api.yaml).
 
 <SwaggerUiWrapper/>

--- a/i18n/en/docusaurus-plugin-content-docs/current/integrations/rest-api.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/integrations/rest-api.mdx
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 1
+hide_table_of_contents: true
 ---
 
 import SwaggerUiWrapper from "../../../../../src/components/SwaggerUiWrapper";
@@ -8,5 +9,7 @@ import SwaggerUiWrapper from "../../../../../src/components/SwaggerUiWrapper";
 
 The HTTP REST API is a simple interface for automatically changing settings.
 This interface is also used by the web interface.
+
+The complete API specification in OpenAPI format can be found [here](/rest-api.yaml).
 
 <SwaggerUiWrapper/>

--- a/src/components/SwaggerUiWrapper.jsx
+++ b/src/components/SwaggerUiWrapper.jsx
@@ -1,6 +1,8 @@
-import React, { useRef, useEffect } from "react";
+import React, { useRef, useEffect, useState } from "react";
 import ReactDOM from "react-dom/client";
 import SwaggerUI from "swagger-ui-react";
+import CodeBlock from "@theme/CodeBlock";
+import restApiYaml from "!!raw-loader!../../static/rest-api.yaml";
 
 const configs = {
   url: "/rest-api.yaml",
@@ -132,6 +134,7 @@ let customCss = `
 
 export default () => {
   const containerRef = useRef(null);
+  const [initialized, setInitialized] = useState(false);
 
   useEffect(() => {
     if (containerRef.current?.attachShadow) {
@@ -146,11 +149,22 @@ export default () => {
 
         const root = ReactDOM.createRoot(div);
         root.render(<SwaggerUI {...configs} />);
+        setInitialized(true);
       } catch (e) {
         console.error(e);
       }
     }
   }, []);
 
-  return <div ref={containerRef}></div>;
+  return (
+    <>
+      <div ref={containerRef}></div>
+      {/* crawler fallback */}
+      {!initialized && (
+        <CodeBlock language="yaml" title="rest-api.yaml">
+          {restApiYaml}
+        </CodeBlock>
+      )}
+    </>
+  );
 };


### PR DESCRIPTION
🕷️ add yaml fallback for Algolia crawler
↔️ hide ToC column for more content space
📒 add link to raw spec file

<img width="1659" alt="Bildschirmfoto 2025-02-07 um 09 58 40" src="https://github.com/user-attachments/assets/1b7eafcd-7729-45ea-bf98-fd39bb37743c" />

\\cc @Maschga