### PR TITLE
Darstellung des § korrigiert

### DIFF
--- a/blog/2024-08-17/highlights-14a-enwg-ocpp-loadmanagement-elli.mdx
+++ b/blog/2024-08-17/highlights-14a-enwg-ocpp-loadmanagement-elli.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Highlights: Lastmanagement, §14a EnWG"
+title: "Highlights: Lastmanagement, § 14a EnWG"
 slug: "/2024/08/17/highlights-14a-enwg-ocpp-loadmanagement-elli"
 authors: [naltatis]
 tags: [release, highlights]
@@ -13,7 +13,7 @@ Da der letzte "Release" Blogartikel schon etwas her ist, ist hier ein Überblick
 
 {/* truncate */}
 
-## Lastmanagement & §14a EnWG
+## Lastmanagement & § 14a EnWG
 
 Vor ein paar Releases haben wir Lastmanagement als experimentelles Feature eingeführt.
 Damit ist es möglich, eine Leistungs- und/oder Stromgrenze für das gesamte Haus festzulegen.
@@ -24,7 +24,7 @@ Mehr dazu findest du in der [Dokumentation](/docs/features/loadmanagement).
 
 ### Steuerbare Verbraucher
 
-In Deutschland ist §14a des Energiewirtschaftsgesetzes (EnWG) derzeit ein prominentes Thema.
+In Deutschland ist § 14a des Energiewirtschaftsgesetzes (EnWG) derzeit ein prominentes Thema.
 Hier geht es darum, dass der Netzbetreiber bei hoher Netzauslastung große Verbraucher, wie zum Beispiel Wallboxen, herunterregeln kann.
 Entscheidet sich der Kunde für diese Regelung profitiert er im Gegenzug von reduzierten Netzentgelten.
 
@@ -33,7 +33,7 @@ Der Netzbetreiber greift nicht direkt auf die Wallbox zu, sondern kommuniziert d
 Das Energiemanagementsystem im Haus muss dann die relevanten Verbraucher herunterregeln.
 
 evcc ist in der Lage diese Anforderung (Dimming) zu erfüllen, und zwar, für alle bereits heute unterstützten Wallboxen und das ohne sie, bspw. über einen potentialfreien Kontakt, einfach abschalten zu müssen.
-Die Ladepunkte können in dem Zeitraum weiter mit ihrer Mindestleistung (z.B. 4,2 kW) betrieben werden.
+Die Ladepunkte können in dem Zeitraum weiter mit ihrer Mindestleistung (z. B. 4,2 kW) betrieben werden.
 Damit kann jede von evcc unterstützte Wallbox in diesem Szenario eingesetzt werden und benötigt selbst keine spezielle Unterstützung für eine Kommunikation mit SMGW oder Steuerbox.
 
 ### Funktionsweise
@@ -50,7 +50,7 @@ Dieser kann dann bspw. über einen GPIO-Pin an evcc angeschlossen werden.
 Empfängt die Steuerbox ein Reduzierungssignal, wird der Kontakt geschlossen, evcc erkennt dies und regelt die Wallboxen herunter.
 
 Diese, deutlich simplere Kontaktlösung, lässt sich auch mit bereits vorhandenen (Funk)Rundsteuerempfängern (FRSE) einsetzen.
-Im Rahmen des §14a EnWG sind diese nicht vorgesehen, werden aber als Übergangslösung gedultet.
+Im Rahmen des § 14a EnWG sind diese nicht vorgesehen, werden aber als Übergangslösung gedultet.
 
 In der Praxis fehlt es für die Nutzung dieses Features noch an im Feld verbauten Steuerboxen.
 Diese werden in den kommenden Monaten ausgerollt.


### PR DESCRIPTION
Korrekte Darstellung von § aufgenommen. Es muss ein Leerzeichen zwischen dem Zeichen und der Ziffer vorhanden sein.