### PR TITLE
Update meters.mdx, add hint to subnet restrictions when connecting to…

### DIFF
--- a/docs/devices/meters.mdx
+++ b/docs/devices/meters.mdx
@@ -2205,7 +2205,7 @@ Um die aktive Ladesteuerung zu nutzen muss einmalig über das Webinterface oder 
 
 <DeviceFeatures features="battery-control" />
 
-Benutzername und Passwort sind identisch zum Web-Portal bzw. My E3/DC App. Key (=RSCP-Passwort) muss im Hauskraftwerk unter Personalisieren/Benutzerprofil angelegt werden.
+Benutzername und Passwort sind identisch zum Web-Portal bzw. My E3/DC App. Key (=RSCP-Passwort) muss im Hauskraftwerk unter Personalisieren/Benutzerprofil angelegt werden. Die IP-Adressen von evcc und des Hauskraftwerks müssen sich im selben Subnetz befinden.
 
 **Achtung**: Die aktive Batteriesteuerung überschreibt Einstellungen im Smart-Power/Betriebsbereich.
 


### PR DESCRIPTION
… E3/DC

evcc and E3/DC need to be in the same IP subnet. This was not mentioned in the docs before.