### PR TITLE
Fix automatic add-on repo urls

### DIFF
--- a/docs/installation/home-assistant.mdx
+++ b/docs/installation/home-assistant.mdx
@@ -41,7 +41,7 @@ Siehe [Home Assistant Dokumentation](https://www.home-assistant.io/installation/
   Die aktuelle stabile Version.
 
   1. Repository automatisch hinzufügen: Klicke auf den nachfolgenden Button und dann auf **Open link**, dann auf **Hinzufügen**.
-  [![Open your Home Assistant instance and show the add add-on repository dialog with a specific repository URL pre-filled.](https://my.home-assistant.io/badges/supervisor_add_addon_repository.svg)](https://my.home-assistant.io/redirect/supervisor_add_addon_repository/?repository_url=https%3A%2F%2Fgithub.com%2Fevcc%2Fhassio-addon)
+  [![Open your Home Assistant instance and show the add add-on repository dialog with a specific repository URL pre-filled.](https://my.home-assistant.io/badges/supervisor_add_addon_repository.svg)](https://my.home-assistant.io/redirect/supervisor_add_addon_repository/?repository_url=https%3A%2F%2Fgithub.com%2Fevcc-io%2Fhassio-addon)
   2. Repository manuell hinzufügen:
      1. Klicke auf **Einstellungen** → **Addons** → **Addon Store**
      2. Klicke auf die **drei Punkte** → **Repositories**
@@ -60,7 +60,7 @@ Siehe [Home Assistant Dokumentation](https://www.home-assistant.io/installation/
   Falls du das Nightly nutzt, ändern sich auch die in dieser Anleitung genannten Pfade bzw. Docker Container Namen, d.h. statt `evcc` muss `evcc-nightly` verwendet werden. 
 
   1. Repository automatisch hinzufügen: Klicke auf den nachfolgenden Button und dann auf **Open link**, dann auf **Hinzufügen**.
-  [![Open your Home Assistant instance and show the add add-on repository dialog with a specific repository URL pre-filled.](https://my.home-assistant.io/badges/supervisor_add_addon_repository.svg)](https://my.home-assistant.io/redirect/supervisor_add_addon_repository/?repository_url=https%3A%2F%2Fgithub.com%2Fevcc%2Fhassio-addon)
+  [![Open your Home Assistant instance and show the add add-on repository dialog with a specific repository URL pre-filled.](https://my.home-assistant.io/badges/supervisor_add_addon_repository.svg)](https://my.home-assistant.io/redirect/supervisor_add_addon_repository/?repository_url=https%3A%2F%2Fgithub.com%2Fevcc-io%2Fhassio-addon)
   2. Repository manuell hinzufügen:
      1. Klicke auf **Einstellungen** → **Addons** → **Addon Store**
      2. Klicke auf die **drei Punkte** → **Repositories**

--- a/i18n/en/docusaurus-plugin-content-docs/current/installation/home-assistant.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/installation/home-assistant.mdx
@@ -41,7 +41,7 @@ See [Home Assistant Documentation](https://www.home-assistant.io/installation/#a
   The current stable version.
 
   1. Automatically add repository: Click on the following button and then on **Open link**, then on **Add**.
-  [![Open your Home Assistant instance and show the add add-on repository dialog with a specific repository URL pre-filled.](https://my.home-assistant.io/badges/supervisor_add_addon_repository.svg)](https://my.home-assistant.io/redirect/supervisor_add_addon_repository/?repository_url=https%3A%2F%2Fgithub.com%2Fevcc%2Fhassio-addon)
+  [![Open your Home Assistant instance and show the add add-on repository dialog with a specific repository URL pre-filled.](https://my.home-assistant.io/badges/supervisor_add_addon_repository.svg)](https://my.home-assistant.io/redirect/supervisor_add_addon_repository/?repository_url=https%3A%2F%2Fgithub.com%2Fevcc-io%2Fhassio-addon)
   2. Manually add repository:
      1. Click on **Settings** → **Addons** → **Add-on Store**
      2. Click on the **three dots** → **Repositories**
@@ -60,7 +60,7 @@ See [Home Assistant Documentation](https://www.home-assistant.io/installation/#a
   If you use the nightly version, the paths and Docker container names mentioned in this guide will change, i.e., instead of `evcc`, you must use `evcc-nightly`.
 
   1. Automatically add repository: Click on the following button and then on **Open link**, then on **Add**.
-  [![Open your Home Assistant instance and show the add add-on repository dialog with a specific repository URL pre-filled.](https://my.home-assistant.io/badges/supervisor_add_addon_repository.svg)](https://my.home-assistant.io/redirect/supervisor_add_addon_repository/?repository_url=https%3A%2F%2Fgithub.com%2Fevcc%2Fhassio-addon)
+  [![Open your Home Assistant instance and show the add add-on repository dialog with a specific repository URL pre-filled.](https://my.home-assistant.io/badges/supervisor_add_addon_repository.svg)](https://my.home-assistant.io/redirect/supervisor_add_addon_repository/?repository_url=https%3A%2F%2Fgithub.com%2Fevcc-io%2Fhassio-addon)
   2. Manually add repository:
      1. Click on **Settings** → **Addons** → **Add-on Store**
      2. Click on the **three dots** → **Repositories**


### PR DESCRIPTION
The "Add add-on repository" buttons are currently missing  the "-io" portion of the GitHub organisation in the URL. This PR fixes them to point to https://github.com/evcc-io/hassio-addon instead of https://github.com/evcc/hassio-addon