### PR TITLE
fix:     "integrateddevice" in "loadpoints" führt zu Fehlern

### DIFF
--- a/docs/devices/heating.mdx
+++ b/docs/devices/heating.mdx
@@ -67,7 +67,6 @@ loadpoints:
   - title: Meine Wärmepumpe
     charger: heatpump_control
     meter: heatpump_power
-    integrateddevice: true # Fahrzeugauswahl deaktivieren
 
 meters:
   - name: heatpump_power
@@ -78,6 +77,7 @@ meters:
 chargers:
   - name: heatpump_control
     type: sgready
+    integrateddevice: true # Fahrzeugauswahl deaktivieren
     setmode:
       source: switch
       switch:


### PR DESCRIPTION
"integrateddevice" sollte bei den "chargers" angegeben werden.
Ich habe das Beispiel dementsprechend angepasst.