### PR TITLE
Updated documentation for EM24 and EM24_E1

### DIFF
--- a/docs/devices/meters.mdx
+++ b/docs/devices/meters.mdx
@@ -1334,6 +1334,8 @@ Um die aktive Ladesteuerung zu nutzen muss einmalig über das Webinterface oder 
 
 <DeviceFeatures features="" />
 
+EM24 mit RS-485 anschluss. Benutze die EM24_E1 für die EM24 mit Ethernet anschluss, denn die Definition is nicht compatibel.
+
 <Tabs>
 <TabItem value="grid" label="Netz" default>
 
@@ -1390,6 +1392,9 @@ Um die aktive Ladesteuerung zu nutzen muss einmalig über das Webinterface oder 
 ### EM24_E1
 
 <DeviceFeatures features="" />
+
+EM24 mit Ethernet anschluss. Benutze die EM24 für die EM24 mit RS-485 anschluss, denn die Definition is nicht compatibel.
+Die EM24_E1 muss mindestens Firmware version 1.8.3 haben, die is hier to zu finden: https://professional.victronenergy.com/downloads/firmware/
 
 <Tabs>
 <TabItem value="grid" label="Netz" default>
@@ -11371,6 +11376,8 @@ PV nur verfügbar mit PV-Sensor
 
 <DeviceFeatures features="" />
 
+EM24 mit RS-485 anschluss. Benutze die EM24_E1 für die EM24 mit Ethernet anschluss, denn die Definition is nicht compatibel.
+
 <Tabs>
 <TabItem value="grid" label="Netz" default>
 
@@ -11427,6 +11434,9 @@ PV nur verfügbar mit PV-Sensor
 ### EM24_E1
 
 <DeviceFeatures features="" />
+
+EM24 mit Ethernet anschluss. Benutze die EM24 für die EM24 mit RS-485 anschluss, denn die Definition is nicht compatibel.
+Die EM24_E1 muss mindestens version 1.8.3 habe, die is hier to zu finden: https://professional.victronenergy.com/downloads/firmware/
 
 <Tabs>
 <TabItem value="grid" label="Netz" default>

--- a/docs/devices/meters.mdx
+++ b/docs/devices/meters.mdx
@@ -1393,7 +1393,7 @@ EM24 mit RS-485-Anschluss. Benutze die EM24_E1 für die EM24 mit Ethernet-Anschl
 
 <DeviceFeatures features="" />
 
-EM24_E1 mit Ethernet-Anschluss. Benutze die EM24_ für die EM24 mit RS-485-Anschluss, denn die Definition is nicht kompatibel.
+EM24_E1 mit Ethernet-Anschluss. Benutze die EM24 für die EM24 mit RS-485-Anschluss, denn die Definition is nicht kompatibel.
 Die EM24_E1 muss mindestens Firmware version 1.8.3 haben, diese is hier to zu finden: https://professional.victronenergy.com/downloads/firmware/
 
 <Tabs>

--- a/docs/devices/meters.mdx
+++ b/docs/devices/meters.mdx
@@ -1394,7 +1394,7 @@ EM24 mit RS-485-Anschluss. Benutze die EM24_E1 für die EM24 mit Ethernet-Anschl
 <DeviceFeatures features="" />
 
 EM24_E1 mit Ethernet-Anschluss. Benutze die EM24 für die EM24 mit RS-485-Anschluss, denn die Definition is nicht kompatibel.
-Die EM24_E1 muss mindestens Firmware version 1.8.3 haben, diese is hier zu finden: https://professional.victronenergy.com/downloads/firmware/
+Die EM24_E1 muss mindestens Firmware version 1.8.3 haben, diese is hier zu finden: [victronenergy.com](https://professional.victronenergy.com/downloads/firmware/)
 
 <Tabs>
 <TabItem value="grid" label="Netz" default>
@@ -11436,7 +11436,7 @@ EM24 mit RS-485-Anschluss. Benutze die EM24_E1 für die EM24 mit Ethernet-Anschl
 <DeviceFeatures features="" />
 
 EM24_E1 mit Ethernet-Anschluss. Benutze die EM24 für die EM24 mit RS-485-Anschluss, denn die Definition is nicht Kompatibel.
-Die EM24_E1 muss mindestens Firmware version 1.8.3 haben, diese is hier zu finden: https://professional.victronenergy.com/downloads/firmware/
+Die EM24_E1 muss mindestens Firmware version 1.8.3 haben, diese is hier zu finden: [victronenergy.com](https://professional.victronenergy.com/downloads/firmware/)
 
 <Tabs>
 <TabItem value="grid" label="Netz" default>

--- a/docs/devices/meters.mdx
+++ b/docs/devices/meters.mdx
@@ -1394,7 +1394,7 @@ EM24 mit RS-485-Anschluss. Benutze die EM24_E1 für die EM24 mit Ethernet-Anschl
 <DeviceFeatures features="" />
 
 EM24_E1 mit Ethernet-Anschluss. Benutze die EM24 für die EM24 mit RS-485-Anschluss, denn die Definition is nicht kompatibel.
-Die EM24_E1 muss mindestens Firmware version 1.8.3 haben, diese is hier to zu finden: https://professional.victronenergy.com/downloads/firmware/
+Die EM24_E1 muss mindestens Firmware version 1.8.3 haben, diese is hier zu finden: https://professional.victronenergy.com/downloads/firmware/
 
 <Tabs>
 <TabItem value="grid" label="Netz" default>
@@ -11436,7 +11436,7 @@ EM24 mit RS-485-Anschluss. Benutze die EM24_E1 für die EM24 mit Ethernet-Anschl
 <DeviceFeatures features="" />
 
 EM24_E1 mit Ethernet-Anschluss. Benutze die EM24 für die EM24 mit RS-485-Anschluss, denn die Definition is nicht Kompatibel.
-Die EM24_E1 muss mindestens Firmware version 1.8.3 haben, diese is hier to zu finden: https://professional.victronenergy.com/downloads/firmware/
+Die EM24_E1 muss mindestens Firmware version 1.8.3 haben, diese is hier zu finden: https://professional.victronenergy.com/downloads/firmware/
 
 <Tabs>
 <TabItem value="grid" label="Netz" default>

--- a/docs/devices/meters.mdx
+++ b/docs/devices/meters.mdx
@@ -1334,7 +1334,7 @@ Um die aktive Ladesteuerung zu nutzen muss einmalig über das Webinterface oder 
 
 <DeviceFeatures features="" />
 
-EM24 mit RS-485 anschluss. Benutze die EM24_E1 für die EM24 mit Ethernet anschluss, denn die Definition is nicht compatibel.
+EM24 mit RS-485-Anschluss. Benutze die EM24_E1 für die EM24 mit Ethernet-Anschluss, denn die Definition is nicht kompatibel.
 
 <Tabs>
 <TabItem value="grid" label="Netz" default>
@@ -1393,8 +1393,8 @@ EM24 mit RS-485 anschluss. Benutze die EM24_E1 für die EM24 mit Ethernet anschl
 
 <DeviceFeatures features="" />
 
-EM24 mit Ethernet anschluss. Benutze die EM24 für die EM24 mit RS-485 anschluss, denn die Definition is nicht compatibel.
-Die EM24_E1 muss mindestens Firmware version 1.8.3 haben, die is hier to zu finden: https://professional.victronenergy.com/downloads/firmware/
+EM24_E1 mit Ethernet-Anschluss. Benutze die EM24_ für die EM24 mit RS-485-Anschluss, denn die Definition is nicht kompatibel.
+Die EM24_E1 muss mindestens Firmware version 1.8.3 haben, diese is hier to zu finden: https://professional.victronenergy.com/downloads/firmware/
 
 <Tabs>
 <TabItem value="grid" label="Netz" default>
@@ -11376,7 +11376,7 @@ PV nur verfügbar mit PV-Sensor
 
 <DeviceFeatures features="" />
 
-EM24 mit RS-485 anschluss. Benutze die EM24_E1 für die EM24 mit Ethernet anschluss, denn die Definition is nicht compatibel.
+EM24 mit RS-485-Anschluss. Benutze die EM24_E1 für die EM24 mit Ethernet-Anschluss, denn die Definition is nicht kompatibel.
 
 <Tabs>
 <TabItem value="grid" label="Netz" default>
@@ -11435,8 +11435,8 @@ EM24 mit RS-485 anschluss. Benutze die EM24_E1 für die EM24 mit Ethernet anschl
 
 <DeviceFeatures features="" />
 
-EM24 mit Ethernet anschluss. Benutze die EM24 für die EM24 mit RS-485 anschluss, denn die Definition is nicht compatibel.
-Die EM24_E1 muss mindestens version 1.8.3 habe, die is hier to zu finden: https://professional.victronenergy.com/downloads/firmware/
+EM24_E1 mit Ethernet-Anschluss. Benutze die EM24 für die EM24 mit RS-485-Anschluss, denn die Definition is nicht Kompatibel.
+Die EM24_E1 muss mindestens Firmware version 1.8.3 haben, diese is hier to zu finden: https://professional.victronenergy.com/downloads/firmware/
 
 <Tabs>
 <TabItem value="grid" label="Netz" default>

--- a/i18n/en/docusaurus-plugin-content-docs/current/devices/meters.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/devices/meters.mdx
@@ -1395,7 +1395,7 @@ EM24 with RS-485 connection. Use the EM24_E1 if you have an EM24 with Ethernet c
 <DeviceFeatures features="" />
 
 EM24_E1 with Ethernet connection. Use the EM24 if you have an EM24 with RS-485 connection, the definitions are not compatible.
-The firmware version should be at least version  1.8.3, you can find this version here: https://professional.victronenergy.com/downloads/firmware/
+The firmware version should be at least version  1.8.3, you can find this version here: [victronenergy.com](https://professional.victronenergy.com/downloads/firmware/)
 
 <Tabs>
 <TabItem value="grid" label="Grid" default>
@@ -11437,7 +11437,7 @@ EM24 with RS-485 connection. Use the EM24_E1 if you have an EM24 with Ethernet c
 <DeviceFeatures features="" />
 
 EM24_E1 with Ethernet connection. Use the EM24 if you have an EM24 with RS-485 connection, the definitions are not compatible.
-The firmware version should be at least version  1.8.3, you can find this version here: https://professional.victronenergy.com/downloads/firmware/
+The firmware version should be at least version  1.8.3, you can find this version here: [victronenergy.com](https://professional.victronenergy.com/downloads/firmware/)
 
 <Tabs>
 <TabItem value="grid" label="Grid" default>

--- a/i18n/en/docusaurus-plugin-content-docs/current/devices/meters.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/devices/meters.mdx
@@ -1335,6 +1335,8 @@ To use active battery control, times for grid charging must be defined once via 
 
 <DeviceFeatures features="" />
 
+EM24 with RS-485 connection. Use the EM24_E1 if you have an EM24 with Ethernet connection, the definitions are not compatible.
+
 <Tabs>
 <TabItem value="grid" label="Grid" default>
 
@@ -1391,6 +1393,9 @@ To use active battery control, times for grid charging must be defined once via 
 ### EM24_E1
 
 <DeviceFeatures features="" />
+
+EM24 with Ethernet connection. Use the EM24 if you have an EM24 with RS-485 connection, the definitions are not compatible.
+The firmware version should be at least version  1.8.3, you can find this version here: https://professional.victronenergy.com/downloads/firmware/
 
 <Tabs>
 <TabItem value="grid" label="Grid" default>
@@ -11372,6 +11377,8 @@ PV only available with PV sensor
 
 <DeviceFeatures features="" />
 
+EM24 with RS-485 connection. Use the EM24_E1 if you have an EM24 with Ethernet connection, the definitions are not compatible.
+
 <Tabs>
 <TabItem value="grid" label="Grid" default>
 
@@ -11428,6 +11435,9 @@ PV only available with PV sensor
 ### EM24_E1
 
 <DeviceFeatures features="" />
+
+EM24 with Ethernet connection. Use the EM24 if you have an EM24 with RS-485 connection, the definitions are not compatible.
+The firmware version should be at least version  1.8.3, you can find this version here: https://professional.victronenergy.com/downloads/firmware/
 
 <Tabs>
 <TabItem value="grid" label="Grid" default>

--- a/i18n/en/docusaurus-plugin-content-docs/current/devices/meters.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/devices/meters.mdx
@@ -1394,7 +1394,7 @@ EM24 with RS-485 connection. Use the EM24_E1 if you have an EM24 with Ethernet c
 
 <DeviceFeatures features="" />
 
-EM24 with Ethernet connection. Use the EM24 if you have an EM24 with RS-485 connection, the definitions are not compatible.
+EM24_E1 with Ethernet connection. Use the EM24 if you have an EM24 with RS-485 connection, the definitions are not compatible.
 The firmware version should be at least version  1.8.3, you can find this version here: https://professional.victronenergy.com/downloads/firmware/
 
 <Tabs>
@@ -11436,7 +11436,7 @@ EM24 with RS-485 connection. Use the EM24_E1 if you have an EM24 with Ethernet c
 
 <DeviceFeatures features="" />
 
-EM24 with Ethernet connection. Use the EM24 if you have an EM24 with RS-485 connection, the definitions are not compatible.
+EM24_E1 with Ethernet connection. Use the EM24 if you have an EM24 with RS-485 connection, the definitions are not compatible.
 The firmware version should be at least version  1.8.3, you can find this version here: https://professional.victronenergy.com/downloads/firmware/
 
 <Tabs>

--- a/templates/release/de/meter/cg-em24_0.yaml
+++ b/templates/release/de/meter/cg-em24_0.yaml
@@ -2,7 +2,7 @@ product:
   brand: Carlo Gavazzi
   description: EM24
 description: |
- EM24 mit RS-485-Anschluss. Benutze die EM24_E1 für die EM24 mit Ethernet Anschluss, denn die Definition is nicht kompatibel.
+ EM24 mit RS-485-Anschluss. Benutze die EM24_E1 für die EM24 mit Ethernet-Anschluss, denn die Definition is nicht kompatibel.
 render:
   - usage: grid
     default: |

--- a/templates/release/de/meter/cg-em24_0.yaml
+++ b/templates/release/de/meter/cg-em24_0.yaml
@@ -1,6 +1,8 @@
 product:
   brand: Carlo Gavazzi
   description: EM24
+description: |
+ EM24 mit RS-485 anschluss. Benutze die EM24_E1 für die EM24 mit Ethernet anschluss, denn die Definition is nicht compatibel.
 render:
   - usage: grid
     default: |

--- a/templates/release/de/meter/cg-em24_0.yaml
+++ b/templates/release/de/meter/cg-em24_0.yaml
@@ -2,7 +2,7 @@ product:
   brand: Carlo Gavazzi
   description: EM24
 description: |
- EM24 mit RS-485 anschluss. Benutze die EM24_E1 für die EM24 mit Ethernet anschluss, denn die Definition is nicht compatibel.
+ EM24 mit RS-485-Anschluss. Benutze die EM24_E1 für die EM24 mit Ethernet Anschluss, denn die Definition is nicht kompatibel.
 render:
   - usage: grid
     default: |

--- a/templates/release/de/meter/cg-em24_1.yaml
+++ b/templates/release/de/meter/cg-em24_1.yaml
@@ -2,7 +2,7 @@ product:
   brand: Victron
   description: EM24
 description: |
- EM24 mit RS-485 anschluss. Benutze die EM24_E1 für die EM24 mit Ethernet anschluss, denn die Definition is nicht compatibel.
+ EM24 mit RS-485-Anschluss. Benutze die EM24_E1 für die EM24 mit Ethernet-Anschluss, denn die Definition is nicht kompatibel.
 render:
   - usage: grid
     default: |

--- a/templates/release/de/meter/cg-em24_1.yaml
+++ b/templates/release/de/meter/cg-em24_1.yaml
@@ -1,6 +1,8 @@
 product:
   brand: Victron
   description: EM24
+description: |
+ EM24 mit RS-485 anschluss. Benutze die EM24_E1 für die EM24 mit Ethernet anschluss, denn die Definition is nicht compatibel.
 render:
   - usage: grid
     default: |

--- a/templates/release/de/meter/cg-em24_e1_0.yaml
+++ b/templates/release/de/meter/cg-em24_e1_0.yaml
@@ -3,7 +3,7 @@ product:
   brand: Carlo Gavazzi
   description: EM24_E1
 description: |
- EM24_E1 mit Ethernet-Anschluss. Benutze die EM24_ für die EM24 mit RS-485-Anschluss, denn die Definition is nicht kompatibel.
+ EM24_E1 mit Ethernet-Anschluss. Benutze die EM24 für die EM24 mit RS-485-Anschluss, denn die Definition is nicht kompatibel.
  Die EM24_E1 muss mindestens Firmware version 1.8.3 haben, diese is hier to zu finden: https://professional.victronenergy.com/downloads/firmware/
 render:
   - usage: grid

--- a/templates/release/de/meter/cg-em24_e1_0.yaml
+++ b/templates/release/de/meter/cg-em24_e1_0.yaml
@@ -1,6 +1,10 @@
 product:
+  # EM24 mit Ethernet anschluss
   brand: Carlo Gavazzi
   description: EM24_E1
+description: |
+ EM24 mit Ethernet anschluss. Benutze die EM24 für die EM24 mit RS-485 anschluss, denn die Definition is nicht compatibel.
+ Die EM24_E1 muss mindestens Firmware version 1.8.3 haben, die is hier to zu finden: https://professional.victronenergy.com/downloads/firmware/
 render:
   - usage: grid
     default: |

--- a/templates/release/de/meter/cg-em24_e1_0.yaml
+++ b/templates/release/de/meter/cg-em24_e1_0.yaml
@@ -3,8 +3,8 @@ product:
   brand: Carlo Gavazzi
   description: EM24_E1
 description: |
- EM24 mit Ethernet anschluss. Benutze die EM24 für die EM24 mit RS-485 anschluss, denn die Definition is nicht compatibel.
- Die EM24_E1 muss mindestens Firmware version 1.8.3 haben, die is hier to zu finden: https://professional.victronenergy.com/downloads/firmware/
+ EM24_E1 mit Ethernet-Anschluss. Benutze die EM24_ für die EM24 mit RS-485-Anschluss, denn die Definition is nicht kompatibel.
+ Die EM24_E1 muss mindestens Firmware version 1.8.3 haben, diese is hier to zu finden: https://professional.victronenergy.com/downloads/firmware/
 render:
   - usage: grid
     default: |

--- a/templates/release/de/meter/cg-em24_e1_0.yaml
+++ b/templates/release/de/meter/cg-em24_e1_0.yaml
@@ -4,7 +4,7 @@ product:
   description: EM24_E1
 description: |
  EM24_E1 mit Ethernet-Anschluss. Benutze die EM24 für die EM24 mit RS-485-Anschluss, denn die Definition is nicht kompatibel.
- Die EM24_E1 muss mindestens Firmware version 1.8.3 haben, diese is hier to zu finden: https://professional.victronenergy.com/downloads/firmware/
+ Die EM24_E1 muss mindestens Firmware version 1.8.3 haben, diese is hier zu finden: https://professional.victronenergy.com/downloads/firmware/
 render:
   - usage: grid
     default: |

--- a/templates/release/de/meter/cg-em24_e1_0.yaml
+++ b/templates/release/de/meter/cg-em24_e1_0.yaml
@@ -4,7 +4,7 @@ product:
   description: EM24_E1
 description: |
  EM24_E1 mit Ethernet-Anschluss. Benutze die EM24 für die EM24 mit RS-485-Anschluss, denn die Definition is nicht kompatibel.
- Die EM24_E1 muss mindestens Firmware version 1.8.3 haben, diese is hier zu finden: https://professional.victronenergy.com/downloads/firmware/
+ Die EM24_E1 muss mindestens Firmware version 1.8.3 haben, diese is hier zu finden: [victronenergy.com](https://professional.victronenergy.com/downloads/firmware/)
 render:
   - usage: grid
     default: |

--- a/templates/release/de/meter/cg-em24_e1_1.yaml
+++ b/templates/release/de/meter/cg-em24_e1_1.yaml
@@ -1,6 +1,9 @@
 product:
   brand: Victron
   description: EM24_E1
+description: |
+ EM24 mit Ethernet anschluss. Benutze die EM24 für die EM24 mit RS-485 anschluss, denn die Definition is nicht compatibel.
+ Die EM24_E1 muss mindestens Firmware version 1.8.3 haben, die is hier to zu finden: https://professional.victronenergy.com/downloads/firmware/
 render:
   - usage: grid
     default: |

--- a/templates/release/de/meter/cg-em24_e1_1.yaml
+++ b/templates/release/de/meter/cg-em24_e1_1.yaml
@@ -3,7 +3,7 @@ product:
   description: EM24_E1
 description: |
  EM24_E1 mit Ethernet-Anschluss. Benutze die EM24 für die EM24 mit RS-485-Anschluss, denn die Definition is nicht Kompatibel.
- Die EM24_E1 muss mindestens Firmware version 1.8.3 haben, diese is hier to zu finden: https://professional.victronenergy.com/downloads/firmware/
+ Die EM24_E1 muss mindestens Firmware version 1.8.3 haben, diese is hier zu finden: https://professional.victronenergy.com/downloads/firmware/
 render:
   - usage: grid
     default: |

--- a/templates/release/de/meter/cg-em24_e1_1.yaml
+++ b/templates/release/de/meter/cg-em24_e1_1.yaml
@@ -3,7 +3,7 @@ product:
   description: EM24_E1
 description: |
  EM24_E1 mit Ethernet-Anschluss. Benutze die EM24 für die EM24 mit RS-485-Anschluss, denn die Definition is nicht Kompatibel.
- Die EM24_E1 muss mindestens Firmware version 1.8.3 haben, diese is hier zu finden: https://professional.victronenergy.com/downloads/firmware/
+ Die EM24_E1 muss mindestens Firmware version 1.8.3 haben, diese is hier zu finden: [victronenergy.com](https://professional.victronenergy.com/downloads/firmware/)
 render:
   - usage: grid
     default: |

--- a/templates/release/de/meter/cg-em24_e1_1.yaml
+++ b/templates/release/de/meter/cg-em24_e1_1.yaml
@@ -2,8 +2,8 @@ product:
   brand: Victron
   description: EM24_E1
 description: |
- EM24 mit Ethernet anschluss. Benutze die EM24 für die EM24 mit RS-485 anschluss, denn die Definition is nicht compatibel.
- Die EM24_E1 muss mindestens Firmware version 1.8.3 haben, die is hier to zu finden: https://professional.victronenergy.com/downloads/firmware/
+ EM24_E1 mit Ethernet-Anschluss. Benutze die EM24 für die EM24 mit RS-485-Anschluss, denn die Definition is nicht Kompatibel.
+ Die EM24_E1 muss mindestens Firmware version 1.8.3 haben, diese is hier to zu finden: https://professional.victronenergy.com/downloads/firmware/
 render:
   - usage: grid
     default: |

--- a/templates/release/en/meter/cg-em24_0.yaml
+++ b/templates/release/en/meter/cg-em24_0.yaml
@@ -1,6 +1,8 @@
 product:
   brand: Carlo Gavazzi
   description: EM24
+description: |
+ EM24 with RS-485 connection. Use the EM24_E1 if you have an EM24 with Ethernet connection, the definitions are not compatible.
 render:
   - usage: grid
     default: |

--- a/templates/release/en/meter/cg-em24_1.yaml
+++ b/templates/release/en/meter/cg-em24_1.yaml
@@ -1,6 +1,8 @@
 product:
   brand: Victron
   description: EM24
+description: |
+ EM24 with RS-485 connection. Use the EM24_E1 if you have an EM24 with Ethernet connection, the definitions are not compatible.
 render:
   - usage: grid
     default: |

--- a/templates/release/en/meter/cg-em24_e1_0.yaml
+++ b/templates/release/en/meter/cg-em24_e1_0.yaml
@@ -3,7 +3,7 @@ product:
   description: EM24_E1
 description: |
  EM24_E1 with Ethernet connection. Use the EM24 if you have an EM24 with RS-485 connection, the definitions are not compatible.
- The firmware version should be at least version  1.8.3, you can find this version here: https://professional.victronenergy.com/downloads/firmware/
+ The firmware version should be at least version  1.8.3, you can find this version here: [victronenergy.com](https://professional.victronenergy.com/downloads/firmware/)
 render:
   - usage: grid
     default: |

--- a/templates/release/en/meter/cg-em24_e1_0.yaml
+++ b/templates/release/en/meter/cg-em24_e1_0.yaml
@@ -1,6 +1,9 @@
 product:
   brand: Carlo Gavazzi
   description: EM24_E1
+description: |
+ EM24 with Ethernet connection. Use the EM24 if you have an EM24 with RS-485 connection, the definitions are not compatible.
+ The firmware version should be at least version  1.8.3, you can find this version here: https://professional.victronenergy.com/downloads/firmware/
 render:
   - usage: grid
     default: |

--- a/templates/release/en/meter/cg-em24_e1_0.yaml
+++ b/templates/release/en/meter/cg-em24_e1_0.yaml
@@ -2,7 +2,7 @@ product:
   brand: Carlo Gavazzi
   description: EM24_E1
 description: |
- EM24 with Ethernet connection. Use the EM24 if you have an EM24 with RS-485 connection, the definitions are not compatible.
+ EM24_E1 with Ethernet connection. Use the EM24 if you have an EM24 with RS-485 connection, the definitions are not compatible.
  The firmware version should be at least version  1.8.3, you can find this version here: https://professional.victronenergy.com/downloads/firmware/
 render:
   - usage: grid

--- a/templates/release/en/meter/cg-em24_e1_1.yaml
+++ b/templates/release/en/meter/cg-em24_e1_1.yaml
@@ -2,7 +2,7 @@ product:
   brand: Victron
   description: EM24_E1
 description: |
- EM24 with Ethernet connection. Use the EM24 if you have an EM24 with RS-485 connection, the definitions are not compatible.
+ EM24_E1 with Ethernet connection. Use the EM24 if you have an EM24 with RS-485 connection, the definitions are not compatible.
  The firmware version should be at least version  1.8.3, you can find this version here: https://professional.victronenergy.com/downloads/firmware/
 render:
   - usage: grid

--- a/templates/release/en/meter/cg-em24_e1_1.yaml
+++ b/templates/release/en/meter/cg-em24_e1_1.yaml
@@ -3,7 +3,7 @@ product:
   description: EM24_E1
 description: |
  EM24_E1 with Ethernet connection. Use the EM24 if you have an EM24 with RS-485 connection, the definitions are not compatible.
- The firmware version should be at least version  1.8.3, you can find this version here: https://professional.victronenergy.com/downloads/firmware/
+ The firmware version should be at least version  1.8.3, you can find this version here: [victronenergy.com](https://professional.victronenergy.com/downloads/firmware/)
 render:
   - usage: grid
     default: |

--- a/templates/release/en/meter/cg-em24_e1_1.yaml
+++ b/templates/release/en/meter/cg-em24_e1_1.yaml
@@ -1,6 +1,9 @@
 product:
   brand: Victron
   description: EM24_E1
+description: |
+ EM24 with Ethernet connection. Use the EM24 if you have an EM24 with RS-485 connection, the definitions are not compatible.
+ The firmware version should be at least version  1.8.3, you can find this version here: https://professional.victronenergy.com/downloads/firmware/
 render:
   - usage: grid
     default: |


### PR DESCRIPTION
The EM24 and EM24_E1 are not compatible. Make this explicit in the documentation. 

Also include in the EM24 documentation that the EM24_E1 needs to be at firmware version 1.8.3 or highers