### PR TITLE
fix: documentation to use 'features' flag 

### DIFF
--- a/docs/devices/smartswitches.mdx
+++ b/docs/devices/smartswitches.mdx
@@ -97,12 +97,12 @@ Dies ist natürlich auch automatisiert via API möglich (bspw. jede Nacht).
 Standardmäßig bieten Ladepunkte die Möglichkeit einer Fahrzeugzuordnung.
 In vielen Szenarien ist das jedoch nicht erwünscht.
 Es ergibt wenig Sinn den Tesla mit dem SG-Ready-Kontakt einer Wärmepumpe zu verbinden.
-Über den Parameter `integrateddevice: true` deaktivierst du die manuelle Zuordnung von Fahrzeugen in der UI.
+Über das `features`-Flag `integrateddevice` deaktivierst du die manuelle Zuordnung von Fahrzeugen in der UI.
 Zusätzlich wird die automatische Fahrzeugerkennung für diesen Ladepunkt deaktiviert.
 
 ### Wärmeerzeugung
 
-Nutzt du den Schalter zur Steuerung eines Wärmeerzeugers solltest du den Parameter `heating: true` setzen.
+Nutzt du den Schalter zur Steuerung eines Wärmeerzeugers solltest du den das `feature`-Flag `heating` setzen.
 Dadurch verändert sich die Darstellung in der UI.
 Es werden die Begriffe "heizen" anstatt "laden" verwendet.
 Zudem wird der `soc` des Chargers (sofern verfügbar) nicht mehr in % sondern als Temperatur in °C angezeigt.

--- a/docs/reference/configuration/chargers.mdx
+++ b/docs/reference/configuration/chargers.mdx
@@ -60,7 +60,8 @@ In Zusammenhang mit diesem Parameter kann auch ein Icon vergeben werden (siehe [
 **Beispiel**:
 
 ```yaml
-integrateddevice: true
+features:
+  - integrateddevice
 icon: bike
 ```
 
@@ -73,7 +74,8 @@ Dieser Parameter bewirkt, dass bei Ladegeräten der Gruppe "schaltbare Steckdose
 **Beispiel**:
 
 ```yaml
-heating: true
+features:
+  - heating
 ```
 
 ---

--- a/docs/reference/configuration/loadpoints.md
+++ b/docs/reference/configuration/loadpoints.md
@@ -129,7 +129,7 @@ soc:
 
 Definiert, wie die Fahrzeug APIs benutzt werden um aktuelle Informationen des Fahrzeugs abzurufen.
 
-Ist beim Charger `integrateddevice: true` konfiguriert, werden die Daten fortlaufend abgerufen. Dann sind keine `poll` Einstellungen notwendig, bzw. diese werden ignoriert.
+Ist beim Charger das `feature` `integrateddevice` konfiguriert, werden die Daten fortlaufend abgerufen. Dann sind keine `poll` Einstellungen notwendig, bzw. diese werden ignoriert.
 
 :::warning
 Es wird **NICHT** empfohlen, die Standardeinstellungen zu ändern, denn dies könnte dazu führen, dass die Fahrzeugbatterie entleert wird

--- a/i18n/en/docusaurus-plugin-content-docs/current/devices/smartswitches.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/devices/smartswitches.mdx
@@ -99,12 +99,12 @@ You could automate this via API (e.g. every night).
 By default, charging points offer the possibility of vehicle assignment.
 In many switch scenarios this is not desired.
 It makes little sense to connect the Tesla to the SG-Ready contact of a heat pump.
-By setting the parameter `integrateddevice: true` you disable the manual vehicle assignment in the UI.
+By setting the `features`-flag `integrateddevice` you disable the manual vehicle assignment in the UI.
 Additionally, the automatic vehicle detection is disabled for this charging point.
 
 ### Heating
 
-If you use the switch to control a heat pump, you should set the parameter `heating: true`.
+If you use the switch to control a heat pump, you should set the `feature`-Flag `heating`.
 This changes the display in the UI.
 Now the status uses the word "heating" instead of "charging".
 Additionally, the `soc` of the charger (if available) is no longer displayed in % but as a temperature in °C.

--- a/i18n/en/docusaurus-plugin-content-docs/current/reference/configuration/chargers.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/reference/configuration/chargers.mdx
@@ -60,12 +60,22 @@ In connection with this parameter, an icon can also be assigned (see [`vehicle.i
 **For example**:
 
 ```yaml
-integrateddevice: true
+features:
+  - integrateddevice
 icon: bike
 ```
 
 ---
 
+### `heating`
+
+This parameter causes the state of charge for chargers in the "switchable sockets (switchsockets)" group to be displayed in degrees instead of percent.
+
+**Example**:
+
+```yaml
+features:
+  - heating
 ```
 
-```
+---


### PR DESCRIPTION
for integrated device and heating parameters