### PR TITLE
Blog: fehlender Name in Tesla Konfig

### DIFF
--- a/blog/2025-01-20/tesla-api-update.mdx
+++ b/blog/2025-01-20/tesla-api-update.mdx
@@ -74,7 +74,8 @@ Beispiel:
 
 ```yaml {5-7}
 vehicles:
-  - type: template
+  - name: my_car
+    type: template
     template: tesla
     title: Tesla Model 3
     clientId: aaaaaa-11111-...     # von developer.tesla.com
@@ -105,7 +106,8 @@ Trage dieses Token in die evcc-Konfiguration ein:
 
 ```yaml {8}
 vehicles:
-  - type: template
+  - name: my_car
+    type: template
     template: tesla
     title: Tesla Model 3
     clientId: aaaaaa-11111-...     # von developer.tesla.com


### PR DESCRIPTION
kommt aus https://github.com/evcc-io/evcc/discussions/22127#discussioncomment-13611600