### PR TITLE
Add external device instruction for raspberry pi/home assistant addon

### DIFF
--- a/docs/installation/home-assistant.mdx
+++ b/docs/installation/home-assistant.mdx
@@ -157,7 +157,7 @@ exit
 
 Wenn sich dein Home Assistant-Gerät in der Nähe deines Zählers (PV / Batterie / Netz, ...) kannst du die Daten auch direkt über Modbus (bspw. USB) abrufen.
 
-Sie können jedes externe Gerät im evcc-Addon verwenden, indem Sie die `config.txt` auf Ihrer Boot-Partition des Home Assistant OS ändern. Dekommentieren Sie die folgende Zeile:
+Dafür musst du externe Geräte für Home Assistant aktivieren, was auch das evcc-Addon einschließt. Kommentiere dafür die Zeile uart = 1 in der config.txt auf der Home Assistant OS Boot-Partition ein.
 
 ```ini title=/config.txt
 uart = 1 

--- a/docs/installation/home-assistant.mdx
+++ b/docs/installation/home-assistant.mdx
@@ -153,11 +153,12 @@ Schließe die Shell im evcc Docker Container wenn du fertig bist:
 exit
 ```
 
-### Wie kann ich meinen externen Adapter/Hat im Home Assistant EVCC Addon (Home Assistant OS/Raspberry-pi) verwenden?
+### Wie kann ich meinen externen Adapter/Hat im Home Assistant evcc Addon (Home Assistant OS, Raspberry Pi) verwenden?
 
-Wenn sich dein Home Assistant-Gerät in der Nähe deines Zählers (PV / Batterie / Netz, ...) kannst du die Daten auch direkt über Modbus (bspw. USB) abrufen.
+Wenn sich dein Home Assistant-Gerät in der Nähe deines Zählers (PV, Batterie, Netz, ...) kannst du die Daten auch direkt über Modbus (bspw. USB) abrufen.
 
-Dafür musst du externe Geräte für Home Assistant aktivieren, was auch das evcc-Addon einschließt. Kommentiere dafür die Zeile uart = 1 in der config.txt auf der Home Assistant OS Boot-Partition ein.
+Dafür musst du externe Geräte für Home Assistant aktivieren, was auch das evcc-Addon einschließt.
+Kommentiere dafür die Zeile `uart = 1` in der `config.txt` auf der Home Assistant OS Boot-Partition ein.
 
 ```ini title=/config.txt
 uart = 1 

--- a/docs/installation/home-assistant.mdx
+++ b/docs/installation/home-assistant.mdx
@@ -164,7 +164,7 @@ Sie können jedes externe Gerät im evcc-Addon verwenden, indem Sie die `config.
 ```
 
 
-Nach einem Neustart sollte Ihr Gerät für das evcc-Addon verfügbar sein (wahrscheinlich als `/dev/ttyS0` oder `/dev/ttyUSB`)
+Nach einem Neustart sollte dein Gerät für das evcc-Addon verfügbar sein (wahrscheinlich als `/dev/ttyS0` oder `/dev/ttyUSB`)
 
 
 ## Nächster Schritt: Integration

--- a/docs/installation/home-assistant.mdx
+++ b/docs/installation/home-assistant.mdx
@@ -153,6 +153,20 @@ Schließe die Shell im evcc Docker Container wenn du fertig bist:
 exit
 ```
 
+### Wie kann ich meinen externen Adapter/Hat im Home Assistant EVCC Addon (Home Assistant OS/Raspberry-pi) verwenden?
+
+Wenn sich Ihr Home Assistant-Gerät in der Nähe Ihrer Batterie/PV befindet, können Sie das gleiche Gerät zum Abrufen von Modbus-Daten verwenden.  
+
+Sie können jedes externe Gerät im evcc-Addon verwenden, indem Sie die `config.txt` auf Ihrer Boot-Partition des Home Assistant OS ändern. Dekommentieren Sie die folgende Zeile:
+
+```
+# uart = 1 
+```
+
+
+Nach einem Neustart sollte Ihr Gerät für das evcc-Addon verfügbar sein (wahrscheinlich als `/dev/ttyS0` oder `/dev/ttyUSB`)
+
+
 ## Nächster Schritt: Integration
 
 Wenn dein System läuft, kannst du dich um die Integration zwischen evcc und Home Assistant kümmern.

--- a/docs/installation/home-assistant.mdx
+++ b/docs/installation/home-assistant.mdx
@@ -159,7 +159,7 @@ Wenn sich dein Home Assistant-Gerät in der Nähe deines Zählers (PV / Batterie
 
 Sie können jedes externe Gerät im evcc-Addon verwenden, indem Sie die `config.txt` auf Ihrer Boot-Partition des Home Assistant OS ändern. Dekommentieren Sie die folgende Zeile:
 
-```
+```ini title=/config.txt
 # uart = 1 
 ```
 

--- a/docs/installation/home-assistant.mdx
+++ b/docs/installation/home-assistant.mdx
@@ -155,7 +155,7 @@ exit
 
 ### Wie kann ich meinen externen Adapter/Hat im Home Assistant EVCC Addon (Home Assistant OS/Raspberry-pi) verwenden?
 
-Wenn sich Ihr Home Assistant-Gerät in der Nähe Ihrer Batterie/PV befindet, können Sie das gleiche Gerät zum Abrufen von Modbus-Daten verwenden.  
+Wenn sich dein Home Assistant-Gerät in der Nähe deines Zählers (PV / Batterie / Netz, ...) kannst du die Daten auch direkt über Modbus (bspw. USB) abrufen.
 
 Sie können jedes externe Gerät im evcc-Addon verwenden, indem Sie die `config.txt` auf Ihrer Boot-Partition des Home Assistant OS ändern. Dekommentieren Sie die folgende Zeile:
 

--- a/docs/installation/home-assistant.mdx
+++ b/docs/installation/home-assistant.mdx
@@ -160,7 +160,7 @@ Wenn sich dein Home Assistant-Gerät in der Nähe deines Zählers (PV / Batterie
 Sie können jedes externe Gerät im evcc-Addon verwenden, indem Sie die `config.txt` auf Ihrer Boot-Partition des Home Assistant OS ändern. Dekommentieren Sie die folgende Zeile:
 
 ```ini title=/config.txt
-# uart = 1 
+uart = 1 
 ```
 
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/installation/home-assistant.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/installation/home-assistant.mdx
@@ -153,6 +153,19 @@ Close the shell in the evcc Docker container if you are done:
 exit
 ```
 
+### How can I use my external adapter / HAT in the Home Assistant evcc addon (Home Assistant OS, Raspberry Pi)?
+
+If your Home Assistant device is close to your meter (solar, battery, grid, ...) you can also retrieve the data directly via Modbus (e.g. USB).
+
+To do this, you need to enable external devices for Home Assistant, which also includes the evcc addon.
+To do this, uncomment the line `uart = 1` in the `config.txt` file on the Home Assistant OS boot partition.
+
+```ini title=/config.txt
+uart = 1
+```
+
+After a restart, your device should be available to the evcc addon (probably as `/dev/ttyS0` or `/dev/ttyUSB`)
+
 ## Next Step: Integration
 
 Once your system is running, you can set up the integration between evcc and Home Assistant.


### PR DESCRIPTION
To use physical Modbus hat/adapter in EVCC on the same raspberry pi used by home assistant, the config.txt in the boot partition of home assistant should be edited for the device to be available. This instruction adds that information to the docs

Please spell check, German is not my first language and mostly used translator tools and common sense. 

**Todos**

- [ ] English translation