### PR TITLE
Fix spelling of "Add-on" in Home Assistant docs

### DIFF
--- a/docs/installation/home-assistant.mdx
+++ b/docs/installation/home-assistant.mdx
@@ -79,7 +79,7 @@ Siehe [Home Assistant Dokumentation](https://www.home-assistant.io/installation/
 
 Gehe im **evcc** Add-on in den Tab **Information** und aktiviere **In Seitenleiste anzeigen** (evcc UI http://your-ha-instance-ip-address:7070)
 
-Gehe zum in den Tab **Konfiguration** und wähle dein Arbeitsverzeichnis aus (Beispiel):
+Gehe zum Tab **Konfiguration** und wähle dein Arbeitsverzeichnis aus (Beispiel):
 
 ![Image](screenshots/ha_configuration_ui.webp)
 


### PR DESCRIPTION
Home Assistant uses "add-on" in English and "Add-on" in German as the consistent official spelling.

This commit fixes the wrong use of "Addon".