### PR TITLE
fix syntax in doc for named meters

### DIFF
--- a/docs/devices/meters.mdx
+++ b/docs/devices/meters.mdx
@@ -51,7 +51,7 @@ site:
 
 Auf dieser Seite findest du die Konfigurationen für alle unterstützte Komponenten die als Energiemesspunkte (Zähler) eingebunden werden können.
 Nachdem du das Code-Beispiel für deine Zähler angepasst und in die `evcc.yaml` übernommen hast, kannst du die Verbindung mit dem Befehl `evcc meter` testen. Dabei werden alle konfigurierten Zähler getestet.
-Mit dem Befehl `evcc meter --name my_meter` kann man mittels des vergebenen Namens selektiv testen.
+Mit dem Befehl `evcc meter my_meter` kann man mittels des vergebenen Namens selektiv testen.
 
 ```
 $ ./evcc meter

--- a/i18n/en/docusaurus-plugin-content-docs/current/devices/meters.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/devices/meters.mdx
@@ -51,7 +51,7 @@ site:
 
 This page lists the configurations for all supported components that can be used as energy measuring points (`meter`).
 Once you have adapted the code samples to suit your meters in `evcc.yaml`, you can test the connection using the `evcc meter` command, which returns the current status of all connected meters.
-The command `evcc meter --name grid1` can be used to test a single meter by name.
+The command `evcc meter grid1` can be used to test a single meter by name.
 
 ```
 $ ./evcc meter


### PR DESCRIPTION
Update syntax for `evcc` command: instead of `evcc meter --name [name]`, use the correct `evcc meter [name]`.
