### PR TITLE
Document that EM2GO Duo Power Support is currently broken

### DIFF
--- a/templates/nightly/de/charger/em2go-duo-power.yaml
+++ b/templates/nightly/de/charger/em2go-duo-power.yaml
@@ -4,6 +4,9 @@ product:
   brand: EM2GO
   description: Duo Power
 capabilities: ["mA"]
+description: |
+  Die Unterstützung ist im Moment vollständig kaputt und keine Verbindung möglich.
+  Alternativ [OCPP 1.6J](https://docs.evcc.io/docs/devices/chargers#ocpp-16j-kompatibel) mit `connector` Parameter nutzen.
 render:
   - default: |
       type: template
@@ -28,7 +31,7 @@ params:
   - name: modbus
     example:
     default:
-    choice: ['tcpip']
+    choice: ["tcpip"]
     unit:
     description: Modbus Typ
     help:

--- a/templates/nightly/en/charger/em2go-duo-power.yaml
+++ b/templates/nightly/en/charger/em2go-duo-power.yaml
@@ -4,6 +4,9 @@ product:
   brand: EM2GO
   description: Duo Power
 capabilities: ["mA"]
+description: |
+  Support is currently completely broken and no connection possible.
+  Alternatively use [OCPP 1.6J](https://docs.evcc.io/en/docs/devices/chargers#ocpp-16j-compatible) with `connector` parameter.
 render:
   - default: |
       type: template
@@ -28,7 +31,7 @@ params:
   - name: modbus
     example:
     default:
-    choice: ['tcpip']
+    choice: ["tcpip"]
     unit:
     description: Modbus Type
     help:


### PR DESCRIPTION
As can be seen with Wireshark the wrong Modbus registers for the Duo Power are used. This is to document the current state until the issue is fixed.

It seems https://github.com/evcc-io/evcc/pull/22528 was YOLO merged. As can be seen with Wireshark the wrong Modbus registers for the Duo Power are used. This is to document the current state until the issue is fixed. evcc uses Modbus registers as documented for the Pro Power to which the Duo Power rightfully not responds.

I have an EM2GO Pro Power and Duo Power available and can support in fixing the code, but would like to know what kind of license evcc actually uses. [evcc/license](https://github.com/evcc-io/evcc?tab=MIT-1-ov-file) shows the MIT license being used. But why do you then state that [individual files](https://github.com/evcc-io/evcc/blob/668344bf320cd0b4a55b272a833ac827d66e93fb/charger/em2go.go#L7) are not covered by the MIT license?