### PR TITLE
Fix: evcc.yaml path in docker.mdx

### DIFF
--- a/docs/installation/docker.mdx
+++ b/docs/installation/docker.mdx
@@ -48,7 +48,7 @@ Es gibt mehrere Möglichkeiten, diese zu erstellen:
 
 Der evcc Docker Container benötigt zwei Volumes:
 
-- `/etc/evcc.yaml` für die Konfigurationsdatei
+- `/app/evcc.yaml` für die Konfigurationsdatei
 - `/root/.evcc/` Verzeichnis für die interne SQLite Datenbank. Die Datenbank wird automatisch in diesem Verzeichnis abgelegt.
 
 Erstelle diese Verzeichnisse auf deinem Host-System.
@@ -73,7 +73,7 @@ Hier sind die relevanten Angaben, die du eintragen musst:
 
 | Host Pfad              | Container Pfad  | Beschreibung                      |
 |------------------------|-----------------|-----------------------------------|
-| `/home/user/evcc.yaml` | `/etc/evcc.yaml`| Konfigurationsdatei               |
+| `/home/user/evcc.yaml` | `/app/evcc.yaml`| Konfigurationsdatei               |
 | `/home/user/.evcc/`    | `/root/.evcc`   | Verzeichnis für interne Datenbank |
 
 #### Ports {#ports}
@@ -114,7 +114,7 @@ Ob du `sudo` benötigst, hängt von deinem System ab.
 
 ```sh
 sudo docker run -d --name evcc \
--v /home/user/evcc.yaml:/etc/evcc.yaml \
+-v /home/user/evcc.yaml:/app/evcc.yaml \
 -v /home/user/.evcc:/root/.evcc \
 -p 7070:7070 \
 -p 8887:8887 \
@@ -126,7 +126,7 @@ evcc/evcc:latest
 
   ```sh
   sudo docker run -d --name evcc \
-  -v /home/user/evcc.yaml:/etc/evcc.yaml \
+  -v /home/user/evcc.yaml:/app/evcc.yaml \
   -v /home/user/.evcc:/root/.evcc \
   -p 7070:7070 \
   -p 8887:8887 \
@@ -206,7 +206,7 @@ services:
       - 7070:7070/tcp
       - 8887:8887/tcp
     volumes:
-      - /home/user/evcc.yaml:/etc/evcc.yaml
+      - /home/user/evcc.yaml:/app/evcc.yaml
       - /home/user/.evcc:/root/.evcc
     restart: unless-stopped
 ```
@@ -228,7 +228,7 @@ services:
       - 9522:9522/udp
       - 4712:4712/tcp
     volumes:
-      - /home/user/evcc.yaml:/etc/evcc.yaml
+      - /home/user/evcc.yaml:/app/evcc.yaml
       - /home/user/.evcc:/root/.evcc
       - /etc/machine-id:/etc/machine-id
       - /var/lib/dbus/machine-id:/var/lib/dbus/machine-id


### PR DESCRIPTION
added the current path in all config blocks. (compare - https://github.com/evcc-io/docs/blob/main/docs/installation/docker.mdx?plain=1#L44 )