### PR TITLE
Kommunikationsparameter für Heidelberg Energy Wallbox detailliert

### DIFF
--- a/docs/devices/chargers.mdx
+++ b/docs/devices/chargers.mdx
@@ -555,7 +555,7 @@ Die Hauptplatine benötigt eine aktuelle Firmware. Eine aktuelle Softwareversion
 
 <DeviceFeatures features="mA" />
 
-Bitte das Handbuch zur Verkabelung und Konfiguration genau lesen. Alle Boxen müssen für die externe Steuerung auf Follower-Modus konfiguriert sein (DIP S5/4 OFF). Jede Box braucht eine individuelle Modbus-ID (DIP S4). Auf korrekte RS485-Verkabelung inkl. Busterminierung (DIP S6/2) achten.
+Bitte das Handbuch zur Verkabelung und Konfiguration genau lesen. Alle Boxen müssen für die externe Steuerung auf Follower-Modus konfiguriert sein (DIP S5/4 OFF). Jede Box braucht eine individuelle Modbus-ID (DIP S4). Auf korrekte RS485-Verkabelung inkl. Busterminierung (DIP S6/2) achten. Die Parameter zur Kommunikation sind Baudrate: 19200, Data Bit: 8, Stop Bit: 1, Parity: even, Flow Control: disabled.
 
 <DeviceConfig code={`chargers:
     - name: my_charger


### PR DESCRIPTION
Ja, wenn man sich auskennt seht unten in den Config comset 8E1, aber ein neuling weis daraus nicht unbedingt was im RS485 zu TCP Adapter einzustellen ist ;) Mir hätte diese ausführliche Beschreibung geholfen, daher der Vorschlag sie einzufügen.

Danke auch nochmal für das tolle Projekt, wenn die Software einmal läuft ist sie grandios.