### PR TITLE
Sunny home manager integration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,12 +52,14 @@ YAML device templates organized by:
 #### Auto-Generated Content
 
 ##### Device & Tariff Pages
+
 1. Templates in `/templates/{version}/{lang}/{category}/`
 2. Processed by `src/generateFromTemplate.js`
 3. Output to `docs/devices/*.mdx` and `docs/tariffs.mdx`
 4. Marked with `<!-- AUTO-GENERATED CONTENT BELOW THIS LINE -->`
 
 ##### CLI Documentation
+
 1. Generated from main evcc repository
 2. Output to `docs/reference/cli/*.md`
 3. See README.md section "Update CLI docs" for generation instructions
@@ -83,8 +85,9 @@ Everything else is manually maintained:
 
 - **Be informal and casual** - address readers directly with "you" (English) or "du" (German)
 - Write for individual professionals, not businesses
-- Avoid corporate or marketing language
+- Avoid corporate or marketing language (e.g. don't use words like "bequem", "convenient", "seamlessly")
 - Be concise and direct
+- Use simple, factual language without embellishment
 
 ### Terminology
 
@@ -102,6 +105,12 @@ Everything else is manually maintained:
 
 ### Formatting Conventions
 
+#### Document Structure
+
+- Keep document structure flat where possible - avoid excessive nesting
+- Use clear, descriptive section headings
+- Consider restructuring if sections become too granular
+
 #### Headings
 
 - **German**: Use sentence case (e.g., "Häufige Fragen")
@@ -118,6 +127,7 @@ Everything else is manually maintained:
 - End complete sentences with periods
 - Don't use periods for simple fragments
 - Be consistent within each list
+- Convert bulleted lists to prose when they become too short
 
 #### Numbers & Units
 
@@ -145,6 +155,9 @@ Everything else is manually maintained:
 - Import components: `import Screenshot from "../../src/components/Screenshot"`
 - Tabs for multi-language/multi-platform content: `<Tabs>` and `<TabItem>`
 - Admonitions: `:::note`, `:::tip`, `:::info`, `:::warning`, `:::danger`
+  - Use sparingly - prefer integrating information into main text
+  - `:::warning` for important cautions about functionality
+  - `:::tip` only for genuinely helpful tips that save users time
 - Code blocks with syntax highlighting: ` ```yaml `, ` ```javascript `
 - Frontmatter for metadata: `sidebar_position`, `title`, `tags`
 - Images automatically optimized from `/static/img/`

--- a/docs/integrations/sma-sunny-home-manager.md
+++ b/docs/integrations/sma-sunny-home-manager.md
@@ -1,0 +1,59 @@
+---
+sidebar_position: 5
+---
+
+# Sunny Home Manager
+
+evcc unterstützt die Integration mit dem [SMA Sunny Home Manager 2.0 (SHM)](https://www.sma.de/produkte/energiemanagement/sunny-home-manager).
+Durch diese Integration werden die Ladepunkte im Sunny Portal sichtbar und können optional vom SHM gesteuert werden.
+
+## Funktionsweise
+
+Die Integration ist dauerhaft aktiv.
+Sobald evcc läuft, stellt es automatisch einen SEMP-Endpunkt (Smart Energy Management Protocol) bereit und kündigt diesen per mDNS im lokalen Netzwerk an.
+Der SHM kann dadurch die Ladepunkte automatisch erkennen und einbinden.
+
+Durch die Integration erscheinen alle evcc-Ladepunkte als Verbraucher im Sunny Portal mit detaillierten Verbrauchsdaten.
+Zusätzlich kann der SHM bei Bedarf die Ladeleistung beeinflussen, wenn dies explizit erlaubt wird.
+
+Der SEMP-Endpunkt ist unter `http://[evcc-IP]:7070/semp/` erreichbar und zeigt eine XML-Übersicht der registrierten Geräte.
+
+## Einrichtung im Sunny Home Manager
+
+Nach der evcc-Konfiguration werden die Ladepunkte automatisch im Sunny Portal unter **Konfiguration > Geräteübersicht** als neue Geräte vorgeschlagen.
+Dort kannst du sie aktivieren und dem Konfigurations-Assistenten folgen.
+Details zur Einrichtung findest du in der [SMA-Anleitung](https://manuals.sma.de/HM-20/de-DE/10426801547.html).
+
+## Konfiguration
+
+Die Konfiguration erfolgt über die evcc-Oberfläche:
+
+1. Öffne die **Einstellungen** in evcc
+2. Navigiere zum Abschnitt **Sunny Home Manager**
+3. Aktiviere die Integration und konfiguriere die erweiterten Einstellungen bei Bedarf
+
+### Externe Steuerung erlauben
+
+Mit der Option **Externe Steuerung erlauben** bestimmst du, ob der SHM die Ladeleistung beeinflussen darf:
+
+- **Aktiviert**: Der SHM kann die Ladesteuerung beeinflussen und eigene Optimierungen vornehmen
+- **Deaktiviert** (empfohlen): Die Lademodi werden ausschließlich von evcc gesteuert
+
+:::warning
+In der Praxis ist die externe Steuerung durch den SHM meist nicht hilfreich, da evcc bereits eine optimierte Ladesteuerung bietet.
+Wir empfehlen, diese Option deaktiviert zu lassen.
+:::
+
+### Gerätekennungen
+
+Jeder Ladepunkt erhält eine eindeutige ID im Format:
+```
+F-AAAAAAAA-BBBBBBBBBBBB-00
+```
+
+Dabei ist:
+- **AAAAAAAA**: Die Vendor ID (8 Zeichen, hexadezimal)
+- **BBBBBBBBBBBB**: Die Device ID (12 Zeichen, hexadezimal)
+
+Diese IDs werden normalerweise automatisch generiert.
+Wenn evcc auf einen anderen Computer umzieht, kannst du die bestehenden IDs aus dem `/semp/` Endpunkt des alten Systems übernehmen, damit der SHM die Geräte weiterhin erkennt.

--- a/i18n/en/docusaurus-plugin-content-docs/current/integrations/sma-sunny-home-manager.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/integrations/sma-sunny-home-manager.md
@@ -1,0 +1,59 @@
+---
+sidebar_position: 5
+---
+
+# Sunny Home Manager
+
+evcc supports integration with the [SMA Sunny Home Manager 2.0 (SHM)](https://www.sma.de/produkte/energiemanagement/sunny-home-manager).
+This integration makes charge points visible in the Sunny Portal and optionally allows control by the SHM.
+
+## How It Works
+
+The integration is permanently active.
+Once evcc is running, it automatically provides a SEMP endpoint (Smart Energy Management Protocol) and announces it via mDNS on the local network.
+This allows the SHM to automatically detect and integrate the charge points.
+
+Through the integration, all evcc charge points appear as consumers in the Sunny Portal with detailed consumption data.
+Additionally, the SHM can influence charging power if explicitly allowed.
+
+The SEMP endpoint is accessible at `http://[evcc-IP]:7070/semp/` and displays an XML overview of registered devices.
+
+## Setup in Sunny Home Manager
+
+After configuring evcc, the charge points are automatically suggested as new devices in the Sunny Portal under **Configuration > Device overview**.
+There you can activate them and follow the configuration wizard.
+See the [SMA manual](https://manuals.sma.de/HM-20/en-US/10426801547.html) for setup details.
+
+## Configuration
+
+Configuration is done via the evcc interface:
+
+1. Open **Settings** in evcc
+2. Navigate to the **Sunny Home Manager** section
+3. Enable the integration and configure advanced settings if needed
+
+### Allow External Control
+
+The **Allow external control** option determines whether the SHM may influence charging power:
+
+- **Enabled**: The SHM can influence charge control and apply its own optimisations
+- **Disabled** (recommended): Charging modes are controlled exclusively by evcc
+
+:::warning
+In practice, external control by the SHM is usually not helpful as evcc already provides optimised charge control.
+We recommend leaving this option disabled.
+:::
+
+### Device IDs
+
+Each charge point receives a unique ID in the format:
+```
+F-AAAAAAAA-BBBBBBBBBBBB-00
+```
+
+Where:
+- **AAAAAAAA**: The Vendor ID (8 characters, hexadecimal)
+- **BBBBBBBBBBBB**: The Device ID (12 characters, hexadecimal)
+
+These IDs are usually generated automatically.
+When moving evcc to another computer, you can copy the existing IDs from the `/semp/` endpoint of the old system so the SHM continues to recognise the devices.


### PR DESCRIPTION
add dedicated page for sunny home manager

@premultiply lies mal bitte gegen. Beschreibt die Umstellung in https://github.com/evcc-io/evcc/pull/23190

Ich würde die Seite in https://docs.evcc.io/docs/reference/configuration/hems dann beim nächsten Release entfernen.

<img width="1916" height="3328" alt="localhost_3000_docs_integrations_sma-sunny-home-manager" src="https://github.com/user-attachments/assets/fbdabd44-144a-4d32-ba0f-739153e2e7bf" />
