### PR TITLE
Docsaurus: Implement Work around for YAML copying issue

### DIFF
--- a/src/theme/CodeBlock/Buttons/CopyButton/index.tsx
+++ b/src/theme/CodeBlock/Buttons/CopyButton/index.tsx
@@ -1,0 +1,102 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React, {
+  useCallback,
+  useState,
+  useRef,
+  useEffect,
+  type ReactNode,
+} from 'react';
+import clsx from 'clsx';
+
+// Changes from original
+
+// import copy from 'copy-text-to-clipboard';
+
+function copy(text){
+  navigator.clipboard.writeText(text).catch(console.error);
+}
+// What does it do...
+// prevent going through the docsaurus parseLines() function that tries to strip magic comments, potentially affecting indentation
+// instead copy directly to Clipboard
+
+// Todo: remove the overwrite as soon as it is fixed in upstream
+
+// end Changes from original
+
+import {translate} from '@docusaurus/Translate';
+import {useCodeBlockContext} from '@docusaurus/theme-common/internal';
+import Button from '@theme/CodeBlock/Buttons/Button';
+import type {Props} from '@theme/CodeBlock/Buttons/CopyButton';
+import IconCopy from '@theme/Icon/Copy';
+import IconSuccess from '@theme/Icon/Success';
+
+import styles from './styles.module.css';
+
+function title() {
+  return translate({
+    id: 'theme.CodeBlock.copy',
+    message: 'Copy',
+    description: 'The copy button label on code blocks',
+  });
+}
+
+function ariaLabel(isCopied: boolean) {
+  return isCopied
+    ? translate({
+        id: 'theme.CodeBlock.copied',
+        message: 'Copied',
+        description: 'The copied button label on code blocks',
+      })
+    : translate({
+        id: 'theme.CodeBlock.copyButtonAriaLabel',
+        message: 'Copy code to clipboard',
+        description: 'The ARIA label for copy code blocks button',
+      });
+}
+
+function useCopyButton() {
+  const {
+    metadata: {code},
+  } = useCodeBlockContext();
+  const [isCopied, setIsCopied] = useState(false);
+  const copyTimeout = useRef<number | undefined>(undefined);
+
+  const copyCode = useCallback(() => {
+    copy(code);
+    setIsCopied(true);
+    copyTimeout.current = window.setTimeout(() => {
+      setIsCopied(false);
+    }, 1000);
+  }, [code]);
+
+  useEffect(() => () => window.clearTimeout(copyTimeout.current), []);
+
+  return {copyCode, isCopied};
+}
+
+export default function CopyButton({className}: Props): ReactNode {
+  const {copyCode, isCopied} = useCopyButton();
+
+  return (
+    <Button
+      aria-label={ariaLabel(isCopied)}
+      title={title()}
+      className={clsx(
+        className,
+        styles.copyButton,
+        isCopied && styles.copyButtonCopied,
+      )}
+      onClick={copyCode}>
+      <span className={styles.copyButtonIcons} aria-hidden="true">
+        <IconCopy className={styles.copyButtonIcon} />
+        <IconSuccess className={styles.copyButtonSuccessIcon} />
+      </span>
+    </Button>
+  );
+}

--- a/src/theme/CodeBlock/Buttons/CopyButton/styles.module.css
+++ b/src/theme/CodeBlock/Buttons/CopyButton/styles.module.css
@@ -1,0 +1,47 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+:global(.theme-code-block:hover) .copyButtonCopied {
+  opacity: 1 !important;
+}
+
+.copyButtonIcons {
+  position: relative;
+  width: 1.125rem;
+  height: 1.125rem;
+}
+
+.copyButtonIcon,
+.copyButtonSuccessIcon {
+  position: absolute;
+  top: 0;
+  left: 0;
+  fill: currentColor;
+  opacity: inherit;
+  width: inherit;
+  height: inherit;
+  transition: all var(--ifm-transition-fast) ease;
+}
+
+.copyButtonSuccessIcon {
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%) scale(0.33);
+  opacity: 0;
+  color: #00d600;
+}
+
+.copyButtonCopied .copyButtonIcon {
+  transform: scale(0.33);
+  opacity: 0;
+}
+
+.copyButtonCopied .copyButtonSuccessIcon {
+  transform: translate(-50%, -50%) scale(1);
+  opacity: 1;
+  transition-delay: 0.075s;
+}


### PR DESCRIPTION
https://github.com/facebook/docusaurus/issues/11414

overwriting the original code button with a workaround that skips docsaurus parselines() function that seems to be the root cause...

Do not know if we want that as a temporary fix..

works arround: https://github.com/evcc-io/docs/issues/873

müsst ihr entscheiden ob ihr den workarround wollt... oder lieber auf upstream wartet...