### PR TITLE
Update vehicles.mdx with correct Wiki Link for Kia

### DIFF
--- a/docs/devices/vehicles.mdx
+++ b/docs/devices/vehicles.mdx
@@ -406,7 +406,7 @@ Manche Modelle (z.B. Kona) schalten bei geringen Ladeströmen (< 8A) intern auf 
 
 ## Kia Bluelink
 
-Anstelle des Passworts muss in das Passwort-Feld ein `refresh_token` eingetragen werden ([Anleitung](https://github.com/evcc-io/evcc/wiki/Kia:-Refresh%E2%80%90Token-ermitteln)).
+Anstelle des Passworts muss in das Passwort-Feld ein `refresh_token` eingetragen werden ([Anleitung](https://github.com/evcc-io/evcc/wiki/Hyundai-Kia:-Refresh%E2%80%90Token-ermitteln)).
 
 Manche Modelle (z.B. Niro EV) schalten bei geringen Ladeströmen (< 8A) intern auf 2 Phasen um. In den Fällen, in denen die Wallbox auch die Phasenströme misst, führt das zu unerwünschten Schwankungen der Ladeleistung. Abhilfe schafft hier, den Mindestladestrom auf 8A zu setzen.
 


### PR DESCRIPTION
change the link for Kia token generation to https://github.com/evcc-io/evcc/wiki/Hyundai-Kia:-Refresh%E2%80%90Token-ermitteln, since the wiki page was renamed to reflect also Hyundai