### PR TITLE
Document daily session reset for heating systems

### DIFF
--- a/docs/features/sessions.mdx
+++ b/docs/features/sessions.mdx
@@ -87,12 +87,17 @@ Wurde ein Fahrzeug nicht korrekt erkannt, kannst du in dieser Ansicht auch die F
   caption="Detailansicht eines Ladevorgangs"
 />
 
-## Schaltbare Steckdosen
+## Schaltbare Steckdosen und Wärmeerzeugung
 
-Im Gegensatz zu Wallboxen gibt es bei schaltbaren Steckdosen (z. B. Schuko-Ladegerät, E-Bike, ...) oder fest verkabelten Anlagen (z. B. Wärmepumpe, Heizstab, ...) keine Möglichkeit, den Ladevorgang zu erkennen.
-Diese Verbraucher tauchen aktuell trotzdem in der Liste der Ladevorgänge mit langen Zeiträumen auf.
-Wird evcc neu gestartet, wird ein neuer Ladevorgang protokolliert.
+Im Gegensatz zu Wallboxen gibt es bei schaltbaren Steckdosen (z. B. Schuko-Ladegerät, E-Bike, ...) oder Wärmeerzeugern (z. B. Wärmepumpe, Heizstab, ...) keine Möglichkeit, den Ladevorgang zu erkennen.
+
+### Heizungsanlagen
+
+Für Heizungsanlagen (Wärmepumpen, Heizstäbe, etc.) werden Ladevorgänge täglich um Mitternacht automatisch zurückgesetzt.
+Dadurch werden die Messwerte für jeden Tag neu erfasst und die Liste der Ladevorgänge bleibt übersichtlich.
+
+### Schaltbare Steckdosen
+
+Für schaltbare Steckdosen werden Ladevorgänge mit langen Zeiträumen protokolliert.
+Wird evcc neu gestartet, wird ein neuer Ladevorgang begonnen.
 Dies kann auch über aktives Stoppen und Starten am Ladepunkt (Modus: aus) manuell erfolgen.
-
-Die momentane Lösung ist für diese Fälle nicht optimal.
-In einem zukünftigen Release werden wir die Auswertung für Schaltsteckdosen und fest verkabelte Anlagen verbessern.

--- a/i18n/en/docusaurus-plugin-content-docs/current/features/sessions.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/features/sessions.mdx
@@ -86,12 +86,17 @@ If a vehicle was not recognized correctly, you can also correct the vehicle assi
   caption="Detailed view of a charging session"
 />
 
-## Switchable sockets
+## Switchable sockets and heating
 
-In contrast to wall boxes, there is no way to detect the charging session with switchable sockets (e.g. Schuko charger, e-bike, ...) or hard-wired systems (e.g. heat pump, heating element, ...).
-However, these consumers currently appear in the list of charging sessions with long periods of time.
+In contrast to wall boxes, there is no way to detect the charging session with switchable sockets (e.g. Schuko charger, e-bike, ...) or heating systems (e.g. heat pump, heating element, ...).
+
+### Heating systems
+
+For heating systems (heat pumps, heating elements, etc.), charging sessions are automatically reset daily at midnight.
+This means measurements are captured for each day separately and the list of charging sessions remains clear.
+
+### Switchable sockets
+
+For switchable sockets, charging sessions with long periods of time are logged.
 If evcc is restarted, a new charging session is logged.
 This can also be done manually by actively stopping and starting at the charging point (mode: off).
-
-The current solution is not optimal for these cases.
-In a future release, we will improve the evaluation for switchable sockets and hard-wired systems.

--- a/templates/nightly/de/charger/neoom-n.yaml
+++ b/templates/nightly/de/charger/neoom-n.yaml
@@ -2,7 +2,7 @@ template: neoom-n
 product:
   identifier: neoom-n
   brand: Neoom
-  description: N
+  description: 'N'
 capabilities: ["mA", "1p3p"]
 requirements: ["sponsorship"]
 render:

--- a/templates/nightly/de/meter/hager-xem-with-emc-flow-r2.yaml
+++ b/templates/nightly/de/meter/hager-xem-with-emc-flow-r2.yaml
@@ -1,8 +1,7 @@
 template: hager-flow
 product:
   identifier: hager-xem-with-emc-flow-r2
-  description: Hager XEM mit EMC flow R2
-
+  description: "Hager XEM mit EMC flow R2\n"
 description: |
   "Modbus TCP server" muss aktiviert sein
 

--- a/templates/nightly/de/vehicle/smart-1.yaml
+++ b/templates/nightly/de/vehicle/smart-1.yaml
@@ -2,7 +2,7 @@ template: smart-hello
 product:
   identifier: smart-1
   brand: Smart
-  description: #1
+  description: '#1'
 render:
   - default: |
       type: template

--- a/templates/nightly/en/charger/neoom-n.yaml
+++ b/templates/nightly/en/charger/neoom-n.yaml
@@ -2,7 +2,7 @@ template: neoom-n
 product:
   identifier: neoom-n
   brand: Neoom
-  description: N
+  description: 'N'
 capabilities: ["mA", "1p3p"]
 requirements: ["sponsorship"]
 render:

--- a/templates/nightly/en/meter/hager-xem-with-emc-flow-r2.yaml
+++ b/templates/nightly/en/meter/hager-xem-with-emc-flow-r2.yaml
@@ -1,8 +1,7 @@
 template: hager-flow
 product:
   identifier: hager-xem-with-emc-flow-r2
-  description: Hager XEM with EMC flow R2
-
+  description: "Hager XEM with EMC flow R2\n"
 description: |
   "Modbus TCP server" has to be enabled
 

--- a/templates/nightly/en/vehicle/smart-1.yaml
+++ b/templates/nightly/en/vehicle/smart-1.yaml
@@ -2,7 +2,7 @@ template: smart-hello
 product:
   identifier: smart-1
   brand: Smart
-  description: #1
+  description: '#1'
 render:
   - default: |
       type: template


### PR DESCRIPTION
fixes https://github.com/evcc-io/docs/issues/830
fixes #829

Heating systems (heat pumps, heating elements) now have their charging sessions automatically reset daily at midnight. This keeps the session list clear and measurements organized by day.

