### PR TITLE
15min intervals for plugins

### DIFF
--- a/docs/tariffs/_dynamischer_strompreis.mdx
+++ b/docs/tariffs/_dynamischer_strompreis.mdx
@@ -29,12 +29,19 @@ tariffs:
 
 Das Plugin muss eine JSON-Struktur zurückgeben, welches eine Liste von Zeiträumen und Preisen enthält.
 Die Datumsfelder müssen in der Form `YYYY-MM-DDTHH:MM:SSZ` und der Preis in der korrekten Währungseinheit (bspw. EUR) angegeben werden.
-Siehe nachfolgendes Beispiel:
+
+Seit Oktober 2025 veröffentlicht der EPEX Spotmarkt dynamische Stromtarife im 15-Minuten-Takt.
+evcc arbeitet intern mit 15-Minuten-Intervallen.
+Plugins können weiterhin Daten in stündlichen Intervallen liefern, diese werden automatisch in 15-Minuten-Intervalle umgerechnet.
+
+Siehe nachfolgendes Beispiel mit 15-Minuten-Intervallen:
 
 ```js
 [
-  { "start": "2025-01-01T00:00:00Z", "end": "2025-01-01T01:00:00Z", "value": 25.0 },
-  { "start": "2025-01-01T01:00:00Z", "end": "2025-01-01T02:00:00Z", "value": 30.0 },
+  { "start": "2025-01-01T00:00:00Z", "end": "2025-01-01T00:15:00Z", "value": 25.0 },
+  { "start": "2025-01-01T00:15:00Z", "end": "2025-01-01T00:30:00Z", "value": 26.5 },
+  { "start": "2025-01-01T00:30:00Z", "end": "2025-01-01T00:45:00Z", "value": 24.8 },
+  { "start": "2025-01-01T00:45:00Z", "end": "2025-01-01T01:00:00Z", "value": 27.2 },
 ]
 ```
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/tariffs.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/tariffs.mdx
@@ -263,12 +263,19 @@ tariffs:
 
 The plugin must return a JSON structure containing a list of time periods and prices.
 The date fields must be in the form `YYYY-MM-DDTHH:MM:SSZ` and the price in the correct currency unit (e.g. EUR).
-See the following example:
+
+Since October 2025, EPEX Spot Market publishes dynamic electricity tariffs in 15-minute intervals.
+evcc works internally with 15-minute intervals.
+Plugins can still provide data in hourly intervals, which are automatically converted into 15-minute intervals.
+
+See the following example with 15-minute intervals:
 
 ```js
 [
-  { "start": "2025-01-01T00:00:00Z", "end": "2025-01-01T01:00:00Z", "value": 25.0 },
-  { "start": "2025-01-01T01:00:00Z", "end": "2025-01-01T02:00:00Z", "value": 30.0 },
+  { "start": "2025-01-01T00:00:00Z", "end": "2025-01-01T00:15:00Z", "value": 25.0 },
+  { "start": "2025-01-01T00:15:00Z", "end": "2025-01-01T00:30:00Z", "value": 26.5 },
+  { "start": "2025-01-01T00:30:00Z", "end": "2025-01-01T00:45:00Z", "value": 24.8 },
+  { "start": "2025-01-01T00:45:00Z", "end": "2025-01-01T01:00:00Z", "value": 27.2 },
 ]
 ```
 


### PR DESCRIPTION
fixes #896 

Document 15-minute tariff intervals for EPEX

EPEX Spot Market now publishes dynamic electricity tariffs in 15-minute intervals since October 2024. Updated the custom plugin examples to show 15-minute intervals instead of hourly intervals.

Added note explaining that hourly intervals are still supported and automatically converted by evcc into 15-minute intervals for backward compatibility.