### PR TITLE
Document phase switching with load management

### DIFF
--- a/docs/features/loadmanagement.mdx
+++ b/docs/features/loadmanagement.mdx
@@ -140,6 +140,16 @@ Für die Umsetzung von Regelanweisungen durch den Netzbetreiber kann der HEMS-Me
 Weitere Informationen findest du unter [§ 14a EnWG & SteuVE](./14a-enwg-steuve).
 :::
 
+## Phasenumschaltung
+
+Hast du eine Wallbox mit automatischer Phasenumschaltung (1P/3P), nutzt evcc diese, um die Grenzwerte einzuhalten.
+Reicht die verfügbare Leistung nicht für 3-phasiges Laden, schaltet evcc automatisch auf 1-phasig um.
+
+Dies gilt auch für Schnellladen und planbasiertes Laden.
+Wenn z. B. durch Lastmanagement nur noch 3,5 kW verfügbar sind, wird auf 1-phasiges Laden (ab 1,4 kW) umgeschaltet, statt die Ladung zu pausieren.
+
+**Voraussetzung:** Die Wallbox muss Phasenumschaltung unterstützen.
+
 ## Einschränkungen
 
 :::info
@@ -149,4 +159,3 @@ Private Nutzung mit kleineren Installationen wird kostenlos bleiben.
 
 - Die aktuellen Werte und Grenzen der einzelnen Schaltkreise werden auf der Konfigurationsseite im UI angezeigt. Die Visualisierung am Ladepunkt ist in Planung.
 - `priority` Einstellungen am Ladepunkt werden noch nicht berücksichtigt.
-- Lastmanagement wird nicht durch die Ladeplanung berücksichtigt.

--- a/i18n/en/docusaurus-plugin-content-docs/current/features/loadmanagement.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/features/loadmanagement.mdx
@@ -138,6 +138,16 @@ The HEMS mechanism can be used to implement control requests from the grid opera
 For more information, see [§ 14a EnWG & SteuVE](./14a-enwg-steuve).
 :::
 
+## Phase Switching
+
+For chargers with automatic phase switching (1P/3P), load management can use the switching capability to charge within the configured limits.
+When available power is insufficient for 3-phase charging, evcc automatically switches to 1-phase charging.
+
+This applies to fast charging and plan-based charging as well.
+For example, if load management limits available power to 3.5 kW, evcc switches to 1-phase charging (from 1.4 kW) instead of pausing the charge.
+
+**Requirement:** The charger must support phase switching.
+
 ## Restrictions
 
 :::info
@@ -148,4 +158,3 @@ Private use with smaller installations will remain free of charge.
 
 - Current values and limits of individual circuits are displayed on the configuration page in the UI. Visualization at the charging point is planned.
 - `priority` settings at the charging point are not yet taken into account.
-- Charging planning currently ignores Load Management, so reduced charging speeds due to load limits could lead to missing the charge target.


### PR DESCRIPTION
Fixes #884
Fixes #874 

- Add new section explaining automatic phase switching with load management
- Remove limitation that load management doesn't work with charge planning
- Update both German and English documentation

