### PR TITLE
Document asleep messaging event

### DIFF
--- a/docs/reference/configuration/messaging.md
+++ b/docs/reference/configuration/messaging.md
@@ -28,6 +28,7 @@ Die verfügbaren Ereignisse sind:
 - `disconnect`: Fahrzeug entfernt
 - `soc`: Fahrzeug Akku-Ladestandsänderung
 - `guest`: Unbekanntes Fahrzeug erkannt
+- `asleep`: Fahrzeug lädt nicht trotz Ladefreigabe
 
 **Beispiel**:
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/reference/configuration/messaging.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/reference/configuration/messaging.md
@@ -28,6 +28,7 @@ The available events are:
 - `disconnect`: Vehicle disconnected
 - `soc`: Vehicle battery state of charge changed
 - `guest`: Unknown vehicle detected
+- `asleep`: Vehicle not charging despite charge release
 
 **For example**:
 


### PR DESCRIPTION
Fixes #860

Add documentation for the new asleep messaging event that triggers when a vehicle fails to start charging despite charge release.