### PR TITLE
Document EEBUS SHIP-ID configuration

### DIFF
--- a/docs/reference/configuration/eebus.md
+++ b/docs/reference/configuration/eebus.md
@@ -93,7 +93,16 @@ interfaces:
 
 ### `shipid`
 
-Hiermit kann die zu verwendende Geräte-ID (SKI) definiert werden.
+Hiermit kann die zu verwendende SHIP-ID definiert werden.
+Dies sollte nur für Entwicklungszwecke notwendig sein.
+
+Normalerweise generiert evcc die SHIP-ID automatisch aus der `machine-id` (auf realer Hardware) oder einer zufällig generierten Plant-ID (in Container-Umgebungen wie Docker), die in der Datenbank gespeichert wird.
+Du kannst eine explizite Plant-ID über `plant` in der `evcc.yaml` oder die `EVCC_PLANT` Umgebungsvariable setzen – empfohlen für bessere Portierbarkeit.
+Die SHIP-ID ist fest mit dem Zertifikat verknüpft – ändert sich eines von beiden, muss die Kopplung mit den Geräten neu durchgeführt werden.
+
+:::warning Achtung
+Ändere diesen Wert nicht manuell, wenn du nicht genau weißt, was du tust.
+:::
 
 **Beispiel**:
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/reference/configuration/eebus.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/reference/configuration/eebus.md
@@ -93,7 +93,16 @@ interfaces:
 
 ### `shipid`
 
-Defines the Device ID (SKI) to be used.
+Defines the SHIP-ID to be used.
+This should only be necessary for development purposes.
+
+Normally evcc generates the SHIP-ID automatically from the `machine-id` (on real hardware) or a randomly generated plant ID (in container environments like Docker), which is stored in the database.
+You can set an explicit plant ID via `plant` in `evcc.yaml` or the `EVCC_PLANT` environment variable – recommended for better portability.
+The SHIP-ID is tied to the certificate – if either changes, pairing with devices must be redone.
+
+:::warning Warning
+Don't change this value manually unless you know exactly what you're doing.
+:::
 
 **For example**:
 


### PR DESCRIPTION
Fixes #851

Clarifies the `shipid` parameter documentation:
- Changed description from "SKI" to "SHIP-ID" (correct terminology)
- Added explanation that this is for development purposes only
- Documented automatic SHIP-ID generation from machine-id or plant ID
- Explained explicit plant ID configuration via evcc.yaml or EVCC_PLANT
- Added warning about manual changes
- Noted relationship between SHIP-ID and certificate