### PR TITLE
Document meter plugin

### DIFF
--- a/docs/devices/plugins.mdx
+++ b/docs/devices/plugins.mdx
@@ -28,6 +28,7 @@ evcc bietet folgende Plugins an:
 - [SMA/Speedwire Plugin](#speedwire) - Plugin speziell für SMA Geräte, die mit dem Speedwire Protokoll kommunizieren können.
 - [JavaScript Plugin](#javascript) - Plugin, das Werte in über ein JavaScript Skript bereitstellt oder entgegennimmt.
 - [Shell Plugin](#shell) - Plugin, das ein Shell Skript ausführen kann, um Daten zu extrahieren oder schreibend entgegennimmt.
+- [Meter Plugin](#meter-plugin) - Plugin um ein anderes Messgerät als Datenquelle zu verwenden.
 
 Neben diesen Integrations-Plugins, gibt es noch Helfer-Plugins, die Zusatzfunktionen bereit stellt:
 
@@ -579,3 +580,42 @@ value:
 
 In diesem Beispiel wird der Wert nur verwendet, wenn das `valid` Topic `true` zurückgibt.
 Wenn es `false` zurückgibt, wird der Wert als nicht verfügbar markiert.
+
+### Meter <Tag label="lesen" category="read" /> {#meter-plugin}
+
+Das `meter` Plugin ermöglicht es, ein anderes Messgerät als Datenquelle zu verwenden.
+Dies ist nützlich, wenn man ein bestehendes Gerät für mehrere Messwerte verwenden möchte oder wenn man verschiedene Methoden eines Geräts für unterschiedliche Attribute nutzen will.
+
+Die `config` Sektion enthält dabei die vollständige Template-Konfiguration des einzubettenden Messgeräts.
+
+**Beispiel Lesen**:
+
+```yaml
+meters:
+  - name: battery
+    type: custom
+    power:
+      source: meter
+      config:
+        type: template
+        template: shelly-1pm
+        host: 192.168.178.21
+        channel: 0
+        method: power
+        scale: -1
+    energy:
+      source: meter
+      config:
+        type: template
+        template: shelly-1pm
+        host: 192.168.178.21
+        channel: 0
+        method: energy
+    soc:
+      source: mqtt
+      topic: Haus/Batterie
+      jq: .soc
+      timeout: 60s
+```
+
+In diesem Beispiel wird ein Shelly 1PM Gerät als Datenquelle für Leistung und Energie einer Batterie verwendet, während der Ladestand (SoC) über MQTT abgerufen wird.

--- a/i18n/en/docusaurus-plugin-content-docs/current/devices/plugins.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/devices/plugins.mdx
@@ -28,6 +28,7 @@ evcc offers the following plugins:
 - [SMA/Speedwire Plugin](#speedwire) - Plugin specifically for SMA devices that can communicate with the Speedwire protocol.
 - [JavaScript Plugin](#javascript) - Plugin that provides or receives values via a JavaScript script.
 - [Shell Plugin](#shell) - Plugin that can execute a shell script to extract data or receive data for writing.
+- [Meter Plugin](#meter-plugin) - Plugin to use another meter as a data source.
 
 In addition to these integration plugins, there are also helper plugins that provide additional functions:
 
@@ -579,3 +580,42 @@ value:
 
 In this example, the value is only used when the `valid` topic returns `true`.
 If it returns `false`, the value is marked as unavailable.
+
+### Meter <Tag label="read" category="read" /> {#meter-plugin}
+
+The `meter` plugin allows using another meter as a data source.
+This is useful when you want to use an existing device for multiple measurements or when you need different methods of a device for different attributes.
+
+The `config` section contains the complete template configuration of the meter to be embedded.
+
+**Reading Example**:
+
+```yaml
+meters:
+  - name: battery
+    type: custom
+    power:
+      source: meter
+      config:
+        type: template
+        template: shelly-1pm
+        host: 192.168.178.21
+        channel: 0
+        method: power
+        scale: -1
+    energy:
+      source: meter
+      config:
+        type: template
+        template: shelly-1pm
+        host: 192.168.178.21
+        channel: 0
+        method: energy
+    soc:
+      source: mqtt
+      topic: Haus/Batterie
+      jq: .soc
+      timeout: 60s
+```
+
+In this example, a Shelly 1PM device is used as a data source for power and energy of a battery, while the state of charge (SoC) is retrieved via MQTT.


### PR DESCRIPTION
fixes #811

Add documentation for the meter plugin which allows using another meter device as a data source. This is useful for reusing existing devices with multiple methods or attributes.