### PR TITLE
docs(fix): token vs. api key terminology clarification for energyforecast

### DIFF
--- a/templates/nightly/de/tariff/energy-forecast.yaml
+++ b/templates/nightly/de/tariff/energy-forecast.yaml
@@ -24,7 +24,7 @@ params:
     default:
     choice: []
     unit:
-    description: Token
+    description: Token / API Key
     help:
     advanced: false
     optional: false

--- a/templates/nightly/en/tariff/energy-forecast.yaml
+++ b/templates/nightly/en/tariff/energy-forecast.yaml
@@ -24,7 +24,7 @@ params:
     default:
     choice: []
     unit:
-    description: Token
+    description: Token / API Key
     help:
     advanced: false
     optional: false

--- a/templates/release/de/tariff/energy-forecast.yaml
+++ b/templates/release/de/tariff/energy-forecast.yaml
@@ -23,7 +23,7 @@ params:
     default:
     choice: []
     unit:
-    description: Token
+    description: Token / API Key
     help:
     advanced: false
     optional: false

--- a/templates/release/en/tariff/energy-forecast.yaml
+++ b/templates/release/en/tariff/energy-forecast.yaml
@@ -23,7 +23,7 @@ params:
     default:
     choice: []
     unit:
-    description: Token
+    description: Token / API Key
     help:
     advanced: false
     optional: false


### PR DESCRIPTION
Terminology clarification. evcc-io/docs uses "token" while energyforecast uses "api key". This should address questions like [this one](https://github.com/evcc-io/evcc/discussions/14211#discussioncomment-15001318). Further details/terminology per https://www.energyforecast.de/api_keys documentation.