### PR TITLE
Add documentation for charger Pracht Alpha Duo

### DIFF
--- a/templates/release/de/charger/pracht-alpha-duo.yaml
+++ b/templates/release/de/charger/pracht-alpha-duo.yaml
@@ -1,0 +1,70 @@
+template: pracht-alpha
+product:
+  identifier: pracht-alpha-duo
+  brand: Pracht
+  description: Alpha Duo
+requirements: ["sponsorship"]
+description: |
+  Eine Pracht Alpha Duo wird als zwei Pracht Alpha Mono mit unterschiedlichen `connector` Werten konfiguriert.
+  
+  Eine Identifikation des Fahrzeugs über die RFID Karte ist nicht möglich.
+  
+  Um Kommunikationsprobleme durch die doppelte Verbindung zu verhindern, empfiehlt es sich einen [`modbusproxy`](/docs/reference/configuration/modbusproxy) einzurichten.
+  Die Wallbox kommuniziert per `Modbus RTU` mit `baudrate: 9600`, `comset: "8N1"` und `id: 1`.
+  
+  In der Beispielkonfiguration ist der `modbusproxy` unter `host: 127.0.0.1` und `port: 5021` erreichbar.
+  
+  Verbindungen zum `modbusproxy` nutzen immer `modbus: tcpip`.
+  
+  Beispiel ist für den linken Ladepunkt. Tipp: Nutze `name: pracht_links`
+  
+  Füge den rechten Ladepunkt als Kopie linken hinzu und ändere `connector:` zu `2`, sowie `name` z.B. zu `pracht_rechts`.
+  
+render:
+  - default: |
+      type: template
+      template: pracht-alpha
+
+      # Modbus TCP zur Verbindung zu modbusproxy
+      modbus: tcpip
+      id: 1
+      host: 127.0.0.1 # modbusproxy
+      port: 5021 # modbusproxy
+      connector: 1 # Linker Ladepunkt
+      timeout: 10s # Zeitüberschreitung, optional
+
+params:
+  - name: modbus
+    example:
+    default:
+    choice: ['tcpip']
+    unit:
+    description: Modbus Typ. tcpip für Proxy
+    help:
+    advanced: false
+    optional: true
+  - name: timeout
+    example: 10s
+    default:
+    choice: []
+    unit:
+    description: Zeitüberschreitung
+    help:
+    advanced: false
+    optional: true
+  - name: connector
+    example:
+    default: 1
+    choice: []
+    unit:
+    description: Ladepunkt (1 für den Linken Ladepunkt, 2 für den rechten Ladepunkt)
+    help:
+    advanced: true
+    optional: true
+modbus:  # Verbindung zum modbusproxy
+  host: 127.0.0.1 # modbusproxy
+  id: 1
+  port: 5021 # modbusproxy
+  rs485serial: false
+  rs485tcpip: false
+  tcpip: true

--- a/templates/release/en/charger/pracht-alpha-duo.yaml
+++ b/templates/release/en/charger/pracht-alpha-duo.yaml
@@ -1,0 +1,71 @@
+template: pracht-alpha
+product:
+  identifier: pracht-alpha-duo
+  brand: Pracht
+  description: Alpha Duo
+requirements: ["sponsorship"]
+description: |
+  A Pracht Alpha Duo is configured as two Pracht Alpha Mono chargers with modified `connector` settings.
+  
+  Vehicle identification via RFID is not possible.
+  
+  Configure [`modbusproxy`](/docs/reference/configuration/modbusproxy) so there are no connection issues caused by using multiple connections.
+  
+  The wallbox uses `Modbus RTU` with `baudrate: 9600`, `comset: "8N1"` and `id: 1`.
+  
+  In the example below, the `modbusproxy` can be reached on `host: 127.0.0.1` and `port: 5021`.
+  
+  Connections to `modbusproxy` must use `modbus: tcpip`.
+  
+  Example configuration for the left Loadpoint. Tipp: Use `name: pracht_left`
+  
+  Add the right Loadpoint as a copy of the left Loadpoint und change `connector:` to `2`, and `name` e.g. to `pracht_right`.
+  
+render:
+  - default: |
+      type: template
+      template: pracht-alpha
+
+      # Modbus TCP for connecting to modbusproxy
+      modbus: tcpip
+      id: 1
+      host: 127.0.0.1 # modbusproxy
+      port: 5021 # modbusproxy
+      connector: 1 # left Loadpoint
+      timeout: 10s # Timeout, optional
+
+params:
+  - name: modbus
+    example:
+    default:
+    choice: ['tcpip']
+    unit:
+    description: Modbus Typ. tcpip for proxy
+    help:
+    advanced: false
+    optional: true
+  - name: timeout
+    example: 10s
+    default:
+    choice: []
+    unit:
+    description: Timeout
+    help:
+    advanced: false
+    optional: true
+  - name: connector
+    example:
+    default: 1
+    choice: []
+    unit:
+    description: Loadpoint (1 for the left Loadpoint, 2 for the right Loadpoint)
+    help:
+    advanced: true
+    optional: true
+modbus:  # connection to modbusproxy
+  host: 127.0.0.1 # modbusproxy
+  id: 1
+  port: 5021 # modbusproxy
+  rs485serial: false
+  rs485tcpip: false
+  tcpip: true


### PR DESCRIPTION
Uses modbusproxy so there are no issues caused by the two concurrent connections.