### PR TITLE
Fix uppercase typo in configuration for maxPower (circuit)

### DIFF
--- a/docs/features/loadmanagement.mdx
+++ b/docs/features/loadmanagement.mdx
@@ -127,7 +127,7 @@ circuits:
     title: Hauptsicherung
     maxCurrent: 48
     GetMaxCurrent:
-      souce: mqtt
+      source: mqtt
       topic: ext/maxcurrent
     maxPower: 33000
     GetMaxPower:

--- a/i18n/en/docusaurus-plugin-content-docs/current/features/loadmanagement.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/features/loadmanagement.mdx
@@ -125,7 +125,7 @@ circuits:
     title: "main circuit"
     maxCurrent: 48
     GetMaxCurrent:
-      souce: mqtt
+      source: mqtt
       topic: ext/maxcurrent
     maxPower: 33000
     GetMaxPower:


### PR DESCRIPTION
Noticed this very small case typo about maxPower.