### PR TITLE
Fix typo in example code

### DIFF
--- a/docs/features/loadmanagement.mdx
+++ b/docs/features/loadmanagement.mdx
@@ -127,7 +127,7 @@ circuits:
     title: Hauptsicherung
     maxCurrent: 48
     GetMaxCurrent:
-      souce: mqtt
+      source: mqtt
       topic: ext/maxcurrent
     maxpower: 33000
     GetMaxPower:


### PR DESCRIPTION
There is a "r" missing in the example code, "souce" instead of "source"