### PR TITLE
Added installation and upgrade manual for evcc on FreeBSD.

### DIFF
--- a/src/content/docs/de/installation/configuration.mdx
+++ b/src/content/docs/de/installation/configuration.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Einrichtung"
 sidebar:
-  order: 10
+  order: 11
 ---
 
 import { Tabs, TabItem, Steps } from "@astrojs/starlight/components";

--- a/src/content/docs/de/installation/freebsd.mdx
+++ b/src/content/docs/de/installation/freebsd.mdx
@@ -1,0 +1,110 @@
+---
+title: "FreeBSD"
+sidebar:
+  order: 9
+---
+
+import { Steps } from "@astrojs/starlight/components";
+
+Diese Anleitung beschreibt die Installation auf FreeBSD über das offizielle [Paket aus den FreeBSD Ports](https://cgit.freebsd.org/ports/tree/www/evcc).
+
+## Erstinstallation
+
+<Steps>
+
+1. ### Installieren
+
+   Öffne ein Terminal als root und installiere evcc:
+
+   ```sh
+   pkg install evcc
+   ```
+
+2. ### Starten
+
+   Aktiviere den Dienst beim Systemstart und starte ihn:
+
+   ```sh
+   sysrc evcc_enable="YES"
+   service evcc start
+   ```
+
+3. ### Einrichten
+
+   Öffne die evcc Oberfläche in deinem Browser: [http://localhost:7070](http://localhost:7070).
+   Vergib ein Administrator-Passwort und richte deine Geräte direkt über die Weboberfläche ein.
+
+</Steps>
+
+## Konfiguration
+
+:::tip[Empfohlen]
+Richte evcc direkt im Browser ein.
+:::
+
+Nach dem ersten Start kannst du deine evcc Instanz unter [http://localhost:7070](http://localhost:7070) konfigurieren.
+Die Einstellungen werden automatisch in der Datenbank gespeichert.
+
+Alternativ kannst du eine `evcc.yaml` Konfigurationsdatei unter `/usr/local/etc/evcc.yaml` ablegen.
+Details findest du unter [Einrichtung](./configuration).
+
+## Aktualisierung
+
+Um auf eine neue Version zu aktualisieren, führe folgende Schritte durch:
+
+- Prüfe die [Releases](https://github.com/evcc-io/evcc/releases) auf Breaking Changes (BC), die deine Installation betreffen
+- Öffne ein Terminal als root
+- Aktualisiere evcc:
+
+  ```sh
+  pkg upgrade evcc
+  ```
+
+- Starte den Dienst neu:
+
+  ```sh
+  service evcc restart
+  ```
+
+## Weitere Befehle
+
+- Status des evcc-Servers prüfen:
+
+  ```sh
+  service evcc status
+  ```
+
+- Logs anzeigen:
+
+  ```sh
+  tail -f /var/log/evcc.log
+  ```
+
+## nginx als Reverse Proxy
+
+Wenn bereits ein nginx läuft, kann dieser mit einem neuen Virtualhost-Eintrag ergänzt werden:
+
+```nginx
+server {
+  ...
+  server_name evcc.<your-domain>
+  ...
+  location / {
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header Host $http_host;
+
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
+
+    proxy_redirect off;
+    proxy_read_timeout 240s;
+
+    proxy_http_version 1.1;
+
+    proxy_pass http://127.0.0.1:7070;
+  }
+}
+```
+
+Anschließend ist die evcc Oberfläche unter `http://evcc.<your-domain>/` erreichbar.

--- a/src/content/docs/de/installation/index.mdx
+++ b/src/content/docs/de/installation/index.mdx
@@ -45,6 +45,11 @@ Falls du mehr über die Funktionsweise von Wallboxen und E-Auto-Laden erfahren m
     description="Via Homebrew."
   />
   <NavCard
+    to="/de/installation/freebsd"
+    title="FreeBSD"
+    description="Via pkg."
+  />
+  <NavCard
     to="/de/installation/windows"
     title="Windows"
     description="Manuelle Installation. Nicht empfohlen aber geht."

--- a/src/content/docs/de/installation/windows.mdx
+++ b/src/content/docs/de/installation/windows.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Windows"
 sidebar:
-  order: 9
+  order: 10
 ---
 
 import { Steps } from "@astrojs/starlight/components";

--- a/src/content/docs/en/installation/configuration.mdx
+++ b/src/content/docs/en/installation/configuration.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Configuration"
 sidebar:
-  order: 10
+  order: 11
 ---
 
 import { Tabs, TabItem, Steps } from "@astrojs/starlight/components";

--- a/src/content/docs/en/installation/freebsd.mdx
+++ b/src/content/docs/en/installation/freebsd.mdx
@@ -1,0 +1,110 @@
+---
+title: "FreeBSD"
+sidebar:
+  order: 9
+---
+
+import { Steps } from "@astrojs/starlight/components";
+
+This guide describes the installation on FreeBSD using the official [package from the FreeBSD Ports tree](https://cgit.freebsd.org/ports/tree/www/evcc).
+
+## Installation
+
+<Steps>
+
+1. ### Install
+
+   Open a terminal as root and install evcc:
+
+   ```sh
+   pkg install evcc
+   ```
+
+2. ### Start
+
+   Enable the service at boot and start it:
+
+   ```sh
+   sysrc evcc_enable="YES"
+   service evcc start
+   ```
+
+3. ### Set Up
+
+   Open the evcc interface in your browser: [http://localhost:7070](http://localhost:7070).
+   Set an administrator password and configure your devices directly via the web interface.
+
+</Steps>
+
+## Configuration
+
+:::tip[Recommended]
+Configure evcc directly in your browser.
+:::
+
+After the first start, you can configure your evcc instance at [http://localhost:7070](http://localhost:7070).
+Settings are automatically saved in the database.
+
+Alternatively, you can use an `evcc.yaml` configuration file at `/usr/local/etc/evcc.yaml`.
+Details can be found in [Configuration](./configuration).
+
+## Upgrades
+
+To upgrade to a new version, perform the following steps:
+
+- Check the [releases](https://github.com/evcc-io/evcc/releases) for breaking changes (BC) affecting your installation
+- Open a terminal as root
+- Upgrade evcc:
+
+  ```sh
+  pkg upgrade evcc
+  ```
+
+- Restart the service:
+
+  ```sh
+  service evcc restart
+  ```
+
+## Additional Commands
+
+- Check the status of the evcc server:
+
+  ```sh
+  service evcc status
+  ```
+
+- View logs:
+
+  ```sh
+  tail -f /var/log/evcc.log
+  ```
+
+## nginx as Reverse Proxy
+
+If you already have nginx running, add a new virtualhost with the following configuration:
+
+```nginx
+server {
+  ...
+  server_name evcc.<your-domain>
+  ...
+  location / {
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header Host $http_host;
+
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
+
+    proxy_redirect off;
+    proxy_read_timeout 240s;
+
+    proxy_http_version 1.1;
+
+    proxy_pass http://127.0.0.1:7070;
+  }
+}
+```
+
+The evcc interface will then be available at `http://evcc.<your-domain>/`.

--- a/src/content/docs/en/installation/index.mdx
+++ b/src/content/docs/en/installation/index.mdx
@@ -45,6 +45,11 @@ If you want to learn more about how wallboxes and EV charging work, first check 
     description="Via Homebrew."
   />
   <NavCard
+    to="/en/installation/freebsd"
+    title="FreeBSD"
+    description="Via pkg."
+  />
+  <NavCard
     to="/en/installation/windows"
     title="Windows"
     description="Manual installation. Not recommended but works."

--- a/src/content/docs/en/installation/windows.mdx
+++ b/src/content/docs/en/installation/windows.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Windows"
 sidebar:
-  order: 9
+  order: 10
 ---
 
 import { Steps } from "@astrojs/starlight/components";


### PR DESCRIPTION
The evcc FreeBSD package was added with commit:
https://cgit.freebsd.org/ports/commit/?id=d1cd65d39dca2bfa2ab96938df1a5f8b54385a54