### PR TITLE
Loadmanagement: document rebalancing limitions

### DIFF
--- a/src/content/docs/de/features/loadmanagement.mdx
+++ b/src/content/docs/de/features/loadmanagement.mdx
@@ -51,7 +51,7 @@ loadpoints:
 Hier wird der **Hauptstromkreis** `main` definiert, der eine maximale Leistung von 30kW und eine maximale Phasen-Stromstärke von 63A hat.
 Die Ladepunkte _Garage_ und _Carport_ sind diesem Stromkreis zugeordnet.
 Da das Grid Meter diesem Stromkreis zugeordnet ist, wird die Ladeleistung der Ladepunkte so gedrosselt werden, dass am Netzanschluß die eingestellten Werte nicht überschritten werden.
-Ohne Zuordnung des Grid Meters wirken die eingestellten Grenzen direkt auf die Ladeleistung. Sollte an beiden Ladepunkten gleichzeitig ein 22kW Ladevorgang angefordert werden, drosselt die Regelung die Leistung auf jeweils 15kW, um das 30kW Limit (`maxPower`) nicht zu überschreiten.
+Ohne Zuordnung des Grid Meters wirken die eingestellten Grenzen direkt auf die Summe aller Ladepunkte.
 
 ### Beispiel: Verschachtelte Stromkreise
 
@@ -180,4 +180,6 @@ Private Nutzung mit kleineren Installationen wird kostenlos bleiben.
 
 - Die aktuellen Werte und Grenzen der einzelnen Schaltkreise werden auf der Konfigurationsseite im UI angezeigt. Die Visualisierung am Ladepunkt ist in Planung.
 - `priority` Einstellungen am Ladepunkt werden noch nicht berücksichtigt.
+- Neue Ladevorgänge erhalten nur den verbleibenden Spielraum im Stromkreis.
+  Eine aktive Umverteilung auf laufende Ladevorgänge wird noch nicht unterstützt.
 - [Netzladen](./battery#gridcharge) der Hausbatterie wird nicht berücksichtigt. Wenn die Hausbatterie aktiv aus dem Netz lädt, fließt dieser Verbrauch nicht in die Lastmanagement-Berechnung ein. Bei aktivem [§14a Reduzierungssignal](./external-control) wird das Netzladen jedoch automatisch pausiert.

--- a/src/content/docs/en/features/loadmanagement.mdx
+++ b/src/content/docs/en/features/loadmanagement.mdx
@@ -50,7 +50,7 @@ The circuit has a maximum current of 63A.
 If there are other consumers like an oven/heat pump (this requires a meter) using a total of 50A, the charger will only be allowed to use 13A.
 The circuit has a limit of 30kW.
 Since the grid meter is assigned to this circuit, the power of the charging points will be throttled so that the limits ​​are not exceeded at the grid connection.
-Without the grid meter assigned, the limits directly affect the charge power. If there are 2 charging points that each request 22kW, they will both be dialed back to 15kW.
+Without the grid meter assigned, the limits apply directly to the sum of all charging points.
 
 ### Example: Nested Circuits
 
@@ -179,4 +179,6 @@ Private use with smaller installations will remain free of charge.
 
 - Current values and limits of individual circuits are displayed on the configuration page in the UI. Visualization at the charging point is planned.
 - `priority` settings at the charging point are not yet taken into account.
+- New sessions receive only the remaining circuit headroom.
+  Rebalancing across active sessions is not yet supported.
 - Home battery [grid charging](./battery#gridcharge) is not considered. When the home battery actively charges from the grid, this consumption is not included in load management calculations. However, during active [§14a power reduction](./external-control) signals, grid charging is automatically paused.


### PR DESCRIPTION
refs #30340

The example section implied active load balancing (sessions being dialled back equally), which doesn't match the actual first-come-first-served behaviour. Removed the incorrect claim and added a note to the Restrictions section that new sessions receive only the remaining circuit headroom and rebalancing is not yet supported.

\cc @MikeSND