### PR TITLE
devices: show sponsor requirement on list again

### DIFF
--- a/src/components/DeviceCardList.astro
+++ b/src/components/DeviceCardList.astro
@@ -30,13 +30,15 @@ interface Props {
   showCountries?: boolean;
   /** Render every device as its own top-level row (no brand grouping). */
   flat?: boolean;
-  /** Surface a coloured sponsor-token chip per device (required / free). */
-  showSponsorship?: boolean;
+  /** Surface the grey "sponsor free" chip on devices that need no token. */
+  showSponsorFree?: boolean;
+  /** Surface the green "sponsoring" chip on token-required devices. */
+  showSponsorRequired?: boolean;
   /** Stable identifier so the device filter can target this list (`data-device-list="…"`). */
   filterId?: string;
 }
 
-const { devices, lang, basePath, showUsages = false, showFeatures = true, showCountries = false, flat = false, showSponsorship = false, filterId } = Astro.props;
+const { devices, lang, basePath, showUsages = false, showFeatures = true, showCountries = false, flat = false, showSponsorFree = false, showSponsorRequired = false, filterId } = Astro.props;
 
 const NO_BRAND = lang === "de" ? "Sonstige" : "Other";
 
@@ -67,7 +69,7 @@ function usages(d: Device): string[] {
 }
 
 function features(d: Device): string[] {
-  return overviewFeaturesFor(d as any, { showSponsorship });
+  return overviewFeaturesFor(d as any, { showSponsorFree, showSponsorRequired });
 }
 
 function featureClass(f: string): string {
@@ -184,7 +186,7 @@ function brandColumns(list: Device[]): Slot[] {
                     <span class="tag tag-usages"><UsageIcons usages={u} lang={lang} /></span>
                   )}
                   {f.map((feat) => (
-                    <span class="tag tag-feature">{featureShortLabel(feat, lang)}</span>
+                    <span class={featureClass(feat)}>{featureShortLabel(feat, lang)}</span>
                   ))}
                   {c.map((country) => (
                     <span class="tag tag-country">{country}</span>

--- a/src/components/DeviceDetailLayout.astro
+++ b/src/components/DeviceDetailLayout.astro
@@ -67,6 +67,9 @@ const t =
           "Falls du die Konfiguration nicht über die Oberfläche vornehmen möchtest, kannst du alternativ diesen YAML-Block verwenden.",
         params: "Parameter",
         viewNightly: "Nightly-Version ansehen",
+        sponsorTitle: "Sponsortoken erforderlich",
+        sponsorBody:
+          "Dieses Gerät steht Unterstützern des Projekts zur Verfügung. Mehr zu unserem [Sponsoring-Modell](/de/sponsorship).",
       }
     : {
         config: "Configuration example for evcc.yaml",
@@ -74,6 +77,9 @@ const t =
           "If you don't want to configure via the UI, you can alternatively use this YAML block.",
         params: "Parameters",
         viewNightly: "View nightly version",
+        sponsorTitle: "Sponsor token required",
+        sponsorBody:
+          "This device is available to sponsors of the project. Read more about our [sponsorship model](/en/sponsorship).",
       };
 
 const nightlyBannerText =
@@ -99,7 +105,6 @@ const frontmatter = {
   <div class="device-detail" data-pagefind-ignore={isNightly ? "" : undefined}>
     <div class="device-header">
       <a class="device-back" href={overviewHref}>← {categoryLabel}</a>
-      {requiresSponsorship && <SponsorshipBadge variant="required" />}
       {isSponsorFree && <SponsorshipBadge variant="free" />}
     </div>
 
@@ -126,6 +131,21 @@ const frontmatter = {
     <DeviceFeatures features={visibleFeatures} lang={lang} />
 
     <slot name="after-features" />
+
+    {
+      requiresSponsorship && (
+        <aside
+          class="starlight-aside starlight-aside--tip"
+          aria-label={t.sponsorTitle}
+        >
+          <p class="starlight-aside__title">💚 {t.sponsorTitle}</p>
+          <div
+            class="starlight-aside__content"
+            set:html={renderMarkdown(t.sponsorBody)}
+          />
+        </aside>
+      )
+    }
 
     <div class="params-block">
       <div class="params-header">

--- a/src/components/SponsorInfoBox.astro
+++ b/src/components/SponsorInfoBox.astro
@@ -1,0 +1,24 @@
+---
+import { renderMarkdown } from "@utils/devices";
+
+interface Props {
+  lang: "de" | "en";
+}
+const { lang } = Astro.props;
+
+const t =
+  lang === "de"
+    ? {
+        title: "Sponsoring",
+        body: "Geräte mit diesem Label erfordern ein Sponsortoken. Mehr zu unserem [Sponsoring-Modell](/de/sponsorship).",
+      }
+    : {
+        title: "Sponsoring",
+        body: "Devices with this badge require a sponsor token. Read more about our [sponsorship model](/en/sponsorship).",
+      };
+---
+
+<aside class="starlight-aside starlight-aside--tip" aria-label={t.title}>
+  <p class="starlight-aside__title">💚 {t.title}</p>
+  <div class="starlight-aside__content" set:html={renderMarkdown(t.body)} />
+</aside>

--- a/src/components/SponsorshipBadge.astro
+++ b/src/components/SponsorshipBadge.astro
@@ -7,8 +7,8 @@ const lang = Astro.params.lang === "de" ? "de" : "en";
 
 const texts = {
   de: {
-    required: "Sponsor-Token erforderlich",
-    free: "Kein Sponsor-Token nötig",
+    required: "Sponsortoken erforderlich",
+    free: "Kein Sponsortoken nötig",
   },
   en: {
     required: "Sponsor token required",

--- a/src/components/SponsorshipRequired.astro
+++ b/src/components/SponsorshipRequired.astro
@@ -3,7 +3,7 @@ const lang = Astro.params.lang === "de" ? "de" : "en";
 
 const texts = {
   de: {
-    label: "Sponsor-Token erforderlich",
+    label: "Sponsortoken erforderlich",
     href: "/de/sponsorship",
   },
   en: {

--- a/src/components/features.ts
+++ b/src/components/features.ts
@@ -25,7 +25,7 @@ const shortLabels: Record<string, Partial<Record<Lang, string>>> = {
   "iso15118-2": { de: "ISO", en: "ISO" },
   dim: { de: "dimmbar", en: "dimmable" },
   curtail: { de: "abregelbar", en: "curtailable" },
-  sponsorship: { de: "Sponsor", en: "sponsor" },
+  sponsorship: { de: "Sponsoring", en: "sponsoring" },
   sponsorfree: { de: "sponsorfrei", en: "sponsor free" },
 };
 

--- a/src/components/lists/ChargersList.astro
+++ b/src/components/lists/ChargersList.astro
@@ -6,6 +6,7 @@ import DeviceFilter from "@components/DeviceFilter.astro";
 import ChargersIntro from "@components/intros/ChargersIntro.astro";
 import UserDefinedHint from "@components/UserDefinedHint.astro";
 import ChannelListNav from "@components/ChannelListNav.astro";
+import SponsorInfoBox from "@components/SponsorInfoBox.astro";
 import {
   sortDevices,
   filterByType,
@@ -29,7 +30,7 @@ const basePath = `/${lang}${isNightly ? "/nightly" : ""}/chargers`;
 const branded = allDevices.filter((d: any) => (d.data.product.brand || "").trim());
 const generic = allDevices.filter((d: any) => !(d.data.product.brand || "").trim());
 
-const filterFeatures = availableOverviewFeatures(allDevices as any, { showSponsorship: true });
+const filterFeatures = availableOverviewFeatures(allDevices as any, { showSponsorFree: true });
 
 const title = lang === "de" ? "Wallboxen" : "Chargers";
 const description =
@@ -39,6 +40,10 @@ const description =
 
 const supportedTitle = lang === "de" ? "Unterstützte Geräte" : "Supported devices";
 const genericTitle = lang === "de" ? "Generische Unterstützung" : "Generic support";
+
+const hasSponsorship = allDevices.some((d: any) =>
+  (d.data.requirements ?? []).includes("sponsorship"),
+);
 
 const headings = lang === "de"
   ? [
@@ -65,14 +70,15 @@ const frontmatter = {
 <StarlightPage frontmatter={frontmatter} headings={headings}>
   {channel === "nightly" && <ChannelListNav lang={lang} channel={channel} category="chargers" />}
   <ChargersIntro lang={lang} />
+  {hasSponsorship && <SponsorInfoBox lang={lang} />}
   <DeviceFilter lang={lang} features={filterFeatures} />
   <h2 id="supported">{supportedTitle}</h2>
-  <DeviceCardList devices={branded as any} lang={lang} basePath={basePath} showSponsorship filterId="branded" />
+  <DeviceCardList devices={branded as any} lang={lang} basePath={basePath} showSponsorFree showSponsorRequired filterId="branded" />
 
   {generic.length > 0 && (
     <>
       <h2 id="generic">{genericTitle}</h2>
-      <DeviceCardList devices={generic as any} lang={lang} basePath={basePath} showSponsorship flat filterId="generic" />
+      <DeviceCardList devices={generic as any} lang={lang} basePath={basePath} showSponsorFree showSponsorRequired flat filterId="generic" />
     </>
   )}
   {channel === "release" && (

--- a/src/components/lists/HeatingList.astro
+++ b/src/components/lists/HeatingList.astro
@@ -7,6 +7,7 @@ import HeatingIntro from "@components/intros/HeatingIntro.astro";
 import HeatingOutro from "@components/intros/HeatingOutro.astro";
 import UserDefinedHint from "@components/UserDefinedHint.astro";
 import ChannelListNav from "@components/ChannelListNav.astro";
+import SponsorInfoBox from "@components/SponsorInfoBox.astro";
 import {
   sortDevices,
   filterByType,
@@ -27,6 +28,10 @@ const coll = await getCollection(collectionName("chargers", lang, channel) as an
 const devices = sortDevices(filterByType(coll as any, "heating"));
 const basePath = `/${lang}${isNightly ? "/nightly" : ""}/heating`;
 const filterFeatures = availableOverviewFeatures(devices as any);
+
+const hasSponsorship = devices.some((d: any) =>
+  (d.data.requirements ?? []).includes("sponsorship"),
+);
 
 const supportedTitle = lang === "de" ? "Unterstützte Geräte" : "Supported devices";
 const title = lang === "de" ? "Wärmepumpen, Heizstäbe" : "Heat pumps, electric heaters";
@@ -64,9 +69,10 @@ const frontmatter = {
 <StarlightPage frontmatter={frontmatter} headings={headings}>
   {channel === "nightly" && <ChannelListNav lang={lang} channel={channel} category="heating" />}
   <HeatingIntro lang={lang} />
+  {hasSponsorship && <SponsorInfoBox lang={lang} />}
   {filterFeatures.length > 0 && <DeviceFilter lang={lang} features={filterFeatures} />}
   <h2 id="supported">{supportedTitle}</h2>
-  <DeviceCardList devices={devices as any} lang={lang} basePath={basePath} filterId="branded" />
+  <DeviceCardList devices={devices as any} lang={lang} basePath={basePath} showSponsorRequired filterId="branded" />
   <HeatingOutro lang={lang} />
   {channel === "release" && (
     <UserDefinedHint lang={lang} nightlyHref={`/${lang}/nightly/heating`} />

--- a/src/components/lists/MetersList.astro
+++ b/src/components/lists/MetersList.astro
@@ -6,6 +6,7 @@ import DeviceFilter from "@components/DeviceFilter.astro";
 import MetersIntro from "@components/intros/MetersIntro.astro";
 import UserDefinedHint from "@components/UserDefinedHint.astro";
 import ChannelListNav from "@components/ChannelListNav.astro";
+import SponsorInfoBox from "@components/SponsorInfoBox.astro";
 import {
   sortDevices,
   availableOverviewFeatures,
@@ -31,6 +32,10 @@ const generic = allDevices.filter((d: any) => !(d.data.product.brand || "").trim
 
 const filterFeatures = availableOverviewFeatures(allDevices as any);
 const filterUsages = availableUsages(allDevices as any);
+
+const hasSponsorship = allDevices.some((d: any) =>
+  (d.data.requirements ?? []).includes("sponsorship"),
+);
 
 const title = lang === "de" ? "PV, Batterie, Netz, Zähler" : "PV, Battery, Grid, Meter";
 const description =
@@ -70,6 +75,7 @@ const frontmatter = {
 <StarlightPage frontmatter={frontmatter} headings={headings}>
   {channel === "nightly" && <ChannelListNav lang={lang} channel={channel} category="meters" />}
   <MetersIntro lang={lang} />
+  {hasSponsorship && <SponsorInfoBox lang={lang} />}
   <DeviceFilter lang={lang} features={filterFeatures} usages={filterUsages} />
   <h2 id="supported">{supportedTitle}</h2>
   <DeviceCardList
@@ -77,6 +83,7 @@ const frontmatter = {
     lang={lang}
     basePath={basePath}
     showUsages={true}
+    showSponsorRequired={true}
     filterId="branded"
   />
 
@@ -88,6 +95,7 @@ const frontmatter = {
         lang={lang}
         basePath={basePath}
         showUsages={true}
+        showSponsorRequired={true}
         flat
         filterId="generic"
       />

--- a/src/components/lists/SmartswitchesList.astro
+++ b/src/components/lists/SmartswitchesList.astro
@@ -6,6 +6,7 @@ import DeviceFilter from "@components/DeviceFilter.astro";
 import SmartswitchesIntro from "@components/intros/SmartswitchesIntro.astro";
 import UserDefinedHint from "@components/UserDefinedHint.astro";
 import ChannelListNav from "@components/ChannelListNav.astro";
+import SponsorInfoBox from "@components/SponsorInfoBox.astro";
 import {
   sortDevices,
   filterByType,
@@ -26,6 +27,10 @@ const coll = await getCollection(collectionName("chargers", lang, channel) as an
 const devices = sortDevices(filterByType(coll as any, "smartswitch"));
 const basePath = `/${lang}${isNightly ? "/nightly" : ""}/smartswitches`;
 const filterFeatures = availableOverviewFeatures(devices as any);
+
+const hasSponsorship = devices.some((d: any) =>
+  (d.data.requirements ?? []).includes("sponsorship"),
+);
 
 const supportedTitle = lang === "de" ? "Unterstützte Geräte" : "Supported devices";
 const title = lang === "de" ? "Smarte Schalter" : "Smart switches";
@@ -57,9 +62,10 @@ const frontmatter = {
 <StarlightPage frontmatter={frontmatter} headings={headings}>
   {channel === "nightly" && <ChannelListNav lang={lang} channel={channel} category="smartswitches" />}
   <SmartswitchesIntro lang={lang} />
+  {hasSponsorship && <SponsorInfoBox lang={lang} />}
   {filterFeatures.length > 0 && <DeviceFilter lang={lang} features={filterFeatures} />}
   <h2 id="supported">{supportedTitle}</h2>
-  <DeviceCardList devices={devices as any} lang={lang} basePath={basePath} filterId="branded" />
+  <DeviceCardList devices={devices as any} lang={lang} basePath={basePath} showSponsorRequired filterId="branded" />
   {channel === "release" && (
     <UserDefinedHint lang={lang} nightlyHref={`/${lang}/nightly/smartswitches`} />
   )}

--- a/src/components/lists/VehiclesList.astro
+++ b/src/components/lists/VehiclesList.astro
@@ -6,6 +6,7 @@ import DeviceFilter from "@components/DeviceFilter.astro";
 import VehiclesIntro from "@components/intros/VehiclesIntro.astro";
 import UserDefinedHint from "@components/UserDefinedHint.astro";
 import ChannelListNav from "@components/ChannelListNav.astro";
+import SponsorInfoBox from "@components/SponsorInfoBox.astro";
 import {
   sortDevices,
   availableOverviewFeatures,
@@ -29,6 +30,10 @@ const branded = allDevices.filter((d: any) => (d.data.product.brand || "").trim(
 const generic = allDevices.filter((d: any) => !(d.data.product.brand || "").trim());
 
 const filterFeatures = availableOverviewFeatures(allDevices as any);
+
+const hasSponsorship = allDevices.some((d: any) =>
+  (d.data.requirements ?? []).includes("sponsorship"),
+);
 
 const title = lang === "de" ? "Fahrzeuge" : "Vehicles";
 const description =
@@ -62,14 +67,15 @@ const frontmatter = {
 <StarlightPage frontmatter={frontmatter} headings={headings}>
   {channel === "nightly" && <ChannelListNav lang={lang} channel={channel} category="vehicles" />}
   <VehiclesIntro lang={lang} />
+  {hasSponsorship && <SponsorInfoBox lang={lang} />}
   <DeviceFilter lang={lang} features={filterFeatures} />
   <h2 id="supported">{supportedTitle}</h2>
-  <DeviceCardList devices={branded as any} lang={lang} basePath={basePath} filterId="branded" />
+  <DeviceCardList devices={branded as any} lang={lang} basePath={basePath} showSponsorRequired filterId="branded" />
 
   {generic.length > 0 && (
     <>
       <h2 id="generic">{genericTitle}</h2>
-      <DeviceCardList devices={generic as any} lang={lang} basePath={basePath} flat filterId="generic" />
+      <DeviceCardList devices={generic as any} lang={lang} basePath={basePath} showSponsorRequired flat filterId="generic" />
     </>
   )}
   {channel === "release" && (

--- a/src/utils/devices.ts
+++ b/src/utils/devices.ts
@@ -390,7 +390,9 @@ export async function deviceDetailPaths(opts: {
     const otherColl = await getCollection(
       collectionName(prefix, lang, other) as any,
     );
-    const otherById = new Map(otherColl.map((e: any) => [e.id, e]));
+    const otherById = new Map<string, any>(
+      otherColl.map((e: any) => [e.id, e] as [string, any]),
+    );
     const list = filterType
       ? filterByType(coll as any, filterType)
       : (coll as any[]);

--- a/src/utils/devices.ts
+++ b/src/utils/devices.ts
@@ -229,18 +229,19 @@ const OVERVIEW_HIDDEN = new Set([
 
 export function overviewFeaturesFor(
   d: DeviceEntry,
-  opts: { showSponsorship?: boolean } = {},
+  opts: { showSponsorFree?: boolean; showSponsorRequired?: boolean } = {},
 ): string[] {
   const base = [
     ...(d.data.capabilities ?? []),
     ...(d.data.requirements ?? []),
   ].filter((f) => !OVERVIEW_HIDDEN.has(f));
-  if (
-    opts.showSponsorship &&
-    !(d.data.requirements ?? []).includes("sponsorship")
-  ) {
-    base.push("sponsorfree");
-  }
+  const requiresSponsorship = (d.data.requirements ?? []).includes(
+    "sponsorship",
+  );
+  // The two sponsor chips are independent: enable the green "sponsorship" chip,
+  // the grey "sponsorfree" inverse, or both.
+  if (opts.showSponsorRequired && requiresSponsorship) base.push("sponsorship");
+  if (opts.showSponsorFree && !requiresSponsorship) base.push("sponsorfree");
   return base;
 }
 
@@ -248,11 +249,13 @@ import { FEATURE_KEYS } from "@components/features";
 
 export function availableOverviewFeatures(
   devices: DeviceEntry[],
-  opts: { showSponsorship?: boolean } = {},
+  opts: { showSponsorFree?: boolean; showSponsorRequired?: boolean } = {},
 ): string[] {
   const seen = new Set<string>();
   for (const d of devices)
     for (const f of overviewFeaturesFor(d, opts)) seen.add(f);
+  // "sponsorship" is surfaced as a coloured row badge, not a filter toggle.
+  seen.delete("sponsorship");
   return [...seen].sort((a, b) => {
     const ia = FEATURE_KEYS.indexOf(a);
     const ib = FEATURE_KEYS.indexOf(b);
@@ -292,11 +295,11 @@ export function featuresFor(
     ...countryList,
   ].filter((f) => f !== "skiptest");
 
-  if (type === "charger") {
-    const idx = features.indexOf("sponsorship");
-    if (idx > -1) features.splice(idx, 1);
-    else features.push("sponsorfree");
-  }
+  // "sponsorship" is surfaced via the info box (and, for chargers, the grey
+  // "sponsorfree" inverse badge) — never as a plain feature chip.
+  const sponsorshipIdx = features.indexOf("sponsorship");
+  if (sponsorshipIdx > -1) features.splice(sponsorshipIdx, 1);
+  else if (type === "charger") features.push("sponsorfree");
 
   const eebusIdx = features.indexOf("eebus");
   if (eebusIdx > -1) features.splice(eebusIdx, 1);


### PR DESCRIPTION
fixes https://github.com/evcc-io/evcc/issues/30449

The Starlight migration https://github.com/evcc-io/docs/pull/1063 dropped the sponsor required info from the device list view. This PR readds it.

<img width="1580" height="1445" alt="Bildschirmfoto 2026-06-03 um 17 25 55" src="https://github.com/user-attachments/assets/00ab275c-2c0c-4dbf-85dd-4c9c2015c883" />

<img width="1580" height="1445" alt="Bildschirmfoto 2026-06-03 um 17 25 49" src="https://github.com/user-attachments/assets/7ff82c1c-cbaf-4037-9430-e875bbc73c5d" />
