### PR TITLE
FAQ: run password commands as evcc user

### DIFF
--- a/src/content/docs/de/faq.mdx
+++ b/src/content/docs/de/faq.mdx
@@ -275,7 +275,7 @@ Stelle sicher, dass du evcc stoppst, bevor du das Passwort änderst.
 
 ```bash
 service evcc stop
-EVCC_DATABASE_DSN=/var/lib/evcc/evcc.db evcc password set
+sudo -u evcc evcc password set --database /var/lib/evcc/evcc.db
 service evcc start
 ```
 
@@ -284,7 +284,7 @@ Dann wirst du beim nächsten Aufruf der evcc UI aufgefordert ein neues Passwort 
 
 ```bash
 service evcc stop
-EVCC_DATABASE_DSN=/var/lib/evcc/evcc.db evcc password reset
+sudo -u evcc evcc password reset --database /var/lib/evcc/evcc.db
 service evcc start
 ```
 

--- a/src/content/docs/en/faq.mdx
+++ b/src/content/docs/en/faq.mdx
@@ -283,7 +283,7 @@ Make sure to stop evcc before changing the password.
 
 ```bash
 service evcc stop
-EVCC_DATABASE_DSN=/var/lib/evcc/evcc.db evcc password set
+sudo -u evcc evcc password set --database /var/lib/evcc/evcc.db
 service evcc start
 ```
 
@@ -292,7 +292,7 @@ You'll be prompted to set a new password the next time you access the evcc UI.
 
 ```bash
 service evcc stop
-EVCC_DATABASE_DSN=/var/lib/evcc/evcc.db evcc password reset
+sudo -u evcc evcc password reset --database /var/lib/evcc/evcc.db
 service evcc start
 ```
 


### PR DESCRIPTION
pairs with evcc-io/evcc#30703

The documented password set/reset commands run evcc as the invoking login user. On package installs the database at /var/lib/evcc/evcc.db is owned by the evcc service user, so the database opens read-only and the command fails with "attempt to write a readonly database (8)".

Prefix the commands with sudo -u evcc and use the --database flag instead of the EVCC_DATABASE_DSN variable, since sudo's default env_reset policy does not pass command-line environment assignments without the SETENV tag.