### PR TITLE
Docker: recommend mounting the database directory as a named volume

### DIFF
--- a/src/content/docs/de/installation/docker.mdx
+++ b/src/content/docs/de/installation/docker.mdx
@@ -40,6 +40,12 @@ Erstelle das Datenbank-Verzeichnis auf deinem Host-System.
 In dieser Anleitung verwenden wir exemplarisch den Pfad `/home/user/.evcc/`.
 Falls du die dateibasierte Konfiguration nutzt, verwende zusätzlich `/home/user/evcc.yaml`
 
+:::tip[Das Verzeichnis einbinden, nicht die Datenbankdatei]
+Binde immer das **Verzeichnis** `/root/.evcc` ein — niemals eine einzelne `evcc.db` Datei. evcc legt die SQLite Datenbank zusammen mit ihren Begleitdateien (`evcc.db-wal` und `evcc.db-shm`) in diesem Verzeichnis ab, und alle müssen gemeinsam erhalten bleiben.
+
+Ein [Named Volume](https://docs.docker.com/engine/storage/volumes/) (`docker volume create evcc`, dann `evcc:/root/.evcc` einbinden) ist die robusteste Wahl: Es hält die Dateien zusammen und liegt auf dem nativen Dateisystem des Hosts, das die von SQLite benötigte Dateisperrung bereitstellt. Lege die Datenbank nicht auf einer Netzwerkfreigabe (NFS/SMB) ab und — bei Docker Desktop für macOS/Windows — nicht auf einem Bind Mount, da dies die SQLite-Sperrung beeinträchtigen kann.
+:::
+
 ## Installation
 
 In diesem Abschnitt werden drei Möglichkeiten zur Installation von evcc über Docker beschrieben.

--- a/src/content/docs/en/installation/docker.mdx
+++ b/src/content/docs/en/installation/docker.mdx
@@ -41,6 +41,12 @@ Create the database directory on your host system.
 In this guide we use the path `/home/user/.evcc/` as an example.
 If you're using file-based configuration, also use `/home/user/evcc.yaml`
 
+:::tip[Mount the directory, not the database file]
+Always mount the `/root/.evcc` **directory** — never a single `evcc.db` file. evcc keeps the SQLite database together with its sidecar files (`evcc.db-wal` and `evcc.db-shm`) in this directory, and all of them have to persist together.
+
+A [named volume](https://docs.docker.com/engine/storage/volumes/) (`docker volume create evcc`, then mount `evcc:/root/.evcc`) is the most robust choice: it keeps the files together and lives on the host's native filesystem, which provides the file locking SQLite needs. Avoid placing the database on a network share (NFS/SMB) or — on Docker Desktop for macOS/Windows — on a bind mount, as these can break SQLite locking.
+:::
+
 ## Installation
 
 This section describes three ways to install evcc using Docker:


### PR DESCRIPTION
Draft, queued to land with evcc-io/evcc#30903 (sqlite: enable WAL mode).

Adds a tip to the Docker installation page (en + de) clarifying that the `/root/.evcc` **directory** must be mounted, never a single `evcc.db` file, and recommending a named Docker volume.

Why: with WAL enabled, evcc keeps `evcc.db-wal` and `evcc.db-shm` next to the database; these sidecar files have to persist together with `evcc.db`. A named volume keeps them together and lives on the hosts native filesystem, which provides the file locking SQLite needs — bind mounts over network shares (NFS/SMB) or the Docker Desktop virtualized FS (macOS/Windows) can break SQLite locking.

The existing examples already bind-mount the directory (`/home/user/.evcc:/root/.evcc`), so they keep working; this only adds the explicit guidance and the named-volume recommendation. Kept as a draft so it merges alongside the WAL change rather than ahead of it.