### PR TITLE
Features: fix broken relative links (404 on trailing slash)

### DIFF
--- a/src/content/docs/de/features/battery.mdx
+++ b/src/content/docs/de/features/battery.mdx
@@ -170,4 +170,4 @@ Optional kannst du einen maximalen Ladestand festlegen, bis zu dem die Batterie 
 Erreicht die Batterie diesen Wert, wird das Netzladen automatisch gestoppt.
 Die Option **Maximaler Ladestand** (`maxsoc`) findest du in der Gerätekonfiguration deines Batteriesystems.
 
-Unter [PV, Batterie, Netz, Zähler](../meters) kannst du an dem Tag **aktive Batteriesteuerung** erkennen, ob dein System Batteriesteuerung unterstützt und ob `maxsoc` verfügbar ist.
+Unter [PV, Batterie, Netz, Zähler](/de/meters) kannst du an dem Tag **aktive Batteriesteuerung** erkennen, ob dein System Batteriesteuerung unterstützt und ob `maxsoc` verfügbar ist.

--- a/src/content/docs/de/features/co2.mdx
+++ b/src/content/docs/de/features/co2.mdx
@@ -27,7 +27,7 @@ tariffs:
 ```
 
 In diesem Beispiel verwenden wir die Daten von [GrünstromIndex.de](https://www.gruenstromindex.de/).
-Unter [Stromtarife](../tariffs) findest du eine Liste aller unterstützten Datenquellen.
+Unter [Stromtarife](/de/tariffs) findest du eine Liste aller unterstützten Datenquellen.
 
 ## Sauberes Netzladen
 

--- a/src/content/docs/de/features/dynamic-feedin.mdx
+++ b/src/content/docs/de/features/dynamic-feedin.mdx
@@ -6,7 +6,7 @@ sidebar:
 
 import Screenshot from "@components/Screenshot.astro";
 
-Diese Funktionen sind relevant, wenn du einen [dynamischen Einspeisetarif](../tariffs) (bspw. Direktvermarktung, Niederlande, Australien, ...) hast.
+Diese Funktionen sind relevant, wenn du einen [dynamischen Einspeisetarif](/de/tariffs) (bspw. Direktvermarktung, Niederlande, Australien, ...) hast.
 
 ## Einspeisung priorisieren
 

--- a/src/content/docs/de/features/dynamic-prices.mdx
+++ b/src/content/docs/de/features/dynamic-prices.mdx
@@ -58,7 +58,7 @@ tariffs:
     token: "..." # Access Token
 ```
 
-Unter [Stromtarife](../tariffs) findest du eine Liste aller unterstützten Tarife.
+Unter [Stromtarife](/de/tariffs) findest du eine Liste aller unterstützten Tarife.
 Wenn dein Anbieter eine Schnittstelle hat, aber noch nicht von evcc unterstützt wird, dann mach gerne einen [Feature Request](https://github.com/evcc-io/evcc/issues/new/choose) auf.
 
 ### Zeitabhängige Netzentgelte

--- a/src/content/docs/de/features/limits.mdx
+++ b/src/content/docs/de/features/limits.mdx
@@ -64,7 +64,7 @@ Wählst du beispielsweise ein Limit von 30 kWh aus, stoppt die Ladung, sobald di
 />
 
 Standardmäßig kannst du einen Wert in 5 kWh Schritten bis 100 kWh auswählen.
-Hast du die Akkukapazität deines Fahrzeugs in den [Fahrzeugeinstellungen](../reference/configuration/vehicles#capacity) hinterlegt, werden die Schritte entsprechend angepasst.
+Hast du die Akkukapazität deines Fahrzeugs in den [Fahrzeugeinstellungen](/de/reference/configuration/vehicles#capacity) hinterlegt, werden die Schritte entsprechend angepasst.
 Zusätzlich siehst du, wie vielen Akku-Prozenten die ausgewählte Energiemenge entspricht.
 
 Das eingestellte Energielimit gilt nur für den aktuellen Ladevorgang und wird beim Abstecken wieder entfernt.

--- a/src/content/docs/de/features/solar-charging.mdx
+++ b/src/content/docs/de/features/solar-charging.mdx
@@ -36,7 +36,7 @@ Die Mindestladeleistung ist abhängig von der Anzahl der Phasen, die Auto und Wa
 
 Die meisten Wallboxen sind heute dreiphasig (11 kW oder 22 kW) angebunden.
 Damit liegt die Mindestladeleistung bei 4,1 kW.
-Bei [Wallboxen mit automatischer Phasenumschaltung](../chargers#features) (1P/3P) kann evcc je nach Bedarf zwischen ein- und dreiphasig umschalten und die Ladung bereits bei 1,4 kW starten.
+Bei [Wallboxen mit automatischer Phasenumschaltung](/de/chargers#features) (1P/3P) kann evcc je nach Bedarf zwischen ein- und dreiphasig umschalten und die Ladung bereits bei 1,4 kW starten.
 
 Im **Energieflussdiagramm** wird die Einspeiseleistung dargestellt.
 Ist der Überschuss für eine gewisse Zeit oberhalb der Mindestladeleistung, startet die Ladung.

--- a/src/content/docs/de/features/vehicle.mdx
+++ b/src/content/docs/de/features/vehicle.mdx
@@ -46,7 +46,7 @@ Hinweis: Diese Funktion kannst du auch für Fremdfahrzeuge nutzen (Freunde, Fami
 ### Fahrzeuge mit API (Online)
 
 Hat dein Fahrzeug eine Online-Schnittstelle, ist es sinnvoll, diese auch in evcc zu konfigurieren.
-Unter [Fahrzeuge](../vehicles) findest du eine Liste aller unterstützten Hersteller.
+Unter [Fahrzeuge](/de/vehicles) findest du eine Liste aller unterstützten Hersteller.
 Die empfohlene Konfiguration erfolgt auch hier über die `evcc.yaml`. Hier ein Beispiel für einen Audi:
 
 ```yaml
@@ -66,7 +66,7 @@ Abhängig vom Hersteller sind auch weitere Informationen wie Ladestatus, Fahrzeu
 :::note[Hinweis]
 Um den Fahrzeugakku zu schonen, aktualisiert evcc den Ladestand nur, wenn ein Fahrzeug am Ladepunkt angeschlossen ist.
 Je nach Hersteller kann ein API-Zugriff zum Aufwecken des Fahrzeugs führen und den Standby-Verbrauch signifikant erhöhen.
-Dieses Verhalten kannst du über den [`poll` Parameter](../reference/configuration/loadpoints#poll) am Ladepunkt verändern.
+Dieses Verhalten kannst du über den [`poll` Parameter](/de/reference/configuration/loadpoints#poll) am Ladepunkt verändern.
 :::
 
 ## Mehrere Fahrzeuge

--- a/src/content/docs/en/features/battery.mdx
+++ b/src/content/docs/en/features/battery.mdx
@@ -168,4 +168,4 @@ Optionally, you can set a maximum charge level up to which the battery is charge
 When the battery reaches this value, grid charging is automatically stopped.
 The **Maximum charge** (`maxsoc`) option can be found in your battery system's device configuration.
 
-Under [PV, Battery, Grid, Meter](../meters) you can see on the **Active battery control** tag whether your system supports battery control and if `maxsoc` is available.
+Under [PV, Battery, Grid, Meter](/en/meters) you can see on the **Active battery control** tag whether your system supports battery control and if `maxsoc` is available.

--- a/src/content/docs/en/features/co2.mdx
+++ b/src/content/docs/en/features/co2.mdx
@@ -27,7 +27,7 @@ tariffs:
 ```
 
 In this example, we'll use data from GrünstromIndex.
-See [tariffs](../tariffs) for a list of all supported data sources.
+See [tariffs](/en/tariffs) for a list of all supported data sources.
 
 ## Clean web charging
 

--- a/src/content/docs/en/features/dynamic-feedin.mdx
+++ b/src/content/docs/en/features/dynamic-feedin.mdx
@@ -6,7 +6,7 @@ sidebar:
 
 import Screenshot from "@components/Screenshot.astro";
 
-These features are relevant if you have a [dynamic feed-in tariff](../tariffs) (e.g., direct marketing, Netherlands, Australia, etc.).
+These features are relevant if you have a [dynamic feed-in tariff](/en/tariffs) (e.g., direct marketing, Netherlands, Australia, etc.).
 
 ## Feed-in priority
 

--- a/src/content/docs/en/features/dynamic-prices.mdx
+++ b/src/content/docs/en/features/dynamic-prices.mdx
@@ -58,7 +58,7 @@ tariffs:
     token: "..." # Access Token
 ```
 
-You can find a list of all supported tariffs under [tariffs](../tariffs).
+You can find a list of all supported tariffs under [tariffs](/en/tariffs).
 If your provider has an interface but is not yet supported by evcc, please submit a [Feature Request](https://github.com/evcc-io/evcc/issues/new/choose).
 
 ### Time-based grid fees

--- a/src/content/docs/en/features/limits.mdx
+++ b/src/content/docs/en/features/limits.mdx
@@ -64,7 +64,7 @@ If, for example, you select a limit of 30 kWh, charging stops as soon as this am
 />
 
 By default, you can select a value in 5 kWh increments up to 100 kWh.
-If you have stored the battery capacity of your vehicle in the [vehicle parameters](../reference/configuration/vehicles#capacity), the increments will be adjusted accordingly.
+If you have stored the battery capacity of your vehicle in the [vehicle parameters](/en/reference/configuration/vehicles#capacity), the increments will be adjusted accordingly.
 You will also see how many percent of the battery the selected amount of energy corresponds to.
 
 The set energy limit only applies to the current charging process and is removed again when unplugged.

--- a/src/content/docs/en/features/solar-charging.mdx
+++ b/src/content/docs/en/features/solar-charging.mdx
@@ -36,7 +36,7 @@ The minimum charging power depends on the number of phases that the car and wall
 
 Most wallboxes today are connected three-phase (11 kW or 22 kW).
 This means that the minimum charging power is 4.1 kW.
-For [wallboxes with automatic phase switching](../chargers#features) (1P/3P), evcc can switch between single-phase and three-phase as required and start charging at just 1.4 kW.
+For [wallboxes with automatic phase switching](/en/chargers#features) (1P/3P), evcc can switch between single-phase and three-phase as required and start charging at just 1.4 kW.
 
 The feed-in power is shown in the **energy flow diagram**.
 If the surplus is above the minimum charging power for a certain period of time, charging starts.

--- a/src/content/docs/en/features/vehicle.mdx
+++ b/src/content/docs/en/features/vehicle.mdx
@@ -46,7 +46,7 @@ Note: You can also use this function for third-party vehicles (friends, family, 
 ### Vehicles with API (online)
 
 If your vehicle has an online interface, it makes sense to configure this in evcc as well.
-You can find a list of all supported manufacturers under [Vehicles](../vehicles).
+You can find a list of all supported manufacturers under [Vehicles](/en/vehicles).
 The recommended configuration is also done here via `evcc.yaml`. Here is an example for an Audi:
 
 ```yaml
@@ -66,7 +66,7 @@ Depending on the manufacturer, other information such as charging status, vehicl
 :::note[Note]
 To protect the vehicle battery, evcc only updates the charge level when a vehicle is connected to the charging point.
 Depending on the manufacturer, API access can wake up the vehicle and significantly increase standby consumption.
-You can change this behavior using the [`poll` parameter](../reference/configuration/loadpoints#poll) at the charging point.
+You can change this behavior using the [`poll` parameter](/en/reference/configuration/loadpoints#poll) at the charging point.
 :::
 
 ## Multiple vehicles


### PR DESCRIPTION
fixes #1095

Relative `../` links in the feature docs resolved one level too few under Starlight's trailing-slash URLs, producing 404s (e.g. the tariffs link reported in #1095 landed on `/en/features/tariffs` instead of `/en/tariffs`).

- Replaced every `../` link in `features/` with a locale-prefixed absolute link (`/en/...`, `/de/...`), per the repo linking convention.
- Fixes 16 links across en + de: tariffs, meters, vehicles, chargers, and config references.
- Sibling `./` links left as-is; they already resolve correctly.