### PR TITLE
EEBUS still documents yaml

### DIFF
--- a/src/content/docs/de/reference/configuration/eebus.md
+++ b/src/content/docs/de/reference/configuration/eebus.md
@@ -4,6 +4,10 @@ sidebar:
   order: 13
 ---
 
+:::note[veraltet in yaml]
+Komfortabler und selbsterklärend kann inzwischen EEBUS im UI Einstellungsdialog konfiguriert werden. Dafür den `eebus:` Block im yaml einfach auskommentieren. Dann generiert evcc beim nächsten start ein neues Zertifikat. Alternativ kannst im UI unter Erweiterte Einstellungen dein bisheriges public und private certificate bei importieren, aus deinem auskommentierten yaml Block. Das kann z.B. sinnvoll sein wenn die SKI, ein fester Bestandteil des public certificate, bereits für https://docs.evcc.io/de/features/external-control/ bei deinem Messstellenbetreiber hinterlegt wurde.
+:::
+
 **Beispiel**:
 
 ```yaml

--- a/src/content/docs/de/reference/configuration/eebus.md
+++ b/src/content/docs/de/reference/configuration/eebus.md
@@ -7,7 +7,7 @@ sidebar:
 :::note[veraltet in yaml]
 Komfortabler und selbsterklärend kann EEBUS inzwischen im UI-Einstellungsdialog konfiguriert werden. Dafür den `eebus:`-Block im yaml einfach auskommentieren. Dann generiert evcc beim nächsten Start ein neues Zertifikat.
 
-Alternativ kannst du im UI unter *Erweiterte Einstellungen* dein bisheriges public und private Zertifikat importieren, aus deinem auskommentierten yaml-Block. Das kann sinnvoll sein wenn die SKI (ein fester Bestandteil des public Zertifikats) bereits für [External Control](https://docs.evcc.io/de/features/external-control/) bei deinem Messstellenbetreiber hinterlegt wurde.
+Alternativ kannst du im UI unter *EEBUS > Erweiterte Einstellungen anzeigen* dein bisheriges public und private Zertifikat importieren, aus deinem auskommentierten yaml-Block. Das kann sinnvoll sein wenn die SKI (ein fester Bestandteil des public Zertifikats) bereits für [External Control](https://docs.evcc.io/de/features/external-control/) bei deinem Messstellenbetreiber hinterlegt wurde.
 :::
 
 **Beispiel**:

--- a/src/content/docs/de/reference/configuration/eebus.md
+++ b/src/content/docs/de/reference/configuration/eebus.md
@@ -5,7 +5,9 @@ sidebar:
 ---
 
 :::note[veraltet in yaml]
-Komfortabler und selbsterklärend kann inzwischen EEBUS im UI Einstellungsdialog konfiguriert werden. Dafür den `eebus:` Block im yaml einfach auskommentieren. Dann generiert evcc beim nächsten start ein neues Zertifikat. Alternativ kannst im UI unter Erweiterte Einstellungen dein bisheriges public und private certificate bei importieren, aus deinem auskommentierten yaml Block. Das kann z.B. sinnvoll sein wenn die SKI, ein fester Bestandteil des public certificate, bereits für https://docs.evcc.io/de/features/external-control/ bei deinem Messstellenbetreiber hinterlegt wurde.
+Komfortabler und selbsterklärend kann EEBUS inzwischen im UI-Einstellungsdialog konfiguriert werden. Dafür den `eebus:`-Block im yaml einfach auskommentieren. Dann generiert evcc beim nächsten Start ein neues Zertifikat.
+
+Alternativ kannst du im UI unter *Erweiterte Einstellungen* dein bisheriges public und private Zertifikat importieren, aus deinem auskommentierten yaml-Block. Das kann sinnvoll sein wenn die SKI (ein fester Bestandteil des public Zertifikats) bereits für [External Control](https://docs.evcc.io/de/features/external-control/) bei deinem Messstellenbetreiber hinterlegt wurde.
 :::
 
 **Beispiel**:

--- a/src/content/docs/de/reference/configuration/eebus.md
+++ b/src/content/docs/de/reference/configuration/eebus.md
@@ -7,7 +7,7 @@ sidebar:
 :::note[veraltet in yaml]
 Komfortabler und selbsterklärend kann EEBUS inzwischen im UI-Einstellungsdialog konfiguriert werden. Dafür den `eebus:`-Block im yaml einfach auskommentieren. Dann generiert evcc beim nächsten Start ein neues Zertifikat.
 
-Alternativ kannst du im UI unter *EEBUS > Erweiterte Einstellungen anzeigen* dein bisheriges public und private Zertifikat importieren, aus deinem auskommentierten yaml-Block. Das kann sinnvoll sein wenn die SKI (ein fester Bestandteil des public Zertifikats) bereits für [External Control](https://docs.evcc.io/de/features/external-control/) bei deinem Messstellenbetreiber hinterlegt wurde.
+Alternativ kannst du im UI unter _EEBUS > Erweiterte Einstellungen anzeigen_ dein bisheriges public und private Zertifikat importieren, aus deinem auskommentierten yaml-Block. Das kann sinnvoll sein wenn die SKI (ein fester Bestandteil des public Zertifikats) bereits für [External Control](https://docs.evcc.io/de/features/external-control/) bei deinem Messstellenbetreiber hinterlegt wurde.
 :::
 
 **Beispiel**:

--- a/src/content/docs/de/reference/configuration/eebus.md
+++ b/src/content/docs/de/reference/configuration/eebus.md
@@ -4,10 +4,9 @@ sidebar:
   order: 13
 ---
 
-:::note[veraltet in yaml]
-Komfortabler und selbsterklärend kann EEBUS inzwischen im UI-Einstellungsdialog konfiguriert werden. Dafür den `eebus:`-Block im yaml einfach auskommentieren. Dann generiert evcc beim nächsten Start ein neues Zertifikat.
-
-Alternativ kannst du im UI unter _EEBUS > Erweiterte Einstellungen anzeigen_ dein bisheriges public und private Zertifikat importieren, aus deinem auskommentierten yaml-Block. Das kann sinnvoll sein wenn die SKI (ein fester Bestandteil des public Zertifikats) bereits für [External Control](https://docs.evcc.io/de/features/external-control/) bei deinem Messstellenbetreiber hinterlegt wurde.
+:::tip[Empfehlung]
+Konfiguriere EEBus im UI unter **Konfiguration → EEBus**.
+Zertifikat und Kennungen werden beim ersten Start automatisch generiert.
 :::
 
 **Beispiel**:
@@ -28,6 +27,14 @@ eebus:
       -----END EC PRIVATE KEY-----
 ```
 
+:::note[Migration von YAML zum UI]
+Entferne den `eebus:`-Block aus deiner `evcc.yaml` und starte neu.
+Ein neues Zertifikat wird automatisch generiert und alle EEBus-Geräte müssen neu gekoppelt werden.
+
+Wenn du dein bisheriges Zertifikat behalten möchtest, trage es im EEBus-Dialog unter **Erweiterte Einstellungen anzeigen** ein.
+Das ist sinnvoll, wenn die SKI (Bestandteil des öffentlichen Zertifikats) bereits für die [externe Steuerung](/de/features/external-control) beim Netzbetreiber hinterlegt ist.
+:::
+
 ---
 
 ## Erforderliche Parameter
@@ -36,7 +43,7 @@ eebus:
 
 Definiert das zu verwendende Zertifikat und dessen privaten Schlüssel für die vorgeschriebene HTTPS Verbindung.
 
-Dieses kann über `evcc eebus-cert` erstellt werden.
+Bei der Konfiguration im UI wird das Zertifikat automatisch generiert.
 
 **Beispiel**:
 
@@ -88,7 +95,7 @@ private: |
 
 ### `interfaces`
 
-Definiert eine Liste von Netzwerkschnittstellen, über welche EEBUS kommunizieren soll. Standardmäßig werden alle Schnittstellen verwendet, dies kann jedoch zu Kommunikationsproblemen führen.
+Definiert eine Liste von Netzwerkschnittstellen, über welche EEBus kommunizieren soll. Standardmäßig werden alle Schnittstellen verwendet, dies kann jedoch zu Kommunikationsproblemen führen.
 
 **Beispiel**:
 

--- a/src/content/docs/en/reference/configuration/eebus.md
+++ b/src/content/docs/en/reference/configuration/eebus.md
@@ -7,7 +7,7 @@ sidebar:
 :::note[deprecated in yaml]
 EEBUS can now be configured more conveniently and self-explanatory via the UI settings dialog. Simply comment out the `eebus:` block in your yaml — evcc will generate a new certificate on the next start.
 
-Alternatively, you can import your existing public and private certificate under *Advanced Settings* in the UI, taken from your commented-out yaml block. This is useful if the SKI (part of the public certificate) has already been registered with your metering operator for [External Control](https://docs.evcc.io/en/features/external-control/).
+Alternatively, you can import your existing public and private certificate under *EEBUS > Show advanced settings* in the UI, taken from your commented-out yaml block. This is useful if the SKI (part of the public certificate) has already been registered with your metering operator for [External Control](https://docs.evcc.io/en/features/external-control/).
 :::
 
 **For example**:

--- a/src/content/docs/en/reference/configuration/eebus.md
+++ b/src/content/docs/en/reference/configuration/eebus.md
@@ -7,7 +7,7 @@ sidebar:
 :::note[deprecated in yaml]
 EEBUS can now be configured more conveniently and self-explanatory via the UI settings dialog. Simply comment out the `eebus:` block in your yaml — evcc will generate a new certificate on the next start.
 
-Alternatively, you can import your existing public and private certificate under *EEBUS > Show advanced settings* in the UI, taken from your commented-out yaml block. This is useful if the SKI (part of the public certificate) has already been registered with your metering operator for [External Control](https://docs.evcc.io/en/features/external-control/).
+Alternatively, you can import your existing public and private certificate under _EEBUS > Show advanced settings_ in the UI, taken from your commented-out yaml block. This is useful if the SKI (part of the public certificate) has already been registered with your metering operator for [External Control](https://docs.evcc.io/en/features/external-control/).
 :::
 
 **For example**:

--- a/src/content/docs/en/reference/configuration/eebus.md
+++ b/src/content/docs/en/reference/configuration/eebus.md
@@ -4,6 +4,12 @@ sidebar:
   order: 13
 ---
 
+:::note[deprecated in yaml]
+EEBUS can now be configured more conveniently and self-explanatory via the UI settings dialog. Simply comment out the `eebus:` block in your yaml — evcc will generate a new certificate on the next start.
+
+Alternatively, you can import your existing public and private certificate under *Advanced Settings* in the UI, taken from your commented-out yaml block. This is useful if the SKI (part of the public certificate) has already been registered with your metering operator for [External Control](https://docs.evcc.io/en/features/external-control/).
+:::
+
 **For example**:
 
 ```yaml

--- a/src/content/docs/en/reference/configuration/eebus.md
+++ b/src/content/docs/en/reference/configuration/eebus.md
@@ -4,10 +4,9 @@ sidebar:
   order: 13
 ---
 
-:::note[deprecated in yaml]
-EEBUS can now be configured more conveniently and self-explanatory via the UI settings dialog. Simply comment out the `eebus:` block in your yaml — evcc will generate a new certificate on the next start.
-
-Alternatively, you can import your existing public and private certificate under _EEBUS > Show advanced settings_ in the UI, taken from your commented-out yaml block. This is useful if the SKI (part of the public certificate) has already been registered with your metering operator for [External Control](https://docs.evcc.io/en/features/external-control/).
+:::tip[Recommendation]
+Configure EEBus in the UI under **Configuration → EEBus**.
+Certificate and identifiers are generated automatically on first start.
 :::
 
 **For example**:
@@ -28,6 +27,14 @@ eebus:
       -----END EC PRIVATE KEY-----
 ```
 
+:::note[Migration from YAML to UI]
+Remove the `eebus:` block from your `evcc.yaml` and restart.
+A new certificate is generated automatically and all EEBus devices must be paired again.
+
+To keep your existing certificate, enter it in the EEBus dialog under **Show advanced settings**.
+This is useful if the SKI (part of the public certificate) is already registered with your grid operator for [external control](/en/features/external-control).
+:::
+
 ---
 
 ## Required Parameters
@@ -36,7 +43,7 @@ eebus:
 
 Defines the certificate and its private key to be used for the required HTTPS connection.
 
-This can be generated using `evcc eebus-cert`.
+When configuring in the UI, the certificate is generated automatically.
 
 **For example**:
 
@@ -88,7 +95,7 @@ private: |
 
 ### `interfaces`
 
-Defines a list of network interfaces through which EEBUS should communicate. By default, all interfaces are used, but this might lead to communication issues.
+Defines a list of network interfaces through which EEBus should communicate. By default, all interfaces are used, but this might lead to communication issues.
 
 **For example**:
 


### PR DESCRIPTION
solves https://github.com/evcc-io/docs/issues/1101

Hints to the new self-explanatory UI config dialog instead of yaml for EEBUS configuration