### PR TITLE
Explain meter energy/returnenergy signs and directions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,12 +89,16 @@ Everything else is hand-written:
 ### Language & Tone
 
 - **Be informal and casual** — address readers directly with "you" (English) or "du" (German)
+- Direct address only for actions the reader actually performs (UI steps, setup instructions). For technical requirements use an impersonal subject: "Das Plugin muss den Zählerstand liefern", not "Liefere den Zählerstand"
+- Write complete, natural sentences — no telegraphic or clipped phrasing, no semicolon-jammed clauses
 - Write for individual professionals, not businesses
 - Avoid corporate or marketing language (e.g. don't use words like "bequem", "convenient", "seamlessly")
 - Be concise and direct; describe behaviour, not internals (no libraries / quotas / internal naming schemes in user-facing docs)
 - Don't pitch the absence of analytics/telemetry as a feature — frame it as the default
 
 ### Terminology
+
+- **Match the evcc UI wording** — check `../evcc/i18n/en.json` and `de.json` for existing terms before inventing new ones (e.g. grid: "imported/exported" / „bezogen/eingespeist", battery: "charged/discharged" / „geladen/entladen", PV: "production" / „Erzeugung")
 
 #### English
 
@@ -203,6 +207,7 @@ Everything else is hand-written:
 
 - Use locale-prefixed absolute paths (`/en/...`, `/de/...`) for clarity
 - Keep anchor names (`#section`) consistent between translations
+- **Anchor names are always English** in both locales, matching the English heading slug (e.g. `signs-and-directions`, not `vorzeichen-und-richtungen`) — this keeps anchors working when switching languages
 - **Create explicit anchors** on headings instead of relying on auto-generated ones
   - Auto-generated anchors change with heading text and differ between languages
   - In `.md` files use the compact form: `### Vehicle Detection {#vehicle}`

--- a/src/content/docs/de/user-defined-devices.mdx
+++ b/src/content/docs/de/user-defined-devices.mdx
@@ -85,6 +85,7 @@ Zähler unter `meters:` können an verschiedenen Stellen innerhalb der `site` Ko
 - `battery`: Hausbatteriezähler
 - `charge`: Zähler für die Ladeleistung der Wallbox
 - `aux`: Verbrauchszähler für intelligente Verbraucher
+- `consumer`: Zähler für einen regulären Verbraucher, erfasst für die Verbrauchsstatistik
 - `ext`: Weiterer Zähler, z. B. für Lastmanagement oder Datenerfassung
 
 `power` ist das einzig erforderliche Attribut.
@@ -102,13 +103,37 @@ Zur Konvertierung dienen die [Lese-Pipelines](/de/reference/plugins#reading).
 | -------------- | --------------------- | --------- | ------------- | --------------------------------------------------------------------------- |
 | `power`        | `float`               | ja        | alle          | Aktuelle Leistung in W                                                      |
 | `energy`       | `float`               | nein      | alle          | Zählerstand in kWh                                                          |
-| `returnenergy` | `float`               | nein      | alle          | Zählerstand in Gegenrichtung in kWh (z. B. Netzeinspeisung)                 |
+| `returnenergy` | `float`               | nein      | alle          | Zählerstand in Gegenrichtung in kWh (siehe unten)                           |
 | `maxpower`     | `int`                 | nein      | `pv` (hybrid) | Maximale AC-Leistung in W                                                   |
 | `soc`          | `int`                 | nein      | `battery`     | Ladestand in %                                                              |
 | `capacity`     | `float`               | nein      | `battery`     | Kapazität in kWh                                                            |
 | `powers`       | `[float,float,float]` | nein      | alle          | Phasenleistungen in W. Zur Vorzeichenerkennung bei vorzeichenlosen Strömen. |
 | `currents`     | `[float,float,float]` | nein      | alle          | Phasenströme in A. Zur Erkennung aktiver Phasen.                            |
 | `voltages`     | `[float,float,float]` | nein      | alle          | Phasenspannungen in V. Zur Anschlusserkennung (1p/3p).                      |
+
+<a id="signs-and-directions"></a>
+
+### Vorzeichen und Richtungen
+
+Was ein positiver `power`-Wert und die beiden Energierichtungen bedeuten, hängt von der Zählerrolle ab:
+
+| Rolle                    | `power` positiv           | `energy`   | `returnenergy`      |
+| ------------------------ | ------------------------- | ---------- | ------------------- |
+| `grid`                   | Netzbezug                 | Bezogen    | Eingespeist         |
+| `pv`                     | Erzeugung                 | Erzeugt    | Verbraucht (selten) |
+| `battery`                | Entladen (negativ: Laden) | Entladen   | Geladen             |
+| `charge`                 | Laden                     | Geladen    | Entladen (V2X)      |
+| `aux`, `ext`, `consumer` | Verbrauch                 | Verbraucht | Erzeugt (selten)    |
+
+`energy` und `returnenergy` sind steigende Zählerstände in kWh, idealerweise Gesamtwerte wie die Bezugs- und Einspeiseregister eines Stromzählers.
+Die Differenzen zwischen den Zählerständen werden automatisch berechnet.
+Das Plugin muss deshalb einen Zählerstand liefern und keine Verbrauchswerte pro Intervall.
+Auch ein Zähler, der sich regelmäßig zurücksetzt (z. B. täglich), funktioniert, da der Rücksprung automatisch erkannt wird.
+Ein Zählerstand von `0` wird als nicht verfügbar behandelt.
+
+Beide Attribute sind optional.
+Ohne sie wird die Energiehistorie aus dem zeitlichen Verlauf von `power` abgeleitet.
+Echte Zählerstände liefern genauere Langzeitstatistiken.
 
 ### Schreib-Attribute
 
@@ -143,7 +168,7 @@ Für andere Geräte stehen spezialisierte Charger-Typen unter [Switchsocket](#ch
 | `enabled`      | `bool`                | ja        | Ist Ladung freigegeben?                                                                  |
 | `power`        | `float`               | nein      | Ladeleistung in W                                                                        |
 | `energy`       | `float`               | nein      | Zählerstand in kWh                                                                       |
-| `returnenergy` | `float`               | nein      | Zählerstand in Gegenrichtung in kWh                                                      |
+| `returnenergy` | `float`               | nein      | Zählerstand in Gegenrichtung in kWh (Entladeenergie, V2X)                                |
 | `identify`     | `string`              | nein      | Aktuelle RFID-Kennung                                                                    |
 | `soc`          | `int`                 | nein      | Ladestand in %                                                                           |
 | `limitsoc`     | `int`                 | nein      | Ladelimit in %                                                                           |

--- a/src/content/docs/en/user-defined-devices.mdx
+++ b/src/content/docs/en/user-defined-devices.mdx
@@ -85,6 +85,7 @@ Meters defined under `meters:` can be referenced from `site`:
 - `battery`: Home battery meter
 - `charge`: Meter for the charging power of the wallbox
 - `aux`: Consumption meter for intelligent consumers
+- `consumer`: Meter for a regular consumer, recorded for consumption statistics
 - `ext`: Additional meter, e.g. for load management or data collection
 
 `power` is the only required attribute.
@@ -98,17 +99,40 @@ To convert, use the [reading pipelines](/en/reference/plugins#reading).
 
 ### Read attributes
 
-| Attribute      | Type                  | Required | Context       | Description                                                   |
-| -------------- | --------------------- | -------- | ------------- | ------------------------------------------------------------- |
-| `power`        | `float`               | yes      | all           | Current power in W                                            |
-| `energy`       | `float`               | no       | all           | Meter reading in kWh                                          |
-| `returnenergy` | `float`               | no       | all           | Meter reading in reverse direction in kWh (e.g. grid feed-in) |
-| `maxpower`     | `int`                 | no       | `pv` (hybrid) | Maximum AC power in W                                         |
-| `soc`          | `int`                 | no       | `battery`     | State of charge in %                                          |
-| `capacity`     | `float`               | no       | `battery`     | Capacity in kWh                                               |
-| `powers`       | `[float,float,float]` | no       | all           | Phase powers in W. For sign detection of unsigned currents.   |
-| `currents`     | `[float,float,float]` | no       | all           | Phase currents in A. For detecting active phases.             |
-| `voltages`     | `[float,float,float]` | no       | all           | Phase voltages in V. For connection detection (1p/3p).        |
+| Attribute      | Type                  | Required | Context       | Description                                                 |
+| -------------- | --------------------- | -------- | ------------- | ----------------------------------------------------------- |
+| `power`        | `float`               | yes      | all           | Current power in W                                          |
+| `energy`       | `float`               | no       | all           | Meter reading in kWh                                        |
+| `returnenergy` | `float`               | no       | all           | Meter reading in reverse direction in kWh (see below)       |
+| `maxpower`     | `int`                 | no       | `pv` (hybrid) | Maximum AC power in W                                       |
+| `soc`          | `int`                 | no       | `battery`     | State of charge in %                                        |
+| `capacity`     | `float`               | no       | `battery`     | Capacity in kWh                                             |
+| `powers`       | `[float,float,float]` | no       | all           | Phase powers in W. For sign detection of unsigned currents. |
+| `currents`     | `[float,float,float]` | no       | all           | Phase currents in A. For detecting active phases.           |
+| `voltages`     | `[float,float,float]` | no       | all           | Phase voltages in V. For connection detection (1p/3p).      |
+
+<a id="signs-and-directions"></a>
+
+### Signs and Directions
+
+What a positive `power` value and the two energy directions mean depends on the meter role:
+
+| Role                     | `power` positive                 | `energy`   | `returnenergy`     |
+| ------------------------ | -------------------------------- | ---------- | ------------------ |
+| `grid`                   | Grid import                      | Imported   | Exported (feed-in) |
+| `pv`                     | Production                       | Produced   | Consumed (rare)    |
+| `battery`                | Discharging (negative: charging) | Discharged | Charged            |
+| `charge`                 | Charging                         | Charged    | Discharged (V2X)   |
+| `aux`, `ext`, `consumer` | Consumption                      | Consumed   | Produced (rare)    |
+
+`energy` and `returnenergy` are increasing meter readings in kWh, ideally lifetime totals like the import and export registers of a grid meter.
+The differences between readings are calculated automatically, so the plugin must return a meter reading and not consumption values per interval.
+A counter that resets periodically (e.g. daily) also works, as the reset is detected automatically.
+A reading of `0` is treated as not available.
+
+Both attributes are optional.
+Without them, the energy history is derived from `power` over time.
+Real meter readings give more accurate long-term statistics.
 
 ### Write attributes
 
@@ -143,7 +167,7 @@ For other devices, specialised charger types are described under [Switchsocket](
 | `enabled`      | `bool`                | yes      | Is charging enabled?                                                                        |
 | `power`        | `float`               | no       | Charging power in W                                                                         |
 | `energy`       | `float`               | no       | Meter reading in kWh                                                                        |
-| `returnenergy` | `float`               | no       | Meter reading in reverse direction in kWh                                                   |
+| `returnenergy` | `float`               | no       | Meter reading in reverse direction in kWh (discharged energy, V2X)                          |
 | `identify`     | `string`              | no       | Current RFID identifier                                                                     |
 | `soc`          | `int`                 | no       | State of charge in %                                                                        |
 | `limitsoc`     | `int`                 | no       | Charge limit in %                                                                           |


### PR DESCRIPTION
Adds a **Signs and Directions** section to the user-defined devices page (EN + DE), documenting per meter role what a positive `power` value means and which direction `energy` / `returnenergy` refer to.

Addresses the confusion raised in evcc-io/evcc#31472.

- Table for `grid`, `pv`, `battery`, `charge`, `aux`/`ext`/`consumer`, wording aligned with the UI translations (`i18n/{en,de}.json`)
- Notes: values are increasing meter readings (lifetime totals preferred, periodically resetting counters are detected automatically, `0` is treated as not available); without counters the history falls back to integrating `power` over time
- Semantics verified against the evcc source (`core/site.go`, `core/metrics/accumulator.go`) and built-in templates; battery: `energy` = discharged, `returnenergy` = charged
- Adds `consumer` role to the meter roles list
- Charger table: clarifies `returnenergy` as discharged energy (V2X)
- Style guide (AGENTS.md): impersonal phrasing for technical requirements, complete sentences, UI wording alignment, English anchor names in both locales