### PR TITLE
Replace YAML config with UI instructions on solar charging page

### DIFF
--- a/src/content/docs/de/features/solar-charging.mdx
+++ b/src/content/docs/de/features/solar-charging.mdx
@@ -52,26 +52,23 @@ Bei Anlagen mit abgeregelter Netzeinspeisung („Nulleinspeisung“) funktionier
 ### Nicht genügend Überschuss?
 
 Standardmäßig wird versucht, möglichst keinen Strom aus dem Netz zu beziehen.
-Dieses Verhalten kann über die Konfiguration am Ladepunkt angepasst werden.
-Hierfür sind die Parameter `delay` und `threshold` relevant.
-Mit ihnen kann die Ein-/Ausschaltverzögerung und die Überschussgrenze eingestellt werden.
+Dieses Verhalten kannst du unter **Konfiguration → Laden & Heizen → [Mein Ladepunkt]** anpassen.
+Stelle im Abschnitt **Verhalten** die Option **PV-Überschuss** von **nur Sonne** auf **manuell**.
+Damit lassen sich eigene Schwellen und Verzögerungen festlegen.
 
-```yaml
-loadpoints:
-  - title: Garage
-    enable:
-      # einschalten, wenn 1 Minute lang mindestens 2000 W Überschuss vorhanden ist
-      delay: 1m
-      threshold: -2000
-    disable:
-      # ausschalten, wenn 30 Minuten lang mehr als 2000 W aus dem Netz bezogen werden
-      delay: 30m
-      threshold: 2000
-```
+**Netzleistung einschalten** legt fest, wie viel Überschuss vorhanden sein muss, bevor die Ladung startet.
+Der Wert ist negativ, weil er sich auf die ins Netz eingespeiste Leistung bezieht, z. B. bedeutet -2.000 W einen Überschuss von 2.000 W.
+Mit dem Standardwert 0 W startet die Ladung, sobald die Mindestladeleistung als Überschuss verfügbar ist.
+Die **Einschaltverzögerung** legt fest, wie lange dieser Überschuss durchgehend vorhanden sein muss, bevor die Ladung startet, z. B. 1 Minute.
+
+**Netzleistung ausschalten** legt fest, wie viel Leistung während der Ladung aus dem Netz bezogen werden darf, bevor sie stoppt.
+Bei 2.000 W wird z. B. weitergeladen, solange nicht mehr als 2.000 W aus dem Netz bezogen werden.
+Mit dem Standardwert 0 W stoppt die Ladung, sobald die Mindestladeleistung nicht mehr durch Überschuss gedeckt ist.
+Die **Ausschaltverzögerung** legt fest, wie lange dieser Wert überschritten sein muss, bevor die Ladung stoppt, z. B. 30 Minuten.
 
 Gerade für kleine PV-Anlagen oder in den Wintermonaten kann dies sinnvoll sein, um den eigenen Ladebedarf zumindest teilweise mit PV-Energie zu decken.
 
-Die `enable` und `disable` Parameter sollten so gewählt werden, dass die Ladung nicht zu häufig ein- und ausgeschaltet wird.
+Die Schwellen und Verzögerungen sollten so gewählt werden, dass die Ladung nicht zu häufig ein- und ausgeschaltet wird.
 Einige Fahrzeuge verweigern die Ladung, wenn sie zu oft unterbrochen wird, und müssen bspw. durch Aufschließen oder An-/Abstecken des Ladekabels wieder zum Laden gebracht werden.
 
 ### Zusammenspiel mit Hausbatterie

--- a/src/content/docs/en/features/solar-charging.mdx
+++ b/src/content/docs/en/features/solar-charging.mdx
@@ -52,26 +52,23 @@ Note: The value on the grid meter is the decisive factor.
 ### Not enough surplus?
 
 By default, the system tries to avoid drawing any power from the grid.
-This behavior can be adjusted via the configuration at the charging point.
-The parameters `delay` and `threshold` are relevant for this.
-They can be used to set the switch-on/switch-off delay and the surplus limit.
+You can adjust this behaviour under **Configuration → Charging & Heating → [My Charging Point]**.
+In the **Behaviour** section, switch the **Solar** setting from **maximum solar** to **custom**.
+You can then set your own thresholds and delays.
 
-```yaml
-loadpoints:
-  - title: Garage
-    enable:
-      # switch on when there is at least 2000 W surplus for 1 minute
-      delay: 1m
-      threshold: -2000
-    disable:
-      # switch off if more than 2000 W are drawn from the mains for 30 minutes
-      delay: 30m
-      threshold: 2000
-```
+**Enable grid power** defines how much surplus must be available before charging starts.
+The value is negative because it refers to power exported to the grid, e.g. -2,000 W means 2,000 W of surplus.
+With the default value of 0 W, charging starts as soon as the minimum charging power is available as surplus.
+The **Enable delay** defines how long this surplus must be available continuously before charging starts, e.g. 1 minute.
 
-This can be particularly useful for small PV systems or in the winter months, in order to at least partially cover your own charging needs with PV energy.
+**Disable grid power** defines how much power may be drawn from the grid while charging before it stops.
+With 2,000 W, for example, charging continues as long as no more than 2,000 W is imported from the grid.
+With the default value of 0 W, charging stops as soon as the minimum charging power is no longer covered by surplus.
+The **Disable delay** defines how long this limit must be exceeded before charging stops, e.g. 30 minutes.
 
-The `enable` and `disable` parameters should be selected so that charging is not switched on and off too often.
+This can be particularly useful for small solar systems or in the winter months, in order to at least partially cover your own charging needs with solar energy.
+
+The thresholds and delays should be selected so that charging is not switched on and off too often.
 Some vehicles refuse to charge if it is interrupted too often and must be made to charge again, for example by unlocking or plugging/unplugging the charging cable.
 
 ### Interaction with the home battery


### PR DESCRIPTION
The solar charging page (en/de) still documented the `enable`/`disable` loadpoint thresholds as an `evcc.yaml` snippet.
Most users configure this via the UI today.

- Replaces the YAML block with the click path **Configuration → Charging & Heating → [My Charging Point]** and the **Behaviour** / **Solar** setting (**maximum solar** → **custom**)
- Explains each field separately: **Enable grid power** / **Enable delay** and **Disable grid power** / **Disable delay**, including the negative-value semantics and the 0 W defaults
- All labels match the UI translations in `evcc-io/evcc` `i18n/{en,de}.json`
- Screenshot of the settings will follow later

First of a series of PRs replacing YAML examples with UI instructions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)