### PR TITLE
Replace YAML with UI instructions on tariff and vehicle feature pages

### DIFF
--- a/src/content/docs/de/features/co2.mdx
+++ b/src/content/docs/de/features/co2.mdx
@@ -16,17 +16,8 @@ Sind wenig erneuerbare Energien im Stromnetz vorhanden, muss der zusätzliche St
 ## Datenquelle konfigurieren
 
 Um CO₂-optimiert zu laden, benötigt evcc Vorhersagedaten über die CO₂-Emissionen in deiner Region.
-Die Konfiguration muss über die `evcc.yaml` vorgenommen werden.
-
-```yaml
-tariffs:
-  co2:
-    type: template
-    template: grünstromindex # Beispiel GrünstromIndex (nur Deutschland)
-    zip: 12349 # Deine Postleitzahl
-```
-
-In diesem Beispiel verwenden wir die Daten von [GrünstromIndex.de](https://www.gruenstromindex.de/).
+Die Datenquelle kannst du unter **Konfiguration → Tarife & Vorhersagen → Vorhersage hinzufügen → CO₂-Vorhersage hinzufügen** anlegen.
+Wähle im Feld **Anbieter** deine Datenquelle, z. B. [Grünstromindex](https://www.gruenstromindex.de/) (nur Deutschland), und fülle die anbieterspezifischen Felder wie deine Postleitzahl aus.
 Unter [Stromtarife](/de/tariffs) findest du eine Liste aller unterstützten Datenquellen.
 
 ## Sauberes Netzladen

--- a/src/content/docs/de/features/dynamic-prices.mdx
+++ b/src/content/docs/de/features/dynamic-prices.mdx
@@ -11,52 +11,25 @@ Wenn du einen Stromtarif mit flexiblen Strompreisen wie [Tibber](https://tibber.
 
 ## Datenquelle konfigurieren
 
-Die Konfiguration von Strompreisen muss aktuell noch über die `evcc.yaml` vorgenommen werden.
+Dein Strompreis wird unter **Konfiguration → Tarife & Vorhersagen → Tarif hinzufügen → Netzbezugstarif hinzufügen** konfiguriert.
+Die Währung kannst du unter **Konfiguration → Allgemein → Währung** ändern.
 
 ### Fester Strompreis
 
-Hier die Konfiguration für einen festen Stromtarif.
+Für einen festen Stromtarif wählst du im Feld **Anbieter** die Option **Fester Preis** und trägst deinen Preis pro kWh ein.
 Diese Information wird für die Berechnung der realen Ladekosten verwendet.
-
-```yaml
-tariffs:
-  currency: EUR
-  grid:
-    type: fixed
-    price: 0.32 # EUR/kWh
-```
 
 ### Zeitabhängiger Strompreis
 
-Über `zones` kannst du abweichende Preise für bestimmte Zeiträume angeben.
-Du kannst beliebig viele Zeiträume definieren, in denen ein abweichender Preis gilt.
-
-```yaml
-tariffs:
-  currency: EUR
-  grid:
-    type: fixed
-    price: 0.32 # EUR/kWh (default)
-    zones:
-      - days: Mo-Fr
-        hours: 2-6
-        price: 0.22 # EUR/kWh (werkstags 2-6 Uhr)
-      - days: Sa,So
-        price: 0.12 # EUR/kWh (Wochenende)
-```
+Gelten zu bestimmten Zeiten abweichende Preise, wählst du im Feld **Anbieter** die Option **Zeitabhängiger Tarif**.
+Im Feld **Standardpreis** trägst du deinen regulären Preis ein.
+Über **Zone hinzufügen** kannst du beliebig viele Zeiträume definieren, in denen ein abweichender Preis gilt, z. B. werktags von 2 bis 6 Uhr oder am Wochenende.
+Jede Zone hat einen eigenen Preis und kann auf bestimmte Tage und Uhrzeiten begrenzt werden.
 
 ### Dynamischer Strompreis via API
 
-Hast du einen Stromtarif der bspw. Strombörsenpreisen folgt, kannst du die Preise auch über eine API beziehen.
-Hier eine Beispielkonfiguration für den Stromtarif von [Tibber](https://tibber.com/de/).
-
-```yaml
-tariffs:
-  grid:
-    type: template
-    template: tibber
-    token: "..." # Access Token
-```
+Hast du einen Stromtarif, der bspw. Strombörsenpreisen folgt, kannst du die Preise auch über eine API beziehen.
+Wähle im Feld **Anbieter** deinen Anbieter, z. B. [Tibber](https://tibber.com/de/), und trage die anbieterspezifischen Zugangsdaten wie den API-Token ein.
 
 Unter [Stromtarife](/de/tariffs) findest du eine Liste aller unterstützten Tarife.
 Wenn dein Anbieter eine Schnittstelle hat, aber noch nicht von evcc unterstützt wird, dann mach gerne einen [Feature Request](https://github.com/evcc-io/evcc/issues/new/choose) auf.

--- a/src/content/docs/de/features/vehicle.mdx
+++ b/src/content/docs/de/features/vehicle.mdx
@@ -27,18 +27,8 @@ Unter [Ladevorgänge](./sessions) wird diese Ladung dem Gastfahrzeug zugeordnet.
 ### Fahrzeuge ohne API (Offline)
 
 Hat dein Fahrzeug keine Online-Schnittstelle oder am Ladepunkt keine Internetverbindung, kannst du es als Offline-Fahrzeug konfigurieren.
-Dies erfolgt aktuell über die `evcc.yaml`:
-
-```yaml
-vehicles:
-  - name: my_honda
-    title: grüner Honda e
-    type: template
-    template: offline
-    capacity: 28.5 # in kWh
-```
-
-Damit erscheint das Fahrzeug als "grüner Honda e" in der UI.
+Gehe zu **Konfiguration → Fahrzeuge → Fahrzeug hinzufügen** und wähle im Feld **Hersteller** die Option **Generisches Fahrzeug (ohne API)**.
+Gib dem Fahrzeug einen **Titel** (z. B. „grüner Honda e“) und trage die **Kapazität** des Akkus ein.
 Durch die nun bekannte Akkukapazität kann bspw. der Ladefortschritt und das Ladelimit auch in Prozent (bspw. +25%) dargestellt werden.
 
 Hinweis: Diese Funktion kannst du auch für Fremdfahrzeuge nutzen (Freunde, Familie, Miet- oder Firmenwagen), zu denen du keinen API-Zugriff hast.
@@ -47,18 +37,8 @@ Hinweis: Diese Funktion kannst du auch für Fremdfahrzeuge nutzen (Freunde, Fami
 
 Hat dein Fahrzeug eine Online-Schnittstelle, ist es sinnvoll, diese auch in evcc zu konfigurieren.
 Unter [Fahrzeuge](/de/vehicles) findest du eine Liste aller unterstützten Hersteller.
-Die empfohlene Konfiguration erfolgt auch hier über die `evcc.yaml`. Hier ein Beispiel für einen Audi:
-
-```yaml
-vehicles:
-  - name: my_audi
-    title: roter Audi Q4 e-tron
-    type: template
-    template: audi
-    user: info@example.org
-    password: ***
-    capacity: 77 # in kWh
-```
+Gehe zu **Konfiguration → Fahrzeuge → Fahrzeug hinzufügen** und wähle deinen **Hersteller**, z. B. Audi.
+Abhängig vom Hersteller trägst du dann die Zugangsdaten deines Fahrzeugkontos ein, wie Benutzername und Passwort.
 
 evcc hat jetzt Zugriff auf den aktuellen Ladestand (SoC).
 Abhängig vom Hersteller sind auch weitere Informationen wie Ladestatus, Fahrzeuglimits, Kilometerstand, Klimatisierung und geschätzte Reichweite verfügbar.
@@ -78,15 +58,10 @@ Für die Zuordnung von Fahrzeugen zu Ladepunkten gibt es verschiedene Möglichke
 
 Hat jedes Fahrzeug einen eigenen Ladepunkt, kannst du das Fahrzeug als Standardfahrzeug am Ladepunkt konfigurieren.
 Das ist die einfachste und empfohlene Konfiguration.
+Gehe zu **Konfiguration → Laden & Heizen → [Mein Ladepunkt]**.
+Wähle im Abschnitt **Fahrzeuge** dein Fahrzeug als **Standard-Fahrzeug** aus.
 evcc geht bei einem neuen Ladevorgang davon aus, dass es sich um das Standardfahrzeug handelt.
 Ist dies einmal nicht der Fall (bspw. Gastfahrzeug), kannst du das Fahrzeug in der UI umschalten.
-
-```yaml
-loadpoints:
-  - title: Garage
-    vehicle: my_audi # Standardfahrzeug
-    ...
-```
 
 ### Zuordnung über die UI
 
@@ -113,16 +88,9 @@ Jedes Mal, wenn das Fahrzeug wieder an die Wallbox angeschlossen wird, muss der 
 
 evcc bekommt von der Wallbox eine eindeutige Identifikationskennung.
 Abhängig vom Hersteller ist das direkt die RFID-Kennung oder eine abgeleitete interne Kennung wie bspw. ein Benutzername aus der Wallboxkonfiguration.
-Über den `evcc charger` Befehl kannst du den aktuellen `Identifier` deiner Wallbox auslesen.
-Diese hinterlegst du dann in der `evcc.yaml` am gewünschten Fahrzeug:
-
-```yaml
-vehicles:
-  - name: vehicle_one
-    ...
-    identifiers:
-      - 1234567890 # über `evcc charger` ermittelt
-```
+Nach dem Freischalten mit der Karte wird die aktuelle Kennung am Ladepunkt unter **Konfiguration → Laden & Heizen** angezeigt.
+Trage diesen Wert im Feld **RFID-Identifikation** des gewünschten Fahrzeugs unter **Konfiguration → Fahrzeuge** ein.
+Pro Fahrzeug kannst du mehrere Kennungen hinterlegen.
 
 ### Erkennung via Plug & Charge
 
@@ -135,30 +103,14 @@ In der Wallbox muss das Feature "PLC-Verbindung zum Fahrzeug" aktiviert sein.
 
 Die Einrichtung erfolgt hier ähnlich wie bei der RFID-Erkennung.
 Das Fahrzeug muss mit der Wallbox verbunden sein.
-Über den `evcc charger` Befehl kannst du den aktuellen `Identifier` deiner Wallbox auslesen.
-Diesen kannst du dann in der `evcc.yaml` einem Fahrzeug zuordnen:
-
-```yaml
-vehicles:
-  - name: vehicle_one
-    ...
-    identifiers:
-      - 01:23:45:67:89:00 # über `evcc charger` ermittelt
-```
+Die Kennung (z. B. `01:23:45:67:89:00`) wird dann am Ladepunkt unter **Konfiguration → Laden & Heizen** angezeigt.
+Trage diesen Wert im Feld **RFID-Identifikation** des Fahrzeugs ein.
 
 :::note[Hinweis]
 Wenn das Fahrzeug und die Wallbox kein Plug & Charge unterstützen, dann liefern die Fahrzeuge eine eigentlich eindeutige Hardware-Adresse (MAC-Adresse) zurück.
 Manche Hersteller wie VW und Audi ändern diese aber jeden Tag auf einen anderen Zufallswert.
 
-Für diesen Fall kann man eine Wildcard verwenden und nur den sich nicht ändernden Teil angeben:
-
-```yaml
-vehicles:
-- name: vehicle_one
-    ...
-    identifiers:
-    - 01:23:45:*
-```
+Für diesen Fall kann man eine Wildcard verwenden und nur den sich nicht ändernden Teil angeben, z. B. `01:23:45:*`.
 
 Dies funktioniert natürlich nur, wenn dies nicht bei mehreren vorhandenen Fahrzeugen auftritt und sich der angegebene Anfangsteil des Wertes jeweils unterscheidet.
 :::

--- a/src/content/docs/en/features/co2.mdx
+++ b/src/content/docs/en/features/co2.mdx
@@ -16,17 +16,8 @@ If there is little renewable energy available in the power grid, the additional 
 ## Configuring the Data Source
 
 In order to charge in a CO₂-optimised way, evcc needs forecast data about CO₂ emissions in your region.
-The configuration must be done via evcc.yaml
-
-```yaml
-tariffs:
-  co2:
-    type: template
-    template: grünstromindex # example GrünstromIndex (Germany only)
-    zip: 12349 # ZIP code
-```
-
-In this example, we'll use data from GrünstromIndex.
+You can add the data source under **Configuration → Tariffs & Forecasts → Add forecast → Add CO₂ forecast**.
+Select your data source in the **Provider** field, e.g. [Grünstromindex](https://www.gruenstromindex.de/) (Germany only), and fill in the provider-specific fields such as your postcode.
 See [tariffs](/en/tariffs) for a list of all supported data sources.
 
 ## Clean web charging

--- a/src/content/docs/en/features/dynamic-prices.mdx
+++ b/src/content/docs/en/features/dynamic-prices.mdx
@@ -11,52 +11,25 @@ If you have an electricity tariff with flexible electricity prices such as [Tibb
 
 ## Configure data source
 
-The configuration of electricity prices currently still has to be done via `evcc.yaml`.
+Your electricity price is configured under **Configuration → Tariffs & Forecasts → Add tariff → Add grid import tariff**.
+The currency can be changed under **Configuration → General → Currency**.
 
 ### Fixed electricity tariff
 
-Here is the configuration for a fixed electricity tariff.
+For a fixed electricity tariff, choose **Fixed Price** in the **Provider** field and enter your price per kWh.
 This information is used to calculate the actual charging costs.
-
-```yaml
-tariffs:
-  currency: EUR
-  grid:
-    type: fixed
-    price: 0.32 # EUR/kWh
-```
 
 ### Time-dependent electricity tariff
 
-Using `zones` you can specify different tariffs for certain periods of time.
-You can define as many periods as you like in which a different tariff applies.
-
-```yaml
-tariffs:
-  currency: EUR
-  grid:
-    type: fixed
-    price: 0.32 # EUR/kWh (default)
-    zones:
-      - days: Mo-Fr
-        hours: 2-6
-        price: 0.22 # EUR/kWh (weekdays 2-6 hours)
-      - days: Sa,So
-        price: 0.12 # EUR/kWh (weekend)
-```
+If different prices apply at certain times, choose **Time-based Tariff** in the **Provider** field.
+Enter your regular price in the **Default price** field.
+With **Add zone** you can define as many periods as you like in which a different price applies, e.g. on weekdays from 2 to 6 am or at the weekend.
+Each zone has its own price and can be limited to specific days and hours.
 
 ### Dynamic electricity tariff via API
 
-If you have an electricity tariff that follows electricity exchange tariff, for example, you can also obtain the prices via an API.
-Here is an example configuration for the electricity tariff from [Tibber](https://tibber.com/de/).
-
-```yaml
-tariffs:
-  grid:
-    type: template
-    template: tibber
-    token: "..." # Access Token
-```
+If you have an electricity tariff that follows electricity exchange prices, for example, you can also obtain the prices via an API.
+Choose your provider in the **Provider** field, e.g. [Tibber](https://tibber.com/de/), and enter the provider-specific access data such as the API token.
 
 You can find a list of all supported tariffs under [tariffs](/en/tariffs).
 If your provider has an interface but is not yet supported by evcc, please submit a [Feature Request](https://github.com/evcc-io/evcc/issues/new/choose).
@@ -70,7 +43,7 @@ See [time-based grid fees](/en/reference/configuration/tariffs#charges-zones) fo
 
 During certain periods of the day and in specific regions, there might be an abundance of solar power. At the same time, there may be almost no load on the grid.
 During these periods your energy provider might apply a cost for injecting your PV-power to the grid as supply is high but demand is low and the grid is overloaded.
-EVCC supports smart feed-in and allows you to define a set point at which it will throttle PV inverters to prevent feed-in.
+evcc supports smart feed-in and allows you to define a set point at which it will throttle PV inverters to prevent feed-in.
 
 ## Cheap grid charging
 

--- a/src/content/docs/en/features/vehicle.mdx
+++ b/src/content/docs/en/features/vehicle.mdx
@@ -27,18 +27,8 @@ Under [Charging Sessions](./sessions), this charge is assigned to the guest vehi
 ### Vehicles without API (offline)
 
 If your vehicle does not have an online interface or no internet connection at the charging point, you can configure it as an offline vehicle.
-This is currently done via the `evcc.yaml`:
-
-```yaml
-vehicles:
-  - name: my_honda
-    title: Green Honda e
-    type: template
-    template: offline
-    capacity: 28.5 # in kWh
-```
-
-This means that the vehicle appears as a "green Honda e" in the UI.
+Go to **Configuration → Vehicles → Add vehicle** and choose **Generic vehicle (without API)** in the **Manufacturer** field.
+Give the vehicle a **Title** (e.g. "Green Honda e") and enter the **Capacity** of its battery.
 Now that the battery capacity is known, the charging progress and the charging limit can also be shown in percent (e.g. +25%).
 
 Note: You can also use this function for third-party vehicles (friends, family, rental or company cars) to which you do not have API access.
@@ -47,18 +37,8 @@ Note: You can also use this function for third-party vehicles (friends, family, 
 
 If your vehicle has an online interface, it makes sense to configure this in evcc as well.
 You can find a list of all supported manufacturers under [Vehicles](/en/vehicles).
-The recommended configuration is also done here via `evcc.yaml`. Here is an example for an Audi:
-
-```yaml
-vehicles:
-  - name: my_audi
-    title: Red Audi Q4 e-tron
-    type: template
-    template: audi
-    user: info@example.org
-    password: ***
-    capacity: 77 # in kWh
-```
+Go to **Configuration → Vehicles → Add vehicle** and choose your **Manufacturer**, e.g. Audi.
+Depending on the manufacturer, you then enter the access data of your vehicle account, such as user and password.
 
 evcc now has access to the current state of charge (SoC).
 Depending on the manufacturer, other information such as charging status, vehicle limits, mileage, climate control and estimated range are also available.
@@ -78,15 +58,10 @@ There are various options for assigning vehicles to charging points:
 
 If each vehicle has its own charging point, you can configure the vehicle as the standard vehicle at the charging point.
 This is the simplest and recommended configuration.
+Go to **Configuration → Charging & Heating → [My Charging Point]**.
+In the **Vehicles** section, select your vehicle as **Default vehicle**.
 When a new charging process starts, evcc assumes that it is the standard vehicle.
 If this is not the case (e.g. guest vehicle), you can switch the vehicle in the UI.
-
-```yaml
-loadpoints:
-  - title: Garage
-    vehicle: my_audi # Standard vehicle
-    ...
-```
 
 ### Assignment via the UI
 
@@ -113,16 +88,9 @@ Every time the vehicle is connected to the wallbox again, the charging process m
 
 evcc receives a unique identification code from the wallbox.
 Depending on the manufacturer, this is either the RFID code or a derived internal code such as a user name from the wallbox configuration.
-You can read the current identifier of your wallbox using the `evcc charger` command.
-You then store this in the `evcc.yaml` on the desired vehicle:
-
-```yaml
-vehicles:
-  - name: vehicle_one
-    ...
-    identifiers:
-      - 1234567890 # determined via `evcc charger`
-```
+After activating with the card, the current identifier is shown on the charging point card under **Configuration → Charging & Heating**.
+Enter this value in the **RFID identification** field of the desired vehicle under **Configuration → Vehicles**.
+You can store multiple identifiers per vehicle.
 
 ### Detection via Plug & Charge
 
@@ -135,30 +103,14 @@ The "PLC connection to the vehicle" feature must be activated in the wallbox.
 
 The setup is similar to RFID detection.
 The vehicle must be connected to the wallbox.
-You can use the `evcc charger` command to read the current `identifier` of your wallbox.
-You can then assign this to a vehicle in the `evcc.yaml`:
-
-```yaml
-vehicles:
-  - name: vehicle_one
-    ...
-    identifiers:
-      - 01:23:45:67:89:00 # determined via `evcc charger`
-```
+The identifier (e.g. `01:23:45:67:89:00`) is then shown on the charging point card under **Configuration → Charging & Heating**.
+Enter this value in the **RFID identification** field of the vehicle.
 
 :::note[Note]
 If the vehicle and the wallbox do not support Plug & Charge, the vehicles return a unique hardware address (MAC address).
 However, some manufacturers such as VW and Audi change this to a different random value every day.
 
-In this case, you can use a wildcard and only specify the part that does not change:
-
-```yaml
-vehicles:
-- name: vehicle_one
-    ...
-    identifiers:
-    - 01:23:45:*
-```
+In this case, you can use a wildcard and only specify the part that does not change, e.g. `01:23:45:*`.
 
 Of course, this only works if this does not occur in several existing vehicles and the specified initial part of the value is different in each case.
 :::


### PR DESCRIPTION
Part of the series replacing `evcc.yaml` snippets in the features section with UI instructions (follow-up to #1106).

**co2** (en/de): CO₂ data source now via **Configuration → Tariffs & Forecasts → Add forecast → Add CO₂ forecast**, provider example Grünstromindex.

**dynamic-prices** (en/de): grid tariff via **Configuration → Tariffs & Forecasts → Add tariff → Add grid import tariff** — fixed price (**Fixed Price**), time-based zones (**Time-based Tariff**, **Default price**, **Add zone**), dynamic providers (e.g. **Tibber**). Currency pointer to **Configuration → General → Currency**. Drive-by: "EVCC" → "evcc" in the smart feed-in section.

**vehicle** (en/de): offline vehicle (**Generic vehicle (without API)**), online vehicle (manufacturer selection + account credentials), loadpoint default vehicle (**Vehicles → Default vehicle**), RFID and Plug & Charge identifiers via the vehicle's **RFID identification** field — the identifier is read from the charging point card in the UI, the `evcc charger` CLI mention is gone.

All labels match the UI translations in `evcc-io/evcc` `i18n/{en,de}.json` and template product names.

Deliberately excluded: `external-control.mdx` and `loadmanagement.mdx` (circuits are not form-based yet) — separate PRs later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)