### PR TITLE
Reference: Document consumer and ext meter keys

### DIFF
--- a/src/content/docs/de/reference/configuration/site.mdx
+++ b/src/content/docs/de/reference/configuration/site.mdx
@@ -26,6 +26,8 @@ site:
       - mybat5 # battery meter reference
     aux:
       - myaux1 # self-regulating consumer
+    consumer:
+      - myconsumer1 # regular consumer, recorded for consumption statistics
     ext:
       - myext1 # for data logging, load management, etc.
   residualPower: 100
@@ -161,6 +163,26 @@ oder
 aux:
   - myaux1 # first aux meter reference
   - myaux2 # second aux meter reference
+```
+
+### `meters.consumer`
+
+Definiert die [`meter`](meters) (Strommessgeräte), welche die Messdaten regulärer Verbraucher liefern, z. B. einer Waschmaschine oder Spülmaschine, die ausschließlich für die Verbrauchsstatistik erfasst werden. Anders als bei `aux` fließt diese Leistung nicht in die Berechnung der verfügbaren Überschussleistung zur Fahrzeugladung ein.
+
+**Mögliche Werte**: Ein Wert oder eine Liste von Werten eines `name` Parameters in der [`meters`](#meters) Konfiguration. Wobei die Listenversion auch bei Einzelwerten genutzt werden kann.
+
+**Beispiel**:
+
+```yaml
+consumer: myconsumer # single consumer meter reference
+```
+
+oder
+
+```yaml
+consumer:
+  - myconsumer1 # first consumer meter reference
+  - myconsumer2 # second consumer meter reference
 ```
 
 ### `residualPower`

--- a/src/content/docs/de/reference/configuration/site.mdx
+++ b/src/content/docs/de/reference/configuration/site.mdx
@@ -185,6 +185,26 @@ consumer:
   - myconsumer2 # second consumer meter reference
 ```
 
+### `meters.ext`
+
+Definiert die [`meter`](meters) (Strommessgeräte), die nicht für die Regelung verwendet oder in der Oberfläche angezeigt werden, z. B. Unterverteilungen oder alternative Netz- oder PV-Zähler. Ihre Daten werden nur geloggt und wie andere Zähler exportiert und fließen weder in die Berechnung der verfügbaren Überschussleistung zur Fahrzeugladung noch in die Verbrauchsstatistik ein.
+
+**Mögliche Werte**: Ein Wert oder eine Liste von Werten eines `name` Parameters in der [`meters`](#meters) Konfiguration. Wobei die Listenversion auch bei Einzelwerten genutzt werden kann.
+
+**Beispiel**:
+
+```yaml
+ext: myext # single ext meter reference
+```
+
+oder
+
+```yaml
+ext:
+  - myext1 # first ext meter reference
+  - myext2 # second ext meter reference
+```
+
 ### `residualPower`
 
 Legt den Soll-Arbeitspunkt der Überschussregelung am Netzübergang (Gridmeter) fest. Der Standardwert ist 0 (Watt).

--- a/src/content/docs/de/user-defined-devices.mdx
+++ b/src/content/docs/de/user-defined-devices.mdx
@@ -85,7 +85,7 @@ Zähler unter `meters:` können an verschiedenen Stellen innerhalb der `site` Ko
 - `battery`: Hausbatteriezähler
 - `charge`: Zähler für die Ladeleistung der Wallbox
 - `aux`: Verbrauchszähler für intelligente Verbraucher
-- `consumers`: Zähler für reguläre Verbraucher, erfasst für die Verbrauchsstatistik
+- `consumer`: Zähler für einen regulären Verbraucher, erfasst für die Verbrauchsstatistik
 - `ext`: Weiterer Zähler, z. B. für Lastmanagement oder Datenerfassung
 
 `power` ist das einzig erforderliche Attribut.
@@ -117,13 +117,13 @@ Zur Konvertierung dienen die [Lese-Pipelines](/de/reference/plugins#reading).
 
 Was ein positiver `power`-Wert und die beiden Energierichtungen bedeuten, hängt von der Zählerrolle ab:
 
-| Rolle                     | `power` positiv           | `energy`   | `returnenergy`      |
-| ------------------------- | ------------------------- | ---------- | ------------------- |
-| `grid`                    | Netzbezug                 | Bezogen    | Eingespeist         |
-| `pv`                      | Erzeugung                 | Erzeugt    | Verbraucht (selten) |
-| `battery`                 | Entladen (negativ: Laden) | Entladen   | Geladen             |
-| `charge`                  | Laden                     | Geladen    | Entladen (V2X)      |
-| `aux`, `ext`, `consumers` | Verbrauch                 | Verbraucht | Erzeugt (selten)    |
+| Rolle                    | `power` positiv           | `energy`   | `returnenergy`      |
+| ------------------------ | ------------------------- | ---------- | ------------------- |
+| `grid`                   | Netzbezug                 | Bezogen    | Eingespeist         |
+| `pv`                     | Erzeugung                 | Erzeugt    | Verbraucht (selten) |
+| `battery`                | Entladen (negativ: Laden) | Entladen   | Geladen             |
+| `charge`                 | Laden                     | Geladen    | Entladen (V2X)      |
+| `aux`, `ext`, `consumer` | Verbrauch                 | Verbraucht | Erzeugt (selten)    |
 
 `energy` und `returnenergy` sind steigende Zählerstände in kWh, idealerweise Gesamtwerte wie die Bezugs- und Einspeiseregister eines Stromzählers.
 Die Differenzen zwischen den Zählerständen werden automatisch berechnet.

--- a/src/content/docs/de/user-defined-devices.mdx
+++ b/src/content/docs/de/user-defined-devices.mdx
@@ -86,7 +86,7 @@ Zähler unter `meters:` können an verschiedenen Stellen innerhalb der `site` Ko
 - `charge`: Zähler für die Ladeleistung der Wallbox
 - `aux`: Verbrauchszähler für intelligente Verbraucher
 - `consumer`: Zähler für einen regulären Verbraucher, erfasst für die Verbrauchsstatistik
-- `ext`: Weiterer Zähler, z. B. für Lastmanagement oder Datenerfassung
+- `ext`: Weiterer Zähler, der nicht für die Regelung verwendet oder angezeigt wird, nur geloggt und exportiert
 
 `power` ist das einzig erforderliche Attribut.
 Nicht alle Zählerrollen unterstützen alle Attribute:

--- a/src/content/docs/de/user-defined-devices.mdx
+++ b/src/content/docs/de/user-defined-devices.mdx
@@ -85,7 +85,7 @@ Zähler unter `meters:` können an verschiedenen Stellen innerhalb der `site` Ko
 - `battery`: Hausbatteriezähler
 - `charge`: Zähler für die Ladeleistung der Wallbox
 - `aux`: Verbrauchszähler für intelligente Verbraucher
-- `consumer`: Zähler für einen regulären Verbraucher, erfasst für die Verbrauchsstatistik
+- `consumers`: Zähler für reguläre Verbraucher, erfasst für die Verbrauchsstatistik
 - `ext`: Weiterer Zähler, z. B. für Lastmanagement oder Datenerfassung
 
 `power` ist das einzig erforderliche Attribut.
@@ -117,13 +117,13 @@ Zur Konvertierung dienen die [Lese-Pipelines](/de/reference/plugins#reading).
 
 Was ein positiver `power`-Wert und die beiden Energierichtungen bedeuten, hängt von der Zählerrolle ab:
 
-| Rolle                    | `power` positiv           | `energy`   | `returnenergy`      |
-| ------------------------ | ------------------------- | ---------- | ------------------- |
-| `grid`                   | Netzbezug                 | Bezogen    | Eingespeist         |
-| `pv`                     | Erzeugung                 | Erzeugt    | Verbraucht (selten) |
-| `battery`                | Entladen (negativ: Laden) | Entladen   | Geladen             |
-| `charge`                 | Laden                     | Geladen    | Entladen (V2X)      |
-| `aux`, `ext`, `consumer` | Verbrauch                 | Verbraucht | Erzeugt (selten)    |
+| Rolle                     | `power` positiv           | `energy`   | `returnenergy`      |
+| ------------------------- | ------------------------- | ---------- | ------------------- |
+| `grid`                    | Netzbezug                 | Bezogen    | Eingespeist         |
+| `pv`                      | Erzeugung                 | Erzeugt    | Verbraucht (selten) |
+| `battery`                 | Entladen (negativ: Laden) | Entladen   | Geladen             |
+| `charge`                  | Laden                     | Geladen    | Entladen (V2X)      |
+| `aux`, `ext`, `consumers` | Verbrauch                 | Verbraucht | Erzeugt (selten)    |
 
 `energy` und `returnenergy` sind steigende Zählerstände in kWh, idealerweise Gesamtwerte wie die Bezugs- und Einspeiseregister eines Stromzählers.
 Die Differenzen zwischen den Zählerständen werden automatisch berechnet.

--- a/src/content/docs/en/reference/configuration/site.mdx
+++ b/src/content/docs/en/reference/configuration/site.mdx
@@ -184,6 +184,26 @@ consumer:
   - myconsumer2 # second consumer meter reference
 ```
 
+### `meters.ext`
+
+Defines the [`meter`](meters) (current measurement devices) that are not used for regulation or shown in the UI, e.g. sub-distributions or alternative grid or solar meters. Their data is only logged and exported like other meters, and does not factor into the available surplus power for vehicle charging or the consumption statistics.
+
+**Possible values**: A single value or a list of values of a `name` parameter in the [`meters`](#meters) configuration. The list version can also be used with single values.
+
+**Example**:
+
+```yaml
+ext: myext # single ext meter reference
+```
+
+or
+
+```yaml
+ext:
+  - myext1 # first ext meter reference
+  - myext2 # second ext meter reference
+```
+
 ### `residualPower`
 
 Sets the target operating point of the surplus regulation at the grid connection (grid meter). The default value is 0 W.

--- a/src/content/docs/en/reference/configuration/site.mdx
+++ b/src/content/docs/en/reference/configuration/site.mdx
@@ -26,6 +26,8 @@ site:
       - mybat5 # battery meter reference
     aux:
       - myaux1 # self-regulating consumer
+    consumer:
+      - myconsumer1 # regular consumer, recorded for consumption statistics
     ext:
       - myext1 # for data logging, load management, etc.
   residualPower: 100
@@ -160,6 +162,26 @@ yaml
 aux:
   - myaux1 # first aux meter reference
   - myaux2 # second aux meter reference
+```
+
+### `meters.consumer`
+
+Defines the [`meter`](meters) (current measurement devices) that provide measurement data from regular consumers, e.g. a washing machine or dishwasher, recorded for consumption statistics only. Unlike `aux`, this power is not factored into the available surplus power for vehicle charging.
+
+**Possible values**: A single value or a list of values of a `name` parameter in the [`meters`](#meters) configuration. The list version can also be used with single values.
+
+**Example**:
+
+```yaml
+consumer: myconsumer # single consumer meter reference
+```
+
+or
+
+```yaml
+consumer:
+  - myconsumer1 # first consumer meter reference
+  - myconsumer2 # second consumer meter reference
 ```
 
 ### `residualPower`

--- a/src/content/docs/en/user-defined-devices.mdx
+++ b/src/content/docs/en/user-defined-devices.mdx
@@ -86,7 +86,7 @@ Meters defined under `meters:` can be referenced from `site`:
 - `charge`: Meter for the charging power of the wallbox
 - `aux`: Consumption meter for intelligent consumers
 - `consumer`: Meter for a regular consumer, recorded for consumption statistics
-- `ext`: Additional meter, e.g. for load management or data collection
+- `ext`: Additional meter not used for regulation or shown in the UI, only logged and exported
 
 `power` is the only required attribute.
 Not all meter roles support all attributes:

--- a/src/content/docs/en/user-defined-devices.mdx
+++ b/src/content/docs/en/user-defined-devices.mdx
@@ -85,7 +85,7 @@ Meters defined under `meters:` can be referenced from `site`:
 - `battery`: Home battery meter
 - `charge`: Meter for the charging power of the wallbox
 - `aux`: Consumption meter for intelligent consumers
-- `consumer`: Meter for a regular consumer, recorded for consumption statistics
+- `consumers`: Meters for regular consumers, recorded for consumption statistics
 - `ext`: Additional meter, e.g. for load management or data collection
 
 `power` is the only required attribute.
@@ -117,13 +117,13 @@ To convert, use the [reading pipelines](/en/reference/plugins#reading).
 
 What a positive `power` value and the two energy directions mean depends on the meter role:
 
-| Role                     | `power` positive                 | `energy`   | `returnenergy`     |
-| ------------------------ | -------------------------------- | ---------- | ------------------ |
-| `grid`                   | Grid import                      | Imported   | Exported (feed-in) |
-| `pv`                     | Production                       | Produced   | Consumed (rare)    |
-| `battery`                | Discharging (negative: charging) | Discharged | Charged            |
-| `charge`                 | Charging                         | Charged    | Discharged (V2X)   |
-| `aux`, `ext`, `consumer` | Consumption                      | Consumed   | Produced (rare)    |
+| Role                      | `power` positive                 | `energy`   | `returnenergy`     |
+| ------------------------- | -------------------------------- | ---------- | ------------------ |
+| `grid`                    | Grid import                      | Imported   | Exported (feed-in) |
+| `pv`                      | Production                       | Produced   | Consumed (rare)    |
+| `battery`                 | Discharging (negative: charging) | Discharged | Charged            |
+| `charge`                  | Charging                         | Charged    | Discharged (V2X)   |
+| `aux`, `ext`, `consumers` | Consumption                      | Consumed   | Produced (rare)    |
 
 `energy` and `returnenergy` are increasing meter readings in kWh, ideally lifetime totals like the import and export registers of a grid meter.
 The differences between readings are calculated automatically, so the plugin must return a meter reading and not consumption values per interval.

--- a/src/content/docs/en/user-defined-devices.mdx
+++ b/src/content/docs/en/user-defined-devices.mdx
@@ -85,7 +85,7 @@ Meters defined under `meters:` can be referenced from `site`:
 - `battery`: Home battery meter
 - `charge`: Meter for the charging power of the wallbox
 - `aux`: Consumption meter for intelligent consumers
-- `consumers`: Meters for regular consumers, recorded for consumption statistics
+- `consumer`: Meter for a regular consumer, recorded for consumption statistics
 - `ext`: Additional meter, e.g. for load management or data collection
 
 `power` is the only required attribute.
@@ -117,13 +117,13 @@ To convert, use the [reading pipelines](/en/reference/plugins#reading).
 
 What a positive `power` value and the two energy directions mean depends on the meter role:
 
-| Role                      | `power` positive                 | `energy`   | `returnenergy`     |
-| ------------------------- | -------------------------------- | ---------- | ------------------ |
-| `grid`                    | Grid import                      | Imported   | Exported (feed-in) |
-| `pv`                      | Production                       | Produced   | Consumed (rare)    |
-| `battery`                 | Discharging (negative: charging) | Discharged | Charged            |
-| `charge`                  | Charging                         | Charged    | Discharged (V2X)   |
-| `aux`, `ext`, `consumers` | Consumption                      | Consumed   | Produced (rare)    |
+| Role                     | `power` positive                 | `energy`   | `returnenergy`     |
+| ------------------------ | -------------------------------- | ---------- | ------------------ |
+| `grid`                   | Grid import                      | Imported   | Exported (feed-in) |
+| `pv`                     | Production                       | Produced   | Consumed (rare)    |
+| `battery`                | Discharging (negative: charging) | Discharged | Charged            |
+| `charge`                 | Charging                         | Charged    | Discharged (V2X)   |
+| `aux`, `ext`, `consumer` | Consumption                      | Consumed   | Produced (rare)    |
 
 `energy` and `returnenergy` are increasing meter readings in kWh, ideally lifetime totals like the import and export registers of a grid meter.
 The differences between readings are calculated automatically, so the plugin must return a meter reading and not consumption values per interval.


### PR DESCRIPTION
The `site.meters` reference was missing dedicated sections for the `consumer` and `ext` meter keys, and used the wrong key name (`consumers`) in the meter role list and signs-and-directions table.

- Fix the key name to `consumer` (singular) in the role list and table
- Add `meters.consumer` and `meters.ext` reference sections
- Align the `ext` description with the evcc UI wording (not used for regulation or shown in the UI, only logged and exported)

All changes in both English and German.

Fixes evcc-io/evcc#31513