### PR TITLE
Add missing mDNS port to Docker EEBus examples

### DIFF
--- a/src/content/docs/de/installation/docker.mdx
+++ b/src/content/docs/de/installation/docker.mdx
@@ -117,9 +117,10 @@ sudo docker run -d --name evcc \
 -p 7070:7070 \
 -p 8887:8887 \
 -p 9522:9522/udp \
+-p 5353:5353/udp \
 -p 4712:4712 \
---network host
--v /etc/machine-id:/etc/machine-id
+--network host \
+-v /etc/machine-id:/etc/machine-id \
 # highlight-end
 evcc/evcc:latest
 ```
@@ -214,6 +215,7 @@ services:
       - 7070:7070/tcp
       - 8887:8887/tcp
       - 9522:9522/udp
+      - 5353:5353/udp
       - 4712:4712/tcp
     volumes:
       - /home/user/evcc.yaml:/etc/evcc.yaml

--- a/src/content/docs/en/installation/docker.mdx
+++ b/src/content/docs/en/installation/docker.mdx
@@ -118,6 +118,7 @@ sudo docker run -d --name evcc \
 -p 7070:7070 \
 -p 8887:8887 \
 -p 9522:9522/udp \
+-p 5353:5353/udp \
 -p 4712:4712 \
 --network host \
 -v /etc/machine-id:/etc/machine-id \
@@ -183,6 +184,7 @@ services:
       - 7070:7070/tcp
       - 8887:8887/tcp
       - 9522:9522/udp
+      - 5353:5353/udp
       - 4712:4712/tcp
     volumes:
       - /home/user/evcc.yaml:/etc/evcc.yaml


### PR DESCRIPTION
## Summary
- Ports table already listed `5353/udp` (mDNS) as available for EEBus, but the "SMA Devices and EEBus" CLI and Compose examples omitted it.
- Fixes broken line continuations in the German CLI example (missing trailing `\`).

Prompted by https://github.com/evcc-io/evcc/discussions/28869#discussioncomment-17559821 where a user needed both the EEBus and mDNS ports set to get EEBus working.

## Test plan
- [x] `npm run format` clean (already run)
- [x] Visual check of both EN/DE docker pages in `npm run dev`