### PR TITLE
Shorten aux, consumer and ext meter role descriptions

### DIFF
--- a/src/content/docs/de/reference/configuration/site.mdx
+++ b/src/content/docs/de/reference/configuration/site.mdx
@@ -136,18 +136,7 @@ battery: # (batteries = veraltet)
 
 ### `meters.aux`
 
-Definiert die meter (Strommessgeräte), welche die Messdaten externer Geräte liefern, die über eine eigene Überschussregelung verfügen, aber nicht direkt durch evcc gesteuert werden. Es können mehrere Geräte angegeben werden. Die Leistungsdaten werden automatisch addiert.
-
-In evcc fließt diese Leistung in die Berechnung der prinzipiell zur Verfügung stehenden Überschussleistung zur Fahrzeugladung ein.
-Es wird davon ausgegangen, dass die mittels der Aux-Meter gemessenen Geräte ihren Leistungsbedarf selbstständig und zeitnah reduzieren bzw. vollständig unterbrechen, wenn die gemessene Aux-Leistung durch evcc der Fahrzeugladung zugeschlagen wird.
-
-Positiver Wert: zusätzliche verfügbare Überschussleistung (steht der Fahrzeugladung zur Verfügung)
-
-Negativer Wert: fehlende Überschussleistung (steht der Fahrzeugladung nicht zur Verfügung)
-
-Beispiele:
-
-- Ein Heizstab für die Warmwasserbereitung, welcher autark auf Basis des PV-Überschuss am Netzübergang geregelt wird. Wenn die Leistungsmessung dieses Heizstabes als `aux`-Meter gemessen und eingerichtet wird, steht die gesamte Überschussleistung (Leistung des Heizstabs plus ggf. verbleibende Netzeinspeisung) jederzeit bevorzugt der Fahrzeugladung zur Verfügung. Greift die Fahrzeugladung darauf zu, sorgt die autarke Regelung des Heizstabes selbstständig dafür, dass dessen Leistung entsprechend reduziert wird.
+Zähler für externe Geräte, die über eine eigene Überschussregelung verfügen, aber nicht direkt durch evcc gesteuert werden, z. B. ein selbstregelnder Heizstab. Ihre Leistung fließt in die verfügbare Überschussleistung zur Fahrzeugladung ein, unter der Annahme, dass das Gerät seinen Verbrauch reduziert, sobald evcc diese Leistung der Ladung zuschlägt. Mehrere Zähler werden addiert.
 
 **Mögliche Werte**: Ein Wert oder eine Liste von Werten eines `name` Parameters in der [`meters`](#meters) Konfiguration. Wobei die Listenversion auch bei Einzelwerten genutzt werden kann.
 
@@ -167,7 +156,7 @@ aux:
 
 ### `meters.consumer`
 
-Definiert die [`meter`](meters) (Strommessgeräte), welche die Messdaten regulärer Verbraucher liefern, z. B. einer Waschmaschine oder Spülmaschine, die ausschließlich für die Verbrauchsstatistik erfasst werden. Anders als bei `aux` fließt diese Leistung nicht in die Berechnung der verfügbaren Überschussleistung zur Fahrzeugladung ein.
+Zähler für reguläre Verbraucher wie Waschmaschine oder Spülmaschine, die ausschließlich für die Verbrauchsstatistik erfasst werden. Anders als bei `aux` fließt diese Leistung nicht in die verfügbare Überschussleistung zur Fahrzeugladung ein.
 
 **Mögliche Werte**: Ein Wert oder eine Liste von Werten eines `name` Parameters in der [`meters`](#meters) Konfiguration. Wobei die Listenversion auch bei Einzelwerten genutzt werden kann.
 
@@ -187,7 +176,7 @@ consumer:
 
 ### `meters.ext`
 
-Definiert die [`meter`](meters) (Strommessgeräte), die nicht für die Regelung verwendet oder in der Oberfläche angezeigt werden, z. B. Unterverteilungen oder alternative Netz- oder PV-Zähler. Ihre Daten werden nur geloggt und wie andere Zähler exportiert und fließen weder in die Berechnung der verfügbaren Überschussleistung zur Fahrzeugladung noch in die Verbrauchsstatistik ein.
+Zähler, die nicht für die Regelung verwendet oder in der Oberfläche angezeigt werden, z. B. Unterverteilungen oder alternative Netz- oder PV-Zähler. Ihre Daten werden nur geloggt und exportiert, fließen aber nicht in die Überschuss- oder Verbrauchsstatistik ein.
 
 **Mögliche Werte**: Ein Wert oder eine Liste von Werten eines `name` Parameters in der [`meters`](#meters) Konfiguration. Wobei die Listenversion auch bei Einzelwerten genutzt werden kann.
 

--- a/src/content/docs/en/reference/configuration/site.mdx
+++ b/src/content/docs/en/reference/configuration/site.mdx
@@ -134,17 +134,7 @@ battery: # (batteries = deprecated)
 
 ### `meters.aux`
 
-Defines the meters (current measurement devices) that provide measurement data from external devices that have their own surplus control but are not directly controlled by evcc. Multiple devices can be specified. Power data is automatically added.
-
-In evcc, this power contributes to the calculation of the available surplus power for vehicle charging. It is assumed that devices measured using auxiliary meters will autonomously and promptly reduce or completely interrupt their power consumption when the measured auxiliary power is allocated to vehicle charging by evcc.
-
-Positive value: additional available surplus power (allocated to vehicle charging)
-
-Negative value: insufficient surplus power (not available for vehicle charging)
-
-Examples:
-
-    An immersion heater for hot water production that is autonomously regulated based on PV surplus at the grid connection point. When the power consumption of this immersion heater is measured and configured as an aux meter, the entire surplus power (power of the immersion heater plus any remaining grid feed-in) is always preferentially allocated to vehicle charging. If the vehicle charging accesses it, the autonomous regulation of the immersion heater ensures that its power is reduced accordingly.
+Meters for external devices that run their own surplus control but aren't directly controlled by evcc, e.g. a self-regulating immersion heater. Their power counts toward the available surplus for vehicle charging, on the assumption that the device reduces its consumption when evcc allocates that power to charging. Multiple meters are added up.
 
 **Possible values**: A single value or a list of values of a `name` parameter in the [`meters`](#meters) configuration. The list version can also be used with single values.
 
@@ -156,8 +146,6 @@ aux: myaux # single aux meter reference
 
 or
 
-yaml
-
 ```yaml
 aux:
   - myaux1 # first aux meter reference
@@ -166,7 +154,7 @@ aux:
 
 ### `meters.consumer`
 
-Defines the [`meter`](meters) (current measurement devices) that provide measurement data from regular consumers, e.g. a washing machine or dishwasher, recorded for consumption statistics only. Unlike `aux`, this power is not factored into the available surplus power for vehicle charging.
+Meters for regular consumers such as a washing machine or dishwasher, recorded for consumption statistics only. Unlike `aux`, this power isn't factored into the available surplus for vehicle charging.
 
 **Possible values**: A single value or a list of values of a `name` parameter in the [`meters`](#meters) configuration. The list version can also be used with single values.
 
@@ -186,7 +174,7 @@ consumer:
 
 ### `meters.ext`
 
-Defines the [`meter`](meters) (current measurement devices) that are not used for regulation or shown in the UI, e.g. sub-distributions or alternative grid or solar meters. Their data is only logged and exported like other meters, and does not factor into the available surplus power for vehicle charging or the consumption statistics.
+Meters that aren't used for regulation or shown in the UI, e.g. sub-distributions or alternative grid or solar meters. Their data is only logged and exported, not factored into surplus or consumption statistics.
 
 **Possible values**: A single value or a list of values of a `name` parameter in the [`meters`](#meters) configuration. The list version can also be used with single values.
 


### PR DESCRIPTION
Trim the `meters.aux`, `meters.consumer` and `meters.ext` reference sections:

- Drop the broken `[`meter`](meters)` link and the redundant "current measurement devices" parenthetical
- Collapse the verbose `aux` section (positive/negative values, immersion-heater example) into one sentence
- Fix a stray `yaml` line in the `aux` example

English and German.