### PR TITLE
Clarify heat pump off behavior in docs

### DIFF
--- a/src/components/intros/HeatingIntro.astro
+++ b/src/components/intros/HeatingIntro.astro
@@ -37,6 +37,11 @@ const sgreadySrc = lang === "de" ? sgreadyDe : sgreadyEn;
       Ist <a href="/de/features/solar-charging">Überschussstrom vorhanden</a> oder der <a href="/de/features/dynamic-prices">Netzstrom besonders günstig</a> bzw. <a href="/de/features/co2">sauber</a>, kann evcc die Wärmepumpe in den <strong>Boost-Betrieb</strong> schalten.
       Für den <strong>Dim-Betrieb</strong> wird die Leistungsaufnahme gesenkt, nützlich bei Netzengpässen oder im Rahmen von § 14a EnWG.
     </p>
+    <p>
+      Die Wärmepumpe regelt ihren Betrieb weiterhin selbst.
+      Von außen werden nur <strong>Boost</strong> und <strong>Dim</strong> signalisiert.
+      Wird der Ladepunkt auf <strong>Aus</strong> gestellt, endet damit nur der Boost, die Wärmepumpe wird nicht ausgeschaltet.
+    </p>
 
     <h3>Direkte Kommunikation</h3>
     <p>
@@ -95,6 +100,10 @@ const sgreadySrc = lang === "de" ? sgreadyDe : sgreadyEn;
     <p>
       If <a href="/en/features/solar-charging">solar surplus is available</a> or the <a href="/en/features/dynamic-prices">grid power is particularly cheap</a> or <a href="/en/features/co2">clean</a>, evcc can switch the heat pump to <strong>boost</strong>.
       For <strong>dim</strong>, the power consumption is reduced, useful during grid constraints or within § 14a EnWG.
+    </p>
+    <p>
+      The heat pump keeps running its own operation.
+      Only <strong>boost</strong> and <strong>dim</strong> are signalled on top of that, so switching the loadpoint to <strong>Off</strong> just stops the boost, it doesn't turn the heat pump off.
     </p>
 
     <h3>Direct communication</h3>

--- a/src/components/intros/HeatingIntro.astro
+++ b/src/components/intros/HeatingIntro.astro
@@ -38,9 +38,8 @@ const sgreadySrc = lang === "de" ? sgreadyDe : sgreadyEn;
       Für den <strong>Dim-Betrieb</strong> wird die Leistungsaufnahme gesenkt, nützlich bei Netzengpässen oder im Rahmen von § 14a EnWG.
     </p>
     <p>
-      Die Wärmepumpe regelt ihren Betrieb weiterhin selbst.
-      Von außen werden nur <strong>Boost</strong> und <strong>Dim</strong> signalisiert.
-      Wird der Ladepunkt auf <strong>Aus</strong> gestellt, endet damit nur der Boost, die Wärmepumpe wird nicht ausgeschaltet.
+      Schaltest du den Ladepunkt auf <strong>Aus</strong>, läuft die Wärmepumpe unbeeinflusst in ihrem Normalbetrieb.
+      evcc greift dann nicht mehr ein, schaltet sie aber auch nicht aus.
     </p>
 
     <h3>Direkte Kommunikation</h3>
@@ -102,8 +101,8 @@ const sgreadySrc = lang === "de" ? sgreadyDe : sgreadyEn;
       For <strong>dim</strong>, the power consumption is reduced, useful during grid constraints or within § 14a EnWG.
     </p>
     <p>
-      The heat pump keeps running its own operation.
-      Only <strong>boost</strong> and <strong>dim</strong> are signalled on top of that, so switching the loadpoint to <strong>Off</strong> just stops the boost, it doesn't turn the heat pump off.
+      Switching the loadpoint to <strong>Off</strong> returns the heat pump to its normal, uncontrolled operation.
+      evcc no longer intervenes, but it doesn't switch the heat pump off either.
     </p>
 
     <h3>Direct communication</h3>

--- a/src/components/intros/HeatingIntro.astro
+++ b/src/components/intros/HeatingIntro.astro
@@ -38,8 +38,8 @@ const sgreadySrc = lang === "de" ? sgreadyDe : sgreadyEn;
       Für den <strong>Dim-Betrieb</strong> wird die Leistungsaufnahme gesenkt, nützlich bei Netzengpässen oder im Rahmen von § 14a EnWG.
     </p>
     <p>
-      Schaltest du den Ladepunkt auf <strong>Aus</strong>, läuft die Wärmepumpe unbeeinflusst in ihrem Normalbetrieb.
-      evcc greift dann nicht mehr ein, schaltet sie aber auch nicht aus.
+      Ist der Ladepunkt auf <strong>Aus</strong> gestellt, wird die Wärmepumpe nicht mehr angesteuert.
+      Sie läuft dann unbeeinflusst in ihrem Normalbetrieb weiter.
     </p>
 
     <h3>Direkte Kommunikation</h3>
@@ -101,8 +101,8 @@ const sgreadySrc = lang === "de" ? sgreadyDe : sgreadyEn;
       For <strong>dim</strong>, the power consumption is reduced, useful during grid constraints or within § 14a EnWG.
     </p>
     <p>
-      Switching the loadpoint to <strong>Off</strong> returns the heat pump to its normal, uncontrolled operation.
-      evcc no longer intervenes, but it doesn't switch the heat pump off either.
+      With the loadpoint set to <strong>Off</strong>, the heat pump is no longer controlled.
+      It then keeps running unaffected in its normal operation.
     </p>
 
     <h3>Direct communication</h3>


### PR DESCRIPTION
Adds a short note to the heat pumps section (EN + DE) explaining that evcc only signals **boost** and **dim** on top of the heat pump's own operation.

Switching the loadpoint to **Off** stops the boost, it doesn't turn the heat pump off. This was a recurring point of confusion.

Closes #1094