### PR TITLE
Notifications: template-based services page

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -180,14 +180,16 @@ export default defineConfig({
           link: "/tariffs",
         },
         {
-          label: "External Limit (§14a, §9)",
-          translations: { de: "Externe Begrenzung (§14a, §9)" },
-          link: "/external-limit",
-        },
-        {
           label: "Features",
           translations: { de: "Funktionen" },
-          items: [{ autogenerate: { directory: "features", collapsed: true } }],
+          items: [
+            { autogenerate: { directory: "features", collapsed: true } },
+            {
+              label: "External Limit (§14a, §9)",
+              translations: { de: "Externe Begrenzung (§14a, §9)" },
+              link: "/external-limit",
+            },
+          ],
         },
         {
           label: "Integrations",
@@ -200,6 +202,11 @@ export default defineConfig({
             {
               label: "Sunny Home Manager",
               slug: "integrations/sma-sunny-home-manager",
+            },
+            {
+              label: "Notifications",
+              translations: { de: "Benachrichtigungen" },
+              link: "/notifications",
             },
           ],
         },

--- a/src/components/UserDefinedHint.astro
+++ b/src/components/UserDefinedHint.astro
@@ -1,7 +1,7 @@
 ---
 interface Props {
   lang: "de" | "en";
-  kind?: "device" | "service" | "hems";
+  kind?: "device" | "tariff" | "hems" | "messenger";
   /** When set, the hint also points at the nightly version of the list. */
   nightlyHref?: string;
 }
@@ -11,11 +11,13 @@ const { lang, kind = "device", nightlyHref } = Astro.props;
 const issuesUrl = "https://github.com/evcc-io/evcc/issues/new/choose";
 const userDefinedUrl = `/${lang}/user-defined-devices`;
 const userDefinedAnchor =
-  kind === "service"
+  kind === "tariff"
     ? `${userDefinedUrl}#tariff`
     : kind === "hems"
       ? `${userDefinedUrl}#external-limit`
-      : userDefinedUrl;
+      : kind === "messenger"
+        ? `${userDefinedUrl}#notification-service`
+        : userDefinedUrl;
 
 const featureRequest =
   lang === "de"
@@ -24,12 +26,12 @@ const featureRequest =
 
 const userDefined =
   lang === "de"
-    ? kind === "service"
+    ? kind === "tariff" || kind === "messenger"
       ? `einen <a href="${userDefinedAnchor}">eigenen Dienst</a> über das Plugin-System`
       : kind === "hems"
         ? `eine <a href="${userDefinedAnchor}">eigene Integration</a> über das Plugin-System`
         : `ein <a href="${userDefinedAnchor}">eigenes Gerät</a> über das Plugin-System`
-    : kind === "service"
+    : kind === "tariff" || kind === "messenger"
       ? `your own <a href="${userDefinedAnchor}">user-defined service</a> via the plugin system`
       : kind === "hems"
         ? `your own <a href="${userDefinedAnchor}">user-defined integration</a> via the plugin system`
@@ -54,12 +56,12 @@ if (lang === "de") {
 
 const title =
   lang === "de"
-    ? kind === "service"
+    ? kind === "tariff" || kind === "messenger"
       ? "Dein Dienst nicht dabei?"
       : kind === "hems"
         ? "Deine Integration nicht dabei?"
         : "Dein Gerät nicht dabei?"
-    : kind === "service"
+    : kind === "tariff" || kind === "messenger"
       ? "Service not in the list?"
       : kind === "hems"
         ? "Integration not in the list?"

--- a/src/components/intros/NotificationsIntro.astro
+++ b/src/components/intros/NotificationsIntro.astro
@@ -1,0 +1,24 @@
+---
+interface Props {
+  lang: "de" | "en";
+}
+const { lang } = Astro.props;
+---
+
+{lang === "de" ? (
+  <>
+    <p>
+      Über Benachrichtigungen bleibst du über deine Ladevorgänge auf dem Laufenden, z.&nbsp;B. per Telegram, Pushover, ntfy oder E-Mail.
+      Du legst fest, bei welchen Ereignissen eine Nachricht verschickt wird, und kannst Titel und Inhalt mit Platzhaltern selbst gestalten.
+      Die Einrichtung erfolgt über <strong>Konfiguration → Benachrichtigungen</strong>.
+    </p>
+  </>
+) : (
+  <>
+    <p>
+      Notifications keep you up to date about your charging sessions, e.g. via Telegram, Pushover, ntfy or email.
+      You choose which events trigger a message and can customise title and content with placeholders.
+      Configuration is done via <strong>Configuration → Notifications</strong>.
+    </p>
+  </>
+)}

--- a/src/components/intros/NotificationsOutro.astro
+++ b/src/components/intros/NotificationsOutro.astro
@@ -1,0 +1,238 @@
+---
+import { Code } from "@astrojs/starlight/components";
+
+interface Props {
+  lang: "de" | "en";
+}
+const { lang } = Astro.props;
+---
+
+{lang === "de" ? (
+  <>
+    <h2 id="events">Ereignisse</h2>
+    <p>Nachrichten können für folgende Ereignisse verschickt werden:</p>
+    <table>
+      <thead>
+        <tr><th>Ereignis</th><th>Wird ausgelöst, wenn …</th></tr>
+      </thead>
+      <tbody>
+        <tr><td><code>start</code></td><td>das Laden beginnt</td></tr>
+        <tr><td><code>stop</code></td><td>das Laden beendet wird</td></tr>
+        <tr><td><code>connect</code></td><td>ein Fahrzeug angeschlossen wird</td></tr>
+        <tr><td><code>disconnect</code></td><td>ein Fahrzeug getrennt wird</td></tr>
+        <tr><td><code>soc</code></td><td>sich der Ladestand des Fahrzeugs ändert</td></tr>
+        <tr><td><code>guest</code></td><td>ein unbekanntes Fahrzeug erkannt wird</td></tr>
+        <tr><td><code>asleep</code></td><td>ein Fahrzeug trotz Ladefreigabe nicht lädt</td></tr>
+        <tr><td><code>planoverrun</code></td><td>ein Ladeplan sein Ziel voraussichtlich verfehlt</td></tr>
+      </tbody>
+    </table>
+    <p>
+      Jedes Ereignis hat einen Titel und eine Nachricht.
+      Beide lassen sich mit <a href="#placeholders">Platzhaltern</a> individuell gestalten.
+    </p>
+
+    <h2 id="message-format">Nachrichtenformat</h2>
+    <p>Nachricht mit einfacher Syntax, z.&nbsp;B. für das Ereignis <code>stop</code>:</p>
+    <Code
+      lang="txt"
+      code={"${title}: ${vehicleTitle} geladen mit ${chargedEnergy:%.1fk}kWh in ${chargeDuration}.\nSonnenanteil: ${sessionSolarPercentage:%.0f}%"}
+    />
+    <p>Dieselbe Nachricht mit Go-Template-Syntax, mit Berechnungen (z.&nbsp;B. Umrechnung W → kW) und Bedingungen:</p>
+    <Code
+      lang="txt"
+      code={"{{.title}}: {{round (divf .chargedEnergy 1000) 1 }} kWh in {{.chargeDuration}}.\nSonnenanteil: {{round .sessionSolarPercentage 0 }}%\n{{- if .sessionPrice}}\nKosten: {{round .sessionPrice 2 }} {{.currency}} ({{round .sessionPricePerKWh 2 }} {{.currency}}/kWh)\n{{- end}}"}
+    />
+    <h3 id="placeholders">Platzhalter</h3>
+    <p>
+      In Titel und Nachricht können Variablen verwendet werden, um evcc-Informationen anzuzeigen.
+      Es gibt zwei Schreibweisen, die auch kombiniert werden können:
+    </p>
+    <ul>
+      <li>
+        <strong>Einfach</strong>: <code>{"${variablenName}"}</code>, z.&nbsp;B. <code>{"${vehicleTitle}"}</code>.
+        Optional mit Formatierung wie <code>{"${pvPower:%.1fk}"}</code>: neben den üblichen <code>printf</code>-Angaben teilt das Suffix <code>k</code> den Wert durch 1000 (z.&nbsp;B. Wh → kWh).
+        Zeitdauern wie <code>{"${chargeDuration}"}</code> werden automatisch sekundengenau ausgegeben (z.&nbsp;B. <code>1h23m4s</code>).
+      </li>
+      <li>
+        <strong>Go-Template</strong>: <code>{"{{.variablenName}}"}</code> — ermöglicht Berechnungen, Bedingungen und <a href="http://masterminds.github.io/sprig/">sprig-Funktionen</a>.
+      </li>
+    </ul>
+    <aside class="starlight-aside starlight-aside--note" aria-label="Hinweis">
+      <p class="starlight-aside__title" aria-hidden="true">Hinweis</p>
+      <div class="starlight-aside__content">
+        <p>Bei Nutzung der Variablen ist auf die korrekte Schreibweise (groß/klein) zu achten!</p>
+      </div>
+    </aside>
+
+    <h3 id="variables">Verfügbare Variablen</h3>
+    <p>
+      Die verfügbaren Variablen entsprechen den Daten der <a href="/integrations/rest-api">REST API</a>.
+      Beim Versand einer Nachricht werden die Daten des auslösenden Ladepunkts und die globalen Daten in einer flachen Struktur zusammengeführt.
+      D.&nbsp;h. sowohl globale Werte (z.&nbsp;B. <code>pvPower</code>, <code>grid.Power</code>) als auch ladepunktspezifische Werte (z.&nbsp;B. <code>mode</code>, <code>chargedEnergy</code>, <code>vehicleTitle</code>) sind direkt verfügbar.
+      Verschachtelte Werte wie <code>grid.Power</code> oder <code>battery.Soc</code> sind nur mit der Go-Template-Syntax erreichbar; die Großschreibung der Feldnamen ist dabei erforderlich.
+    </p>
+    <p>Häufig genutzte Ladepunkt-Variablen:</p>
+    <ul>
+      <li><code>title</code>: Name des Ladepunkts</li>
+      <li><code>loadpoint</code>: Nummer des Ladepunkts 1, 2, …</li>
+      <li><code>mode</code>: Lademodus <code>off</code>/<code>now</code>/<code>minpv</code>/<code>pv</code></li>
+      <li><code>charging</code>: Ladevorgang aktiv</li>
+      <li><code>enabled</code>: Ladefreigabe erteilt</li>
+      <li><code>connected</code>: Fahrzeug angeschlossen</li>
+      <li><code>chargedEnergy</code>: Geladene Energie der Sitzung in Wh</li>
+      <li><code>chargeDuration</code>: Ladedauer</li>
+      <li><code>chargePower</code>: Aktuelle Ladeleistung in W</li>
+      <li><code>connectedDuration</code>: Anschlussdauer</li>
+      <li><code>chargeRemainingDuration</code>: Restladezeit bis Ziel</li>
+      <li><code>chargeRemainingEnergy</code>: Restenergie bis Ziel in Wh</li>
+      <li><code>phasesActive</code>: Aktuell aktive Phasen</li>
+      <li><code>vehicleTitle</code>: Name des Fahrzeugs</li>
+      <li><code>vehicleName</code>: Technischer Name des Fahrzeugs</li>
+      <li><code>vehicleSoc</code>: Fahrzeug-Ladestand in %</li>
+      <li><code>vehicleRange</code>: Fahrzeug-Reichweite in km</li>
+      <li><code>vehicleOdometer</code>: Kilometerstand in km</li>
+      <li><code>sessionSolarPercentage</code>: Sonnenanteil der Ladesitzung in %</li>
+      <li><code>sessionPrice</code>: Kosten der Ladesitzung</li>
+      <li><code>sessionPricePerKWh</code>: Durchschnittspreis pro kWh</li>
+      <li><code>sessionCo2PerKWh</code>: Durchschnittliche CO₂-Emissionen pro kWh</li>
+      <li><code>planActive</code>: Ladeplan aktiv</li>
+      <li><code>smartCostActive</code>: Günstiges Laden aktiv</li>
+    </ul>
+    <p>Häufig genutzte globale Variablen:</p>
+    <ul>
+      <li><code>siteTitle</code>: Name der evcc-Instanz</li>
+      <li><code>pvPower</code>: Aktuelle PV-Leistung in W</li>
+      <li><code>homePower</code>: Aktueller Hausverbrauch in W</li>
+      <li><code>grid.Power</code>: Netzbezug (+) / Einspeisung (−) in W</li>
+      <li><code>battery.Power</code>: Batterieleistung in W</li>
+      <li><code>battery.Soc</code>: Batterie-Ladestand in %</li>
+      <li><code>currency</code>: Tarif-Währung</li>
+      <li><code>tariffGrid</code>: Aktueller Netzpreis pro kWh</li>
+      <li><code>tariffFeedIn</code>: Einspeisevergütung pro kWh</li>
+      <li><code>tariffCo2</code>: Aktuelle CO₂-Intensität</li>
+      <li><code>statistics.&lt;zeitraum&gt;.*</code>: Ladestatistiken für die Zeiträume <code>30d</code>, <code>365d</code>, <code>thisYear</code> und <code>total</code> (<code>avgCo2</code>, <code>avgPrice</code>, <code>chargedKWh</code>, <code>solarPercentage</code>)</li>
+    </ul>
+    <p>
+      Die vollständige Liste aller verfügbaren Felder findest du in der API-Antwort unter <code>http://evcc.local:7070/api/state</code>.
+    </p>
+
+    <p>
+      Beide Schreibweisen funktionieren in den Titel- und Nachrichtenfeldern der Oberfläche.
+      Die Konfiguration über <code>evcc.yaml</code> ist in der <a href="/de/reference/configuration/messaging"><code>messaging</code>-Referenz</a> beschrieben.
+    </p>
+  </>
+) : (
+  <>
+    <h2 id="events">Events</h2>
+    <p>Messages can be sent for the following events:</p>
+    <table>
+      <thead>
+        <tr><th>Event</th><th>Fires when …</th></tr>
+      </thead>
+      <tbody>
+        <tr><td><code>start</code></td><td>charging starts</td></tr>
+        <tr><td><code>stop</code></td><td>charging finishes</td></tr>
+        <tr><td><code>connect</code></td><td>a vehicle is connected</td></tr>
+        <tr><td><code>disconnect</code></td><td>a vehicle is disconnected</td></tr>
+        <tr><td><code>soc</code></td><td>the vehicle state of charge changes</td></tr>
+        <tr><td><code>guest</code></td><td>an unknown vehicle is detected</td></tr>
+        <tr><td><code>asleep</code></td><td>a vehicle does not charge despite charge release</td></tr>
+        <tr><td><code>planoverrun</code></td><td>a charging plan is projected to miss its target</td></tr>
+      </tbody>
+    </table>
+    <p>
+      Each event has a title and a message.
+      Both can be customised with <a href="#placeholders">placeholders</a>.
+    </p>
+
+    <h2 id="message-format">Message Format</h2>
+    <p>Message with simple syntax, e.g. for the <code>stop</code> event:</p>
+    <Code
+      lang="txt"
+      code={"${title}: ${vehicleTitle} charged ${chargedEnergy:%.1fk}kWh in ${chargeDuration}.\nSolar share: ${sessionSolarPercentage:%.0f}%"}
+    />
+    <p>The same message with Go template syntax, with calculations (e.g. converting W to kW) and conditions:</p>
+    <Code
+      lang="txt"
+      code={"{{.title}}: {{round (divf .chargedEnergy 1000) 1 }} kWh in {{.chargeDuration}}.\nSolar share: {{round .sessionSolarPercentage 0 }}%\n{{- if .sessionPrice}}\nCost: {{round .sessionPrice 2 }} {{.currency}} ({{round .sessionPricePerKWh 2 }} {{.currency}}/kWh)\n{{- end}}"}
+    />
+    <h3 id="placeholders">Placeholders</h3>
+    <p>
+      Titles and messages can use variables to display evcc information.
+      There are two syntax options, which can also be combined:
+    </p>
+    <ul>
+      <li>
+        <strong>Simple</strong>: <code>{"${variableName}"}</code>, e.g. <code>{"${vehicleTitle}"}</code>.
+        Optionally with formatting like <code>{"${pvPower:%.1fk}"}</code>: besides the usual <code>printf</code> specifiers, the suffix <code>k</code> divides the value by 1000 (e.g. Wh → kWh).
+        Durations like <code>{"${chargeDuration}"}</code> render rounded to whole seconds (e.g. <code>1h23m4s</code>).
+      </li>
+      <li>
+        <strong>Go template</strong>: <code>{"{{.variableName}}"}</code> — enables calculations, conditions, and <a href="http://masterminds.github.io/sprig/">sprig functions</a>.
+      </li>
+    </ul>
+    <aside class="starlight-aside starlight-aside--note" aria-label="Note">
+      <p class="starlight-aside__title" aria-hidden="true">Note</p>
+      <div class="starlight-aside__content">
+        <p>When using variables, make sure to use the correct capitalisation (uppercase/lowercase)!</p>
+      </div>
+    </aside>
+
+    <h3 id="variables">Available Variables</h3>
+    <p>
+      The available variables correspond to the data from the <a href="/integrations/rest-api">REST API</a>.
+      When sending a message, the data of the triggering loadpoint and the global data are merged into a flat structure.
+      This means both global values (e.g. <code>pvPower</code>, <code>grid.Power</code>) and loadpoint-specific values (e.g. <code>mode</code>, <code>chargedEnergy</code>, <code>vehicleTitle</code>) are directly accessible.
+      Nested values like <code>grid.Power</code> or <code>battery.Soc</code> are only accessible with the Go template syntax; the capitalised field names are required there.
+    </p>
+    <p>Commonly used loadpoint variables:</p>
+    <ul>
+      <li><code>title</code>: Loadpoint name</li>
+      <li><code>loadpoint</code>: Loadpoint number 1, 2, …</li>
+      <li><code>mode</code>: Charge mode <code>off</code>/<code>now</code>/<code>minpv</code>/<code>pv</code></li>
+      <li><code>charging</code>: Charging active</li>
+      <li><code>enabled</code>: Charging enabled</li>
+      <li><code>connected</code>: Vehicle connected</li>
+      <li><code>chargedEnergy</code>: Energy charged in session in Wh</li>
+      <li><code>chargeDuration</code>: Charging duration</li>
+      <li><code>chargePower</code>: Current charge power in W</li>
+      <li><code>connectedDuration</code>: Connection duration</li>
+      <li><code>chargeRemainingDuration</code>: Remaining charge time until target</li>
+      <li><code>chargeRemainingEnergy</code>: Remaining energy until target in Wh</li>
+      <li><code>phasesActive</code>: Currently active phases</li>
+      <li><code>vehicleTitle</code>: Vehicle name</li>
+      <li><code>vehicleName</code>: Technical vehicle name</li>
+      <li><code>vehicleSoc</code>: Vehicle state of charge in %</li>
+      <li><code>vehicleRange</code>: Vehicle range in km</li>
+      <li><code>vehicleOdometer</code>: Odometer reading in km</li>
+      <li><code>sessionSolarPercentage</code>: Solar share of charging session in %</li>
+      <li><code>sessionPrice</code>: Cost of charging session</li>
+      <li><code>sessionPricePerKWh</code>: Average price per kWh</li>
+      <li><code>sessionCo2PerKWh</code>: Average CO₂ emissions per kWh</li>
+      <li><code>planActive</code>: Charge plan active</li>
+      <li><code>smartCostActive</code>: Smart cost charging active</li>
+    </ul>
+    <p>Commonly used global variables:</p>
+    <ul>
+      <li><code>siteTitle</code>: Name of the evcc instance</li>
+      <li><code>pvPower</code>: Current solar power in W</li>
+      <li><code>homePower</code>: Current home consumption in W</li>
+      <li><code>grid.Power</code>: Grid import (+) / export (−) in W</li>
+      <li><code>battery.Power</code>: Battery power in W</li>
+      <li><code>battery.Soc</code>: Battery state of charge in %</li>
+      <li><code>currency</code>: Tariff currency</li>
+      <li><code>tariffGrid</code>: Current grid price per kWh</li>
+      <li><code>tariffFeedIn</code>: Feed-in tariff per kWh</li>
+      <li><code>tariffCo2</code>: Current CO₂ intensity</li>
+      <li><code>statistics.&lt;period&gt;.*</code>: Charging statistics for the periods <code>30d</code>, <code>365d</code>, <code>thisYear</code>, and <code>total</code> (<code>avgCo2</code>, <code>avgPrice</code>, <code>chargedKWh</code>, <code>solarPercentage</code>)</li>
+    </ul>
+    <p>
+      The complete list of all available fields can be found in the API response at <code>http://evcc.local:7070/api/state</code>.
+    </p>
+
+    <p>
+      Both syntaxes work in the title and message fields of the UI.
+      Configuration via <code>evcc.yaml</code> is described in the <a href="/en/reference/configuration/messaging"><code>messaging</code> reference</a>.
+    </p>
+  </>
+)}

--- a/src/components/lists/NotificationsList.astro
+++ b/src/components/lists/NotificationsList.astro
@@ -1,0 +1,78 @@
+---
+import { getCollection } from "astro:content";
+import StarlightPage from "@astrojs/starlight/components/StarlightPage.astro";
+import DeviceCardList from "@components/DeviceCardList.astro";
+import NotificationsIntro from "@components/intros/NotificationsIntro.astro";
+import NotificationsOutro from "@components/intros/NotificationsOutro.astro";
+import UserDefinedHint from "@components/UserDefinedHint.astro";
+import ChannelListNav from "@components/ChannelListNav.astro";
+import { sortDevices, collectionName, nightlyPageHead } from "@utils/devices";
+import type { Channel } from "@utils/devices";
+
+interface Props {
+  lang: "de" | "en";
+  channel: Channel;
+}
+const { lang, channel } = Astro.props;
+const isNightly = channel === "nightly";
+
+const coll = await getCollection(
+  collectionName("messengers", lang, channel) as any,
+);
+const devices = sortDevices(coll as any);
+const basePath = `/${lang}${isNightly ? "/nightly" : ""}/notifications`;
+
+const title = lang === "de" ? "Benachrichtigungen" : "Notifications";
+const description =
+  lang === "de"
+    ? "Benachrichtigungen über Ladevorgänge per Telegram, Pushover, ntfy, E-Mail und mehr."
+    : "Notifications about your charging sessions via Telegram, Pushover, ntfy, email, and more.";
+
+const headings =
+  lang === "de"
+    ? [
+        { depth: 2, slug: "services", text: "Dienste" },
+        { depth: 2, slug: "events", text: "Ereignisse" },
+        { depth: 2, slug: "message-format", text: "Nachrichtenformat" },
+        { depth: 3, slug: "placeholders", text: "Platzhalter" },
+        { depth: 3, slug: "variables", text: "Verfügbare Variablen" },
+      ]
+    : [
+        { depth: 2, slug: "services", text: "Services" },
+        { depth: 2, slug: "events", text: "Events" },
+        { depth: 2, slug: "message-format", text: "Message Format" },
+        { depth: 3, slug: "placeholders", text: "Placeholders" },
+        { depth: 3, slug: "variables", text: "Available Variables" },
+      ];
+
+const frontmatter = {
+  title,
+  description,
+  template: "doc",
+  ...(isNightly ? { pagefind: false, head: nightlyPageHead } : {}),
+};
+---
+
+<StarlightPage frontmatter={frontmatter} headings={headings}>
+  {isNightly && <ChannelListNav lang={lang} channel={channel} category="notifications" />}
+  <NotificationsIntro lang={lang} />
+  <h2 id="services">{lang === "de" ? "Dienste" : "Services"}</h2>
+  {
+    lang === "de" ? (
+      <p>
+        Unter <strong>Dienste</strong> fügst du einen oder mehrere der
+        folgenden Dienste hinzu.
+      </p>
+    ) : (
+      <p>
+        Under <strong>Services</strong>, add one or more of the services listed
+        below.
+      </p>
+    )
+  }
+  <DeviceCardList devices={devices as any} lang={lang} basePath={basePath} flat />
+  {channel === "release" && (
+    <UserDefinedHint lang={lang} kind="messenger" nightlyHref={`/${lang}/nightly/notifications`} />
+  )}
+  <NotificationsOutro lang={lang} />
+</StarlightPage>

--- a/src/components/lists/TariffsList.astro
+++ b/src/components/lists/TariffsList.astro
@@ -98,6 +98,6 @@ const frontmatter = {
     )
   }
   {channel === "release" && (
-    <UserDefinedHint lang={lang} kind="service" nightlyHref={`/${lang}/nightly/tariffs`} />
+    <UserDefinedHint lang={lang} kind="tariff" nightlyHref={`/${lang}/nightly/tariffs`} />
   )}
 </StarlightPage>

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -107,6 +107,8 @@ export const collections = {
   "tariffs-en": deviceCollection("en", "tariff"),
   "hems-de": deviceCollection("de", "hems"),
   "hems-en": deviceCollection("en", "hems"),
+  "messengers-de": deviceCollection("de", "messenger"),
+  "messengers-en": deviceCollection("en", "messenger"),
   "chargers-nightly-de": deviceCollection("de", "charger", "nightly"),
   "chargers-nightly-en": deviceCollection("en", "charger", "nightly"),
   "meters-nightly-de": deviceCollection("de", "meter", "nightly"),
@@ -117,4 +119,6 @@ export const collections = {
   "tariffs-nightly-en": deviceCollection("en", "tariff", "nightly"),
   "hems-nightly-de": deviceCollection("de", "hems", "nightly"),
   "hems-nightly-en": deviceCollection("en", "hems", "nightly"),
+  "messengers-nightly-de": deviceCollection("de", "messenger", "nightly"),
+  "messengers-nightly-en": deviceCollection("en", "messenger", "nightly"),
 };

--- a/src/content/docs/de/index.mdx
+++ b/src/content/docs/de/index.mdx
@@ -103,6 +103,7 @@ Du willst mehr? Diese Funktionen und Integrationen gehen über die Grundlagen hi
 - [Dynamische Einspeisung](/de/features/dynamic-feedin): variable Einspeisevergütung berücksichtigen
 - [Mindestladung & Ladelimit](/de/features/limits): schnelle Grundladung und Ladegrenzen
 - [Externe Begrenzung (§ 14a EnWG & § 9 EEG)](/de/external-limit): Vorgaben des Netzbetreibers
+- [Benachrichtigungen](/de/notifications): Nachrichten über deine Ladevorgänge
 - [Home Assistant](/de/integrations/home-assistant): Integration in dein Smart Home
 - [REST-API](/de/integrations/rest-api) und [MQTT-API](/de/integrations/mqtt-api): Anbindung anderer Systeme
 - [MCP-Server](/de/integrations/mcp): Anbindung von KI-Assistenten

--- a/src/content/docs/de/installation/configuration.mdx
+++ b/src/content/docs/de/installation/configuration.mdx
@@ -41,7 +41,7 @@ Im Konfigurationsbereich kannst du folgende Komponenten einrichten:
 Zusätzlich kannst du verschiedene Dienste und Protokolle einbinden:
 
 - **MQTT**: Datenaustausch mit anderen Systemen im Netzwerk
-- **Benachrichtigungen**: Push-Nachrichten und E-Mail-Benachrichtigungen
+- **[Benachrichtigungen](/de/notifications)**: Push-Nachrichten und E-Mail-Benachrichtigungen
 - **InfluxDB**: Datenexport für Langzeitauswertungen
 - **EEBus**: Kommunikation mit anderen EEBus-Geräten
 - **OCPP Server**: Verbindung mit OCPP-fähigen Wallboxen

--- a/src/content/docs/de/integrations/home-assistant.mdx
+++ b/src/content/docs/de/integrations/home-assistant.mdx
@@ -85,7 +85,7 @@ Solange die Daten als Home Assistant Entität vorliegen, kann evcc damit arbeite
 - **[Wallboxen](/de/chargers#home-assistant-charger)** mit Status, Ein-/Ausschalten und maximalem Ladestrom
 - **[Schaltbare Steckdosen](/de/smartswitches#home-assistant-switch)** mit einfacher Ein-/Aus-Steuerung (für Smartplugs, Relais)
 - **[Fahrzeuge](/de/vehicles#home-assistant)** mit SoC, Reichweite, Status, Kilometerstand; optional Skripte zum Starten/Stoppen
-- **[Benachrichtigungen](/de/reference/configuration/messaging)** unter **Konfiguration → Benachrichtigungen** kannst du evcc-Meldungen über Home Assistant versenden
+- **[Benachrichtigungen](/de/notifications)** unter **Konfiguration → Benachrichtigungen** kannst du evcc-Meldungen über Home Assistant versenden
 
 ## Weitere Ressourcen (Videos)
 

--- a/src/content/docs/de/reference/configuration/messaging.md
+++ b/src/content/docs/de/reference/configuration/messaging.md
@@ -4,9 +4,8 @@ sidebar:
   order: 12
 ---
 
-evcc unterstützt die Übermittlung von Status-Informationen über [Telegram](https://telegram.org), [PushOver](https://pushover.net), [ntfy](https://ntfy.sh) und viele weitere Dienste über das System [shoutrrr](https://containrrr.dev/shoutrrr/). Die Konfiguration ermöglich es eigene Nachrichten für bestimmte Ereignisse und Systeme zu definieren.
-
-`messaging` definiert in Subelementen was und wie es verschickt wird. Unter `events` müssen die Ereignisse definiert werden, für welche Nachrichten verschickt werden sollen. Und unter `services` die Dienste über welche die Nachrichten verschickt werden sollen.
+Der Abschnitt `messaging` konfiguriert [Benachrichtigungen](/de/notifications) über Ladevorgänge per Diensten wie Telegram, Pushover, ntfy oder E-Mail.
+Unter `events` wird definiert, für welche Ereignisse Nachrichten verschickt werden, unter `services`, wohin sie verschickt werden.
 
 **Beispiel**:
 
@@ -29,46 +28,25 @@ Die verfügbaren Ereignisse sind:
 - `soc`: Fahrzeug Akku-Ladestandsänderung
 - `guest`: Unbekanntes Fahrzeug erkannt
 - `asleep`: Fahrzeug lädt nicht trotz Ladefreigabe
+- `planoverrun`: Ladeplan verfehlt voraussichtlich sein Ziel
 
 **Beispiel**:
 
 ```yaml
 start: # charge start event
-  title: Charge started
-  msg: Started charging in "${mode}" mode
+  title: Laden gestartet
+  msg: Laden im Modus "${mode}" gestartet
 ```
 
 ### `title`
 
 `title` definiert den Text für den Nachrichtentitel.
 
-**Beispiel**:
-
-```yaml
-title: Charge started
-```
-
 ### `msg`
 
 `msg` definiert den Text für den Nachrichteninhalt.
-Im Text können verschiedene Variablen zur Anzeige von evcc Informationen verwendet werden.
-
-Es gibt zwei Schreibweisen:
-
-- **Einfach**: `${<Variablenname>}` — z. B. `${vehicleTitle}`, mit optionaler Formatierung wie `${pvPower:%.1fk}`
-- **Go-Template**: `{{.variablenname}}` — ermöglicht Berechnungen, Bedingungen und [sprig-Funktionen](http://masterminds.github.io/sprig/)
-
-:::note
-Bei Nutzung der Variablen ist auf die korrekte Schreibweise (groß/klein) zu achten!
-:::
-
-#### Verfügbare Variablen
-
-Die verfügbaren Variablen entsprechen den Daten der evcc REST API unter `http://evcc.local:7070/api/state`.
-Beim Versand einer Nachricht werden die Daten des jeweiligen Ladepunkts und die globalen Daten in einer flachen Struktur zusammengeführt.
-D. h. sowohl globale Werte (z. B. `pvPower`, `grid.Power`) als auch ladepunktspezifische Werte (z. B. `mode`, `chargedEnergy`, `vehicleTitle`) sind direkt verfügbar.
-
-Eine [Auswahl nützlicher Variablen](#variable-reference) findest du am Ende dieser Seite.
+Titel und Nachricht unterstützen Platzhalter, entweder in der einfachen Form `${variablenName}` oder als Go-Template (`{{.variablenName}}`).
+Die verfügbaren Variablen sind unter [Nachrichtenformat](/de/notifications#message-format) aufgeführt.
 
 **Beispiel** (einfache Syntax):
 
@@ -94,10 +72,7 @@ messaging:
         ${vehicleTitle} getrennt von ${title} nach ${connectedDuration}
 ```
 
-:::note
-Zum Rendern der `msg`-Texte kann auch die [go-Text-Template](https://pkg.go.dev/text/template)-Syntax in Kombination mit [sprig-Funktionen](http://masterminds.github.io/sprig/) genutzt werden.
-
-Damit sind Berechnungen (z. B. Umrechnung W → kW) und Bedingungen möglich.
+**Beispiel** (Go-Template-Syntax mit Berechnungen und Bedingungen):
 
 ```yaml
 messaging:
@@ -129,216 +104,23 @@ messaging:
         {{.vehicleTitle}} getrennt von {{.title}} nach {{.connectedDuration}}.
 ```
 
-:::
-
 ## `services`
 
-`services` definiert eine Liste von zu verwendeten Nachrichtendiensten.
+`services` definiert eine Liste der zu verwendenden Nachrichtendienste.
 
 **Beispiel**:
 
 ```yaml
 services:
-  - type: pushover
+  - type: template
+    template: pushover
     app: 12345
     recipients:
       - 234567
 ```
 
-Im folgenden werden nun alle erforderlichen Parameter erklärt.
+Die verfügbaren Dienste und ihre Parameter sind auf der Seite [Benachrichtigungen](/de/notifications#services) aufgeführt.
+Jede Dienstseite zeigt ein fertiges `evcc.yaml`-Beispiel.
 
-### `type`
-
-`type` definiert den Nachrichtendienst der verwendet werden soll.
-
-**Mögliche Werte**:
-
-- `pushover`: [Pushover](https://pushover.net/). Siehe [`pushover`](#pushover) Definition
-- `telegram`: [Telegram Messenger](https://telegram.org/). Siehe [`telegram`](#telegram) Definition
-- `email`: Email. Siehe [`email`](#email) Definition
-- `shout`: [shoutrrr](https://containrrr.dev/shoutrrr). Siehe [`shout`](#shout) Definition
-- `ntfy`: [ntfy](https://ntfy.sh). Siehe [`ntfy`](#ntfy) Definition
-- `custom`: Ermöglicht die Nutzung von allen [Plugins](/de/reference/plugins), die einen Schreibzugriff erlauben. Siehe [`custom`](#custom) Definition.
-
----
-
-## Unterstützte Dienste
-
-### `pushover`
-
-`pushover` verwendet den Dienst [Pushover](https://pushover.net/). Details siehe [Pushover API](https://pushover.net/api).
-
-**Beispiel**:
-
-```yaml
-- type: pushover
-  app: # API Token/Key der in Pushover angelegten Aplication
-  recipients:
-    -  # Liste der Empfänger: entweder User Key or Delivery Group. In Pushover angelegte Gruppen können auf bestimmte Geräte eingeschränkt werden.
-  devices:
-    - Johns phone
-    - Mias ticker
-```
-
-### `telegram`
-
-`telegram` verwendet den Dienst [Telegram Messenger](https://telegram.org/).
-
-**Beispiel**:
-
-```yaml
-- type: telegram
-  token: # bot id : jede laufende Instanz von evcc benötigt eine eigene bot id
-  chats:
-    -  # Liste von Chat oder Group IDs. Jeder Eintrag benötigt ein - Zeichen am Anfang und muss in einer eigenen Zeile sein.
-    - -GroupID #Achtung Group IDs in Telegram haben ein -Zeichen
-    - ChatID
-```
-
-### `email`
-
-`email` verwendet den Dienst [shoutrrr](https://containrrr.dev/shoutrrr).
-
-Hier wird der Parameter `uri` mit dem Wert `smtp://<user>:<password>@<host>:<port>/?fromAddress=<from>&toAddresses=<to>` erwartet. Die Platzhalter sind wie folgt zu ersetzen:
-
-- `<host>`: Adresse (hostname oder IP Adresse) des Email Servers
-- `<port>`: Port Adresse des Email Servers
-- `<user>`: Benutzername für den Email Server
-- `<password>`: Passwort des Benutzers
-- `<from>`: Email Adresse des Absenders
-- `<to>`: Email Adresse des Empfängers
-
-**Beispiel**:
-
-```yaml
-- type: email
-  uri: smtp://benutzername:passwort@emailserver.domäne:1234/?fromAddress=absender@mail.com&toAddresses=empfänger@mail.com
-```
-
-### `shout`
-
-`shout` verwendet den Dienst [shoutrrr](https://containrrr.dev/shoutrrr) und unterstützt alle seine Dienste.
-
-Die Konfiguration wird im folgenden Beispiel anhand von [Gotify](https://gotify.net/) gezeigt und funktioniert bei den anderen Möglichkeiten über den gleichen Weg.
-
-**Beispiel**:
-
-```yaml
-- type: shout
-  uri: gotify://gotify.example.com:443/AzyoeNS.D4iJLVa/?priority=1
-```
-
-Weitere Informationen sind in der [shoutrrr](https://containrrr.dev/shoutrrr) Dokumentation zu den [unterstützten Diensten](https://containrrr.dev/shoutrrr/v0.5/services/overview/) zu finden.
-
-### `ntfy`
-
-`ntfy` verwendet den Dienst [ntfy](https://ntfy.sh).
-
-Hier wird der Parameter `uri` mit dem Wert `https://<host>/<topics>` erwartet. Die Platzhalter sind wie folgt zu ersetzen:
-
-- `<host>`: Adresse (hostname oder IP Adresse) des ntfy Servers
-- `<topics>`: Abonniertes Thema oder abonnierte Themen
-
-Optionale Parameter sind `priority`, `tags` und `authtoken`. Alle Parameter werden als Strings übergeben.
-
-**Beispiel**:
-
-```yaml
-- type: ntfy
-  uri: https://ntfy.sh/evcctestalerts
-  priority: default
-  tags: electric_plug,blue_car
-  authtoken: 61RgoYLOsi8S318j6ycU2qEsleC2p9njoyw4890121412JloH7rMPaqQwi5KWTit
-```
-
-Weitere Informationen sind in der [ntfy Dokumentation](https://docs.ntfy.sh) zu finden.
-
-### `custom`
-
-Der Typ `custom` ermöglicht es, beliebige [Plugins](/de/reference/plugins) für die Verarbeitung von Nachrichten zu verwenden. Das Plugin muss den Schreibmodus unterstützen. Die Nachricht selbst wird in der Plugin Konfiguration mit dem Parameter `${send}` (bzw. als Template Parameter `{{.send}}`) bereitgestellt.
-
-**Mögliche Werte**:
-
-- `send`: Definiert das zu verwendende Plugin mit dem Feld `source` und plugin-spezifische Parameter. Siehe das Beispiel weiter unten.
-- `encoding`: Definiert das Format, in dem der Wert für `${send}` bereitgestellt wird. Die möglichen Werte sind:
-  - `json`: Der Wert wird als JSON-Objekt im Format `{ "msg": msg, "title": title }` bereitgestellt. Das Feld `title` wird nur hinzugefügt, wenn es im Abschnitt `events` definiert ist.
-  - `csv`: Die Felder `title` und `msg` werden als kommaseparierte Liste bereitgestellt (`title, msg`)
-  - `tsv`: Ähnlich wie `csv`, jedoch mit Tabulator als Trennzeichen.
-  - `title`: Nur der Titel (`title`) wird bereitgestellt.
-
-  Wenn `encoding` nicht definiert ist, wird die Nachricht `msg` ohne Titel direkt verwendet. Dabei wird nur die in `msg` definierte Nachricht ohne Titel in `${send}` verwendet.
-
-**Beispiel**:
-
-```yaml
-messaging:
-  events:
-    connect:
-      title: "Evcc: ${vehicleName} hat sich verbunden"
-      msg: "${vehiclTitle} wurde verbunden (Lademodus: ${mode})."
-  services:
-    - type: custom
-      encoding: json
-      send:
-        # Plugin Typ
-        source: script
-        # Plugin-spezifische Konfiguration.
-        # {{.send}} enthält die JSON Nachricht
-        cmd: /usr/local/bin/evcc_message "{{.send}}"
-```
-
-In diesem Beispiel wird ein Shell-Script (`cmd`) mit dem Argument `{"title": "...", "msg": "...."}` aufgerufen.
-
-## Variablen-Referenz
-
-Die folgende Liste zeigt eine Auswahl häufig genutzter Variablen.
-Die vollständige Liste aller verfügbaren Felder findest du in der API-Antwort unter `http://evcc.local:7070/api/state`.
-
-### Ladepunkt (loadpoint)
-
-Die Ladepunkt-Daten stammen aus dem `loadpoints`-Array der API-Antwort, werden aber in der Nachricht direkt (ohne Präfix) bereitgestellt.
-
-- `title` - Name des Ladepunkts
-- `loadpoint` - Nummer des Ladepunkts 1, 2, ...
-- `mode` - Lademodus: `off`/`now`/`minpv`/`pv`
-- `charging` - Ladevorgang aktiv
-- `enabled` - Ladefreigabe erteilt
-- `connected` - Fahrzeug angeschlossen
-- `chargedEnergy` - Geladene Energie der Sitzung in Wh
-- `chargeDuration` - Ladedauer
-- `chargePower` - Aktuelle Ladeleistung in W
-- `connectedDuration` - Anschlussdauer
-- `chargeRemainingDuration` - Restladezeit bis Ziel
-- `chargeRemainingEnergy` - Restenergie bis Ziel in Wh
-- `phasesActive` - Aktuell aktive Phasen
-- `vehicleTitle` - Name des Fahrzeugs
-- `vehicleName` - Technischer Name des Fahrzeugs
-- `vehicleSoc` - Fahrzeug-Ladestand in %
-- `vehicleRange` - Fahrzeug-Reichweite in km
-- `vehicleOdometer` - Kilometerstand in km
-- `sessionSolarPercentage` - Sonnenanteil der Ladesitzung in %
-- `sessionPrice` - Kosten der Ladesitzung
-- `sessionPricePerKWh` - Durchschnittspreis pro kWh
-- `sessionCo2PerKWh` - Durchschnittliche CO₂-Emissionen pro kWh
-- `planActive` - Ladeplan aktiv
-- `smartCostActive` - Günstiges Laden aktiv
-
-### Global (site)
-
-Die globalen Daten stammen aus der obersten Ebene der API-Antwort.
-
-- `siteTitle` - Name der evcc-Instanz
-- `pvPower` - Aktuelle PV-Leistung in W
-- `homePower` - Aktueller Hausverbrauch in W
-- `grid.Power` - Netzbezug (+) / Einspeisung (-) in W
-- `battery.Power` - Batterieleistung in W
-- `battery.Soc` - Batterie-Ladestand in %
-- `currency` - Tarif-Währung
-- `tariffGrid` - Aktueller Netzpreis pro kWh
-- `tariffFeedIn` - Einspeisevergütung pro kWh
-- `tariffCo2` - Aktuelle CO₂-Intensität
-- `statistics` - Ladestatistiken, verfügbar für die Zeiträume `30d`, `365d`, `thisYear` und `total`
-  - `statistics.<zeitraum>.avgCo2` - Durchschnittliche CO₂-Emissionen pro kWh
-  - `statistics.<zeitraum>.avgPrice` - Durchschnittspreis pro kWh
-  - `statistics.<zeitraum>.chargedKWh` - Geladene Energie in kWh
-  - `statistics.<zeitraum>.solarPercentage` - Sonnenanteil in %
+Zusätzlich ermöglicht `type: custom` die Nutzung beliebiger [Plugins](/de/reference/plugins) mit Schreibzugriff.
+Siehe [benutzerdefinierter Benachrichtigungsdienst](/de/user-defined-devices#notification-service).

--- a/src/content/docs/de/reference/plugins.mdx
+++ b/src/content/docs/de/reference/plugins.mdx
@@ -17,7 +17,7 @@ Plugins können für folgende Kategorien verwendet werden:
 - `tariff`: [Tarife, Vorhersagen](/de/tariffs)
 - `circuit`: [Lastmanagement](/de/features/loadmanagement)
 
-Zusätzlich können Plugins auch für die in [Messaging](/de/reference/configuration/messaging) beschriebenen Endpunkte zum Versenden von Lifecycle-Events genutzt werden.
+Zusätzlich können Plugins auch von [Benachrichtigungen](/de/notifications) zum Versenden von Lifecycle-Events genutzt werden.
 
 ### Plugin-Liste
 

--- a/src/content/docs/de/user-defined-devices.mdx
+++ b/src/content/docs/de/user-defined-devices.mdx
@@ -690,3 +690,50 @@ Steuerbox und evcc müssen einmalig [gekoppelt](/de/external-limit#eebus-pairing
 type: eebus
 ski: "1234-5678-90AB-CDEF" # SKI der Steuerbox
 ```
+
+<a id="notification-service"></a>
+
+## Benachrichtigungsdienst
+
+Ein benutzerdefinierter Benachrichtigungsdienst verarbeitet [Benachrichtigungen](/de/notifications) über ein beliebiges [Plugin](/de/reference/plugins) mit Schreibzugriff, z. B. ein Shell-Skript, einen HTTP-Aufruf oder eine MQTT-Nachricht.
+Wähle dazu in der Oberfläche unter **Konfiguration → Benachrichtigungen → Dienste** die Option **Benutzerdefinierter Dienst**.
+
+Die Nachricht wird dem Plugin im Parameter `${send}` (bzw. als Template-Parameter `{{.send}}`) bereitgestellt.
+
+### Konfiguration
+
+| Attribut   | Typ      | Erforderlich | Beschreibung                                                                      |
+| ---------- | -------- | ------------ | --------------------------------------------------------------------------------- |
+| `send`     | Plugin   | ja           | Plugin, das für jede Nachricht aufgerufen wird. Muss Schreibzugriff unterstützen. |
+| `encoding` | `string` | nein         | Format des Werts in `${send}`. Siehe unten.                                       |
+
+Die möglichen Werte für `encoding` sind:
+
+| Encoding | Inhalt von `${send}`                                                                                                         |
+| -------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| `json`   | JSON-Objekt `{ "msg": msg, "title": title }`. Das Feld `title` wird nur hinzugefügt, wenn es für das Ereignis definiert ist. |
+| `csv`    | `title` und `msg` als kommaseparierte Liste                                                                                  |
+| `tsv`    | Wie `csv`, jedoch mit Tabulator als Trennzeichen                                                                             |
+| `title`  | Nur der Titel                                                                                                                |
+| (keins)  | Nur die Nachricht (`msg`)                                                                                                    |
+
+### Beispiel
+
+```yaml
+messaging:
+  events:
+    connect:
+      title: "${vehicleTitle} verbunden"
+      msg: "${vehicleTitle} wurde verbunden (Lademodus: ${mode})."
+  services:
+    - type: custom
+      encoding: json
+      send:
+        # Plugin-Typ
+        source: script
+        # Plugin-spezifische Konfiguration;
+        # {{.send}} enthält die JSON-Nachricht
+        cmd: /usr/local/bin/evcc_message "{{.send}}"
+```
+
+In diesem Beispiel wird ein Shell-Skript (`cmd`) mit dem Argument `{"title": "...", "msg": "..."}` aufgerufen.

--- a/src/content/docs/en/index.mdx
+++ b/src/content/docs/en/index.mdx
@@ -103,6 +103,7 @@ Want more? These features and integrations go beyond the basics:
 - [Dynamic Feed-In](/en/features/dynamic-feedin): factor in variable feed-in rates
 - [Minimum Charge & Limits](/en/features/limits): quick base charge and charging limits
 - [External Limit (§ 14a EnWG & § 9 EEG)](/en/external-limit): grid operator requirements
+- [Notifications](/en/notifications): messages about your charging sessions
 - [Home Assistant](/en/integrations/home-assistant): integrate with your smart home
 - [REST API](/en/integrations/rest-api) and [MQTT API](/en/integrations/mqtt-api): connect other systems
 - [MCP Server](/en/integrations/mcp): connect AI assistants

--- a/src/content/docs/en/installation/configuration.mdx
+++ b/src/content/docs/en/installation/configuration.mdx
@@ -41,7 +41,7 @@ In the configuration area, you can set up the following components:
 Additionally, you can integrate various services and protocols:
 
 - **MQTT**: Data exchange with other systems on the network
-- **Messaging**: Push notifications and email alerts
+- **[Notifications](/en/notifications)**: Push notifications and email alerts
 - **InfluxDB**: Data export for long-term analysis
 - **EEBus**: Communication with other EEBus devices
 - **OCPP Server**: Connection with OCPP-capable wallboxes

--- a/src/content/docs/en/integrations/home-assistant.mdx
+++ b/src/content/docs/en/integrations/home-assistant.mdx
@@ -85,7 +85,7 @@ As long as the data is available as a Home Assistant entity, evcc can work with 
 - **[Chargers](/en/chargers#home-assistant-charger)** with status, enable/disable, and maximum charging current
 - **[Smart switches](/en/smartswitches#home-assistant-switch)** with simple on/off control (for smart plugs, relays)
 - **[Vehicles](/en/vehicles#home-assistant)** with SoC, range, status, odometer; optionally scripts for start/stop
-- **[Notifications](/en/reference/configuration/messaging)** under **Configuration → Notifications** you can send evcc messages via Home Assistant
+- **[Notifications](/en/notifications)** under **Configuration → Notifications** you can send evcc messages via Home Assistant
 
 ## Further Resources (Videos)
 

--- a/src/content/docs/en/reference/configuration/messaging.md
+++ b/src/content/docs/en/reference/configuration/messaging.md
@@ -4,9 +4,8 @@ sidebar:
   order: 12
 ---
 
-evcc supports the transmission of status information via [Telegram](https://telegram.org), [PushOver](https://pushover.net), [ntfy](https://ntfy.sh), and many other services using the [shoutrrr](https://containrrr.dev/shoutrrr/) system. The configuration allows defining custom messages for specific events and systems.
-
-`messaging` defines in sub-elements what and how to send. The events for which messages should be sent must be defined under `events` and the services through which the messages should be sent must be defined under `services`.
+The `messaging` section configures [notifications](/en/notifications) about charging sessions via services like Telegram, Pushover, ntfy, or email.
+`events` defines for which events messages are sent, `services` defines where they are sent to.
 
 **For example**:
 
@@ -29,6 +28,7 @@ The available events are:
 - `soc`: Vehicle battery state of charge changed
 - `guest`: Unknown vehicle detected
 - `asleep`: Vehicle not charging despite charge release
+- `planoverrun`: Charging plan projected to miss its target
 
 **For example**:
 
@@ -42,33 +42,11 @@ start: # charge start event
 
 `title` defines the text for the message title.
 
-**For example**:
-
-```yaml
-title: Charge started
-```
-
 ### `msg`
 
 `msg` defines the text for the message content.
-Various variables can be used to display evcc information in the text.
-
-There are two syntax options:
-
-- **Simple**: `${<variableName>}` — e.g. `${vehicleTitle}`, with optional formatting like `${pvPower:%.1fk}`
-- **Go template**: `{{.variableName}}` — enables calculations, conditions, and [sprig functions](http://masterminds.github.io/sprig/)
-
-:::note
-When using variables, make sure to use the correct capitalisation (uppercase/lowercase)!
-:::
-
-#### Available Variables
-
-The available variables correspond to the data from the evcc REST API at `http://evcc.local:7070/api/state`.
-When sending a message, the data of the triggering loadpoint and the global data are merged into a flat structure.
-This means both global values (e.g. `pvPower`, `grid.Power`) and loadpoint-specific values (e.g. `mode`, `chargedEnergy`, `vehicleTitle`) are directly accessible.
-
-A [selection of useful variables](#variable-reference) can be found at the bottom of this page.
+Titles and messages support placeholders, either in the simple `${variableName}` form or as Go templates (`{{.variableName}}`).
+The available variables are listed under [message format](/en/notifications#message-format).
 
 **Example** (simple syntax):
 
@@ -94,10 +72,7 @@ messaging:
         ${vehicleTitle} disconnected from ${title} after ${connectedDuration}
 ```
 
-:::note
-To render the `msg` texts, you can also use the [go text/template](https://pkg.go.dev/text/template) syntax in combination with [sprig functions](http://masterminds.github.io/sprig/).
-
-This enables calculations (e.g. converting W to kW) and conditional output.
+**Example** (Go template syntax with calculations and conditions):
 
 ```yaml
 messaging:
@@ -129,8 +104,6 @@ messaging:
         {{.vehicleTitle}} disconnected from {{.title}} after {{.connectedDuration}}.
 ```
 
-:::
-
 ## `services`
 
 `services` defines a list of message services to be used.
@@ -139,206 +112,15 @@ messaging:
 
 ```yaml
 services:
-  - type: pushover
+  - type: template
+    template: pushover
     app: 12345
     recipients:
       - 234567
 ```
 
-The following sections will now explain all the required parameters.
+The available services and their parameters are listed on the [notifications](/en/notifications#services) page.
+Each service page shows a ready-to-use `evcc.yaml` example.
 
-### `type`
-
-`type` defines the type of message service to be used.
-
-**Possible values**:
-
-- `pushover`: [Pushover](https://pushover.net/). See [`pushover`](#pushover) definition
-- `telegram`: [Telegram Messenger](https://telegram.org/). See [`telegram`](#telegram) definition
-- `email`: Email. See [`email`](#email) definition
-- `shout`: [shoutrrr](https://containrrr.dev/shoutrrr/). See [`shout`](#shout) definition
-- `ntfy`: [ntfy](https://ntfy.sh). See [`ntfy`](#ntfy) definition
-- `custom`: Allows the usage of any [plugin](/en/reference/plugins) that supports write access. See [`custom`](#custom) definition.
-
----
-
-## Supported Services
-
-### `pushover`
-
-`pushover` uses the [Pushover](https://pushover.net/) service. Details can be found at [Pushover API](https://pushover.net/api).
-
-**For example**:
-
-```yaml
-- type: pushover
-  app: # API Token/Key of the created application in Pushover
-  recipients:
-    -  # List of recipients: either User Key or Delivery Group. Groups created in Pushover can be limited to specific devices.
-  devices:
-    - Johns phone
-    - Mias ticker
-```
-
-### `telegram`
-
-`telegram` uses the [Telegram Messenger](https://telegram.org/) service.
-
-**For example**:
-
-```yaml
-- type: telegram
-  token: # bot id : each running instance of evcc needs its own bot id
-  chats:
-    -  # List of chat or group IDs. Each entry requires a - sign in the beginning and must be in a separate line.
-    - -GroupID #Note: Group IDs in Telegram have a - sign
-    - ChatID
-```
-
-### `email`
-
-`email` uses the [shoutrrr](https://containrrr.dev/shoutrrr) service.
-
-Here, the parameter `uri` with the value `smtp://<user>:<password>@<host>:<port>/?fromAddress=<from>&toAddresses=<to>` is expected. The placeholders are to be replaced as follows:
-
-- `<host>`: Address (hostname or IP address) of the email server
-- `<port>`: Port address of the email server
-- `<user>`: Username for the email server
-- `<password>`: User password
-- `<from>`: Sender's email address
-- `<to>`: Recipient's email address
-
-**For example**:
-
-```yaml
-- type: email
-  uri: smtp://username:password@emailserver.domain:1234/?fromAddress=sender@mail.com&toAddresses=recipient@mail.com
-```
-
-### `shout`
-
-`shout` uses the [shoutrrr](https://containrrr.dev/shoutrrr) service and supports all its services.
-
-The configuration is shown in the following example using [Gotify](https://gotify.net/), and the same applies to the other options through the same method.
-
-**For example**:
-
-```yaml
-- type: shout
-  uri: gotify://gotify.example.com:443/AzyoeNS.D4iJLVa/?priority=1
-```
-
-Further information can be found in the [shoutrrr documentation](https://containrrr.dev/shoutrrr/v0.5/services/overview/) on [supported services](https://containrrr.dev/shoutrrr/v0.5/services/overview/).
-
-### `ntfy`
-
-`ntfy` uses the [ntfy](https://ntfy.sh) service.
-
-Here, the parameter `uri` with the value `https://<host>/<topics>` is expected. The placeholders are to be replaced as follows:
-
-- `<host>`: Address (hostname or IP address) of the ntfy server
-- `<topics>`: Subscribed topic or topics
-
-Optional parameters are `priority`, `tags` and `authtoken`. All parameters are passed as strings.
-
-**For example**:
-
-```yaml
-- type: ntfy
-  uri: https://ntfy.sh/evcctestalerts
-  priority: default
-  tags: electric_plug,blue_car
-  authtoken: 61RgoYLOsi8S318j6ycU2qEsleC2p9njoyw4890121412JloH7rMPaqQwi5KWTit
-```
-
-Further information can be found in the [ntfy documentation](https://docs.ntfy.sh).
-
-### `custom`
-
-The `custom` type allows the use of any [plugin](/en/reference/plugins) to process messages. The plugin must support write mode. The message itself is provided in the plugin configuration using the parameter `${send}` (or as a template parameter `{{.send}}`).
-
-**Possible Values**:
-
-- `send`: Defines the plugin to be used with the `source` field and plugin-specific parameters. See the example below.
-- `encoding`: Specifies the format in which the value for `${send}` is provided. The possible values are:
-  - `json`: The value is provided as a JSON object in the format `{ "msg": msg, "title": title }`. The `title` field is only added if it is defined in the `events` section.
-  - `csv`: The fields `title` and `msg` are provided as a comma-separated list (`title, msg`).
-  - `tsv`: Similar to `csv`, but with tab separators.
-  - `title`: Only the title (`title`) is provided.
-
-  If `encoding` is not defined, the `msg` value is used directly without the title. In this case, only the message defined in `msg` is used in `${send}`.
-
-**Example**:
-
-```yaml
-messaging:
-  events:
-    connect:
-      title: "Evcc: ${vehicleName} has connected"
-      msg: "${vehicleTitle} was connected (Charging mode: ${mode})."
-  services:
-    - type: custom
-      encoding: json
-      send:
-        # Plugin type
-        source: script
-        # Plugin-specific configuration.
-        # {{.send}} contains the JSON message
-        cmd: /usr/local/bin/evcc_message "{{.send}}"
-```
-
-In this example, a shell script (`cmd`) is invoked with the argument `{"title": "...", "msg": "...."}`.
-
-## Variable Reference
-
-The following list shows a selection of commonly used variables.
-The complete list of all available fields can be found in the API response at `http://evcc.local:7070/api/state`.
-
-### Loadpoint
-
-The loadpoint data comes from the `loadpoints` array in the API response but is provided directly (without prefix) in messages.
-
-- `title` - Loadpoint name
-- `loadpoint` - Loadpoint number 1, 2, ...
-- `mode` - Charge mode: `off`/`now`/`minpv`/`pv`
-- `charging` - Charging active
-- `enabled` - Charging enabled
-- `connected` - Vehicle connected
-- `chargedEnergy` - Energy charged in session in Wh
-- `chargeDuration` - Charging duration
-- `chargePower` - Current charge power in W
-- `connectedDuration` - Connection duration
-- `chargeRemainingDuration` - Remaining charge time until target
-- `chargeRemainingEnergy` - Remaining energy until target in Wh
-- `phasesActive` - Currently active phases
-- `vehicleTitle` - Vehicle name
-- `vehicleName` - Technical vehicle name
-- `vehicleSoc` - Vehicle state of charge in %
-- `vehicleRange` - Vehicle range in km
-- `vehicleOdometer` - Odometer reading in km
-- `sessionSolarPercentage` - Solar share of charging session in %
-- `sessionPrice` - Cost of charging session
-- `sessionPricePerKWh` - Average price per kWh
-- `sessionCo2PerKWh` - Average CO₂ emissions per kWh
-- `planActive` - Charge plan active
-- `smartCostActive` - Smart cost charging active
-
-### Global (Site)
-
-The global data comes from the top level of the API response.
-
-- `siteTitle` - Name of the evcc instance
-- `pvPower` - Current solar power in W
-- `homePower` - Current home consumption in W
-- `grid.Power` - Grid import (+) / export (-) in W
-- `battery.Power` - Battery power in W
-- `battery.Soc` - Battery state of charge in %
-- `currency` - Tariff currency
-- `tariffGrid` - Current grid price per kWh
-- `tariffFeedIn` - Feed-in tariff per kWh
-- `tariffCo2` - Current CO₂ intensity
-- `statistics` - Charging statistics, available for time periods `30d`, `365d`, `thisYear`, and `total`
-  - `statistics.<period>.avgCo2` - Average CO₂ emissions per kWh
-  - `statistics.<period>.avgPrice` - Average price per kWh
-  - `statistics.<period>.chargedKWh` - Energy charged in kWh
-  - `statistics.<period>.solarPercentage` - Solar share in %
+In addition, `type: custom` allows the use of any [plugin](/en/reference/plugins) with write access.
+See [user-defined notification service](/en/user-defined-devices#notification-service).

--- a/src/content/docs/en/reference/plugins.mdx
+++ b/src/content/docs/en/reference/plugins.mdx
@@ -17,7 +17,7 @@ Plugins can be used for the following categories:
 - `tariff`: [Tariffs, forecasts](/en/tariffs)
 - `circuit`: [Load management](/en/features/loadmanagement)
 
-Plugins are also used by the endpoints described in [Messaging](/en/reference/configuration/messaging) to send lifecycle events.
+Plugins are also used by [notifications](/en/notifications) to send lifecycle events.
 
 ### Plugin list
 

--- a/src/content/docs/en/user-defined-devices.mdx
+++ b/src/content/docs/en/user-defined-devices.mdx
@@ -689,3 +689,50 @@ Control box and evcc need to be [paired](/en/external-limit#eebus-pairing) once.
 type: eebus
 ski: "1234-5678-90AB-CDEF" # SKI of the control box
 ```
+
+<a id="notification-service"></a>
+
+## Notification Service
+
+A user-defined notification service processes [notification](/en/notifications) messages via any [plugin](/en/reference/plugins) with write access, e.g. a shell script, HTTP request, or MQTT message.
+In the UI, pick **User-defined service** under **Configuration → Notifications → Services**.
+
+The message is provided to the plugin in the `${send}` parameter (or as a template parameter `{{.send}}`).
+
+### Configuration
+
+| Attribute  | Type     | Required | Description                                                 |
+| ---------- | -------- | -------- | ----------------------------------------------------------- |
+| `send`     | plugin   | yes      | Plugin invoked for each message. Must support write access. |
+| `encoding` | `string` | no       | Format of the value provided in `${send}`. See below.       |
+
+The possible `encoding` values are:
+
+| Encoding | Content of `${send}`                                                                                    |
+| -------- | ------------------------------------------------------------------------------------------------------- |
+| `json`   | JSON object `{ "msg": msg, "title": title }`. The `title` field is only added if defined for the event. |
+| `csv`    | `title` and `msg` as a comma-separated list                                                             |
+| `tsv`    | Like `csv`, but tab-separated                                                                           |
+| `title`  | Only the title                                                                                          |
+| (none)   | Only the message (`msg`)                                                                                |
+
+### Example
+
+```yaml
+messaging:
+  events:
+    connect:
+      title: "${vehicleTitle} connected"
+      msg: "${vehicleTitle} was connected (charging mode: ${mode})."
+  services:
+    - type: custom
+      encoding: json
+      send:
+        # plugin type
+        source: script
+        # plugin-specific configuration;
+        # {{.send}} contains the JSON message
+        cmd: /usr/local/bin/evcc_message "{{.send}}"
+```
+
+In this example, a shell script (`cmd`) is invoked with the argument `{"title": "...", "msg": "..."}`.

--- a/src/pages/[lang]/nightly/notifications/[slug].astro
+++ b/src/pages/[lang]/nightly/notifications/[slug].astro
@@ -1,0 +1,21 @@
+---
+import DeviceDetailLayout from "@components/DeviceDetailLayout.astro";
+import { deviceDetailPaths, featuresFor, buildCodeBlocks, templateEditUrl } from "@utils/devices";
+
+export const getStaticPaths = () =>
+  deviceDetailPaths({ prefix: "messengers", urlType: "notifications", channel: "nightly" });
+
+const { entry, lang, counterpartHref } = Astro.props as any;
+---
+
+<DeviceDetailLayout
+  entry={entry}
+  lang={lang}
+  channel="nightly"
+  type="notifications"
+  categoryLabel={lang === "de" ? "Benachrichtigungen" : "Notifications"}
+  features={featuresFor("messenger", entry, lang)}
+  codeBlocks={buildCodeBlocks(entry, "messenger")}
+  editUrl={templateEditUrl(entry, "messenger")}
+  counterpartHref={counterpartHref}
+/>

--- a/src/pages/[lang]/nightly/notifications/index.astro
+++ b/src/pages/[lang]/nightly/notifications/index.astro
@@ -1,0 +1,11 @@
+---
+import NotificationsList from "@components/lists/NotificationsList.astro";
+
+export async function getStaticPaths() {
+  return [{ params: { lang: "en" } }, { params: { lang: "de" } }];
+}
+
+const lang = Astro.params.lang as "de" | "en";
+---
+
+<NotificationsList lang={lang} channel="nightly" />

--- a/src/pages/[lang]/notifications/[slug].astro
+++ b/src/pages/[lang]/notifications/[slug].astro
@@ -1,0 +1,21 @@
+---
+import DeviceDetailLayout from "@components/DeviceDetailLayout.astro";
+import { deviceDetailPaths, featuresFor, buildCodeBlocks, templateEditUrl } from "@utils/devices";
+
+export const getStaticPaths = () =>
+  deviceDetailPaths({ prefix: "messengers", urlType: "notifications", channel: "release" });
+
+const { entry, lang, counterpartHref } = Astro.props as any;
+---
+
+<DeviceDetailLayout
+  entry={entry}
+  lang={lang}
+  channel="release"
+  type="notifications"
+  categoryLabel={lang === "de" ? "Benachrichtigungen" : "Notifications"}
+  features={featuresFor("messenger", entry, lang)}
+  codeBlocks={buildCodeBlocks(entry, "messenger")}
+  editUrl={templateEditUrl(entry, "messenger")}
+  counterpartHref={counterpartHref}
+/>

--- a/src/pages/[lang]/notifications/index.astro
+++ b/src/pages/[lang]/notifications/index.astro
@@ -1,0 +1,11 @@
+---
+import NotificationsList from "@components/lists/NotificationsList.astro";
+
+export async function getStaticPaths() {
+  return [{ params: { lang: "en" } }, { params: { lang: "de" } }];
+}
+
+const lang = Astro.params.lang as "de" | "en";
+---
+
+<NotificationsList lang={lang} channel="release" />

--- a/src/scripts/generate-legacy-redirects.mjs
+++ b/src/scripts/generate-legacy-redirects.mjs
@@ -28,7 +28,7 @@ function makeRedirectHtml(target) {
 <title>Redirecting…</title>
 <meta http-equiv="refresh" content="0; url=${target}">
 <link rel="canonical" href="${target}">
-<script>window.location.replace(${JSON.stringify(target)})</script>
+<script>window.location.replace(${JSON.stringify(target)} + window.location.hash)</script>
 </head>
 <body><p>Redirecting to <a href="${target}">${target}</a></p></body></html>`;
 }

--- a/src/utils/devices.ts
+++ b/src/utils/devices.ts
@@ -52,6 +52,7 @@ export const CODE_PREAMBLES: Record<string, string> = {
   co2: "tariffs:\n    co2:",
   solar: "tariffs:\n    solar:",
   hems: "hems:",
+  messenger: "messaging:\n  services:",
 };
 
 const TRANSLATIONS_DE: Record<string, string> = {
@@ -289,7 +290,8 @@ export function featuresFor(
     | "vehicle"
     | "smartswitch"
     | "heating"
-    | "hems",
+    | "hems"
+    | "messenger",
   entry: DeviceEntry,
   lang: "de" | "en",
 ): string[] {
@@ -325,7 +327,8 @@ export type Channel = "release" | "nightly";
  * Smart switches and heating use the `chargers` collection.
  */
 export function collectionName(
-  prefix: "chargers" | "meters" | "vehicles" | "tariffs" | "hems",
+  prefix:
+    "chargers" | "meters" | "vehicles" | "tariffs" | "hems" | "messengers",
   lang: "de" | "en",
   channel: Channel,
 ): string {
@@ -344,7 +347,7 @@ export const nightlyPageHead = [
 /** Link to the device's source template in the evcc repo (undefined if none). */
 export function templateEditUrl(
   entry: DeviceEntry,
-  dir: "charger" | "meter" | "vehicle" | "tariff" | "hems",
+  dir: "charger" | "meter" | "vehicle" | "tariff" | "hems" | "messenger",
 ): string | undefined {
   return entry.data.template
     ? `https://github.com/evcc-io/evcc/tree/master/templates/definition/${dir}/${entry.data.template}.yaml`
@@ -354,7 +357,14 @@ export function templateEditUrl(
 /** YAML config blocks for a device detail page (non-meter categories). */
 export function buildCodeBlocks(
   entry: DeviceEntry,
-  type: "charger" | "vehicle" | "smartswitch" | "heating" | "tariff" | "hems",
+  type:
+    | "charger"
+    | "vehicle"
+    | "smartswitch"
+    | "heating"
+    | "tariff"
+    | "hems"
+    | "messenger",
 ): string[] {
   const render = (entry.data.render as any[]) ?? [];
   if (type === "hems") {
@@ -362,6 +372,14 @@ export function buildCodeBlocks(
     return render.map((r) => {
       const src = r.advanced ?? r.default;
       return `${CODE_PREAMBLES.hems}\n${src.replace(/^/gm, "  ").trimEnd()}`;
+    });
+  }
+  if (type === "messenger") {
+    // messengers are list entries under messaging.services (depth 2)
+    return render.map((r) => {
+      const src = r.advanced ?? r.default;
+      const item = src.replace(/^/, "    - ").replace(/\n/gm, "\n      ");
+      return `${CODE_PREAMBLES.messenger}\n${item.trimEnd()}`;
     });
   }
   if (type === "tariff") {
@@ -390,7 +408,8 @@ export function buildCodeBlocks(
  * same-id entry exists.
  */
 export async function deviceDetailPaths(opts: {
-  prefix: "chargers" | "meters" | "vehicles" | "tariffs" | "hems";
+  prefix:
+    "chargers" | "meters" | "vehicles" | "tariffs" | "hems" | "messengers";
   /** URL segment, e.g. "smartswitches" (may differ from the collection prefix). */
   urlType: string;
   channel: Channel;


### PR DESCRIPTION
Fixes #1008

Messengers were missing from the auto-generated docs. This adds a hybrid page like tariffs/external-limit: feature explanation plus generated service list from the synced messenger templates.

## Changes

- **New page `/en/notifications` + `/de/notifications`** ("Notifications" / „Benachrichtigungen", matching the UI): setup via **Configuration → Notifications**, then **Services** (generated cards for Email, Home Assistant, Ntfy, Pushover, Telegram, Shoutrrr), **Events** (all 8 events incl. the previously undocumented `planoverrun`), and **Message Format** with examples, placeholder syntax (`${var}` + Go templates, `k` suffix), and the variable reference. No YAML on the feature page — configuration examples stay in the reference. Variable list verified against a live `/api/state`; added a note that nested values like `grid.Power` need Go template syntax with capitalised field names.
- **Wiring**: `messengers` content collections, `devices.ts` support (config blocks render as `messaging:` → `services:` list entries), routes + nightly variants, detail pages.
- **Sidebar**: Notifications placed in the Integrations group; External Limit moved into the Features group (URLs unchanged).
- **`reference/configuration/messaging`** (en+de) slimmed to pure `evcc.yaml` reference: 8 events, `title`/`msg` with full YAML examples, `services` pointing to the generated pages; `#msg` anchor kept (the evcc UI links there).
- **`user-defined-devices`** (en+de): new "Notification Service" section (`#notification-service`) with `send`/`encoding` tables and script example; `UserDefinedHint` gained `kind="messenger"`, `kind="service"` renamed to `"tariff"`.
- Links updated in installation/configuration, Home Assistant integration, plugins reference, and index feature lists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)