### PR TITLE
Sponsorship: add direct sponsoring option and business bundles

### DIFF
--- a/src/content/docs/de/sponsorship.mdx
+++ b/src/content/docs/de/sponsorship.mdx
@@ -27,7 +27,7 @@ Damit ist natürlicherweise sichergestellt, dass sich das Projekt nach den Vorst
 ## Sponsortoken
 
 Es gibt zwei Wege zu einem Sponsortoken.
-Bei direkter Zahlung erhältst du eine ordentliche Rechnung mit ausgewiesener Umsatzsteuer, die du im Anschluss herunterladen kannst.
+Bei direkter Zahlung erhältst du eine ordentliche Rechnung, die du im Anschluss herunterladen kannst.
 
 <CardGrid>
   <Card title="🩷 GitHub Sponsors">

--- a/src/content/docs/de/sponsorship.mdx
+++ b/src/content/docs/de/sponsorship.mdx
@@ -5,6 +5,7 @@ sidebar:
 ---
 
 import SponsorToken from "@components/SponsorToken.astro";
+import { Card, CardGrid } from "@astrojs/starlight/components";
 
 Wir von evcc glauben an Open-Source-Software.
 Unser Ziel ist es, das Laden von Elektroautos lokal, ohne Cloud, ohne Datensammlung oder Herstellerbindung, zu ermöglichen.
@@ -25,17 +26,30 @@ Damit ist natürlicherweise sichergestellt, dass sich das Projekt nach den Vorst
 
 ## Sponsortoken
 
-Wir haben uns dafür entschieden, Github Sponsoring zu verwenden, da es für uns einfach zu integrieren ist und GitHub keine Gebühren erhebt.
-Euer Beitrag landet also komplett beim Projekt.
+Es gibt zwei Wege zu einem Sponsortoken.
+Bei direkter Zahlung erhältst du eine ordentliche Rechnung mit ausgewiesener Umsatzsteuer, die du im Anschluss herunterladen kannst.
 
-Wir bieten zwei Modelle an:
+<CardGrid>
+  <Card title="🩷 GitHub Sponsors">
+    Der komplette Betrag landet beim Projekt, ohne Zahlungs- oder Bearbeitungsgebühren.
 
-- **[Monatlich $4](https://github.com/sponsors/evcc-io?frequency=recurring)**: Unterstütze das Projekt mit einem kleinen monatlichen Betrag.
-  Das gibt uns Planungssicherheit und euch die Freiheit, das Sponsoring monatlich ändern oder stoppen zu können.
-  Dein Sponsortoken ist so lange gültig, wie Github Sponsoring aktiv ist.
-- **[Einmalig $150](https://github.com/sponsors/evcc-io?frequency=one-time)**: Für einen einmaligen Beitrag, erhältst du ein Sponsortoken mit unbegrenzter Gültigkeit.
+    - **[Monatlich $4](https://github.com/sponsors/evcc-io?frequency=recurring)**: Ein kleiner monatlicher Betrag.
+      Gibt uns Planungssicherheit, und du kannst jederzeit ändern oder stoppen.
+    - **[Einmalig $150](https://github.com/sponsors/evcc-io?frequency=one-time)**: Ein unbefristetes Sponsortoken mit unbegrenzter Gültigkeit.
 
-Dein Sponsortoken kannst du über [sponsor.evcc.io](https://sponsor.evcc.io) einsehen.
+    Dein Token kannst du über [sponsor.evcc.io](https://sponsor.evcc.io) einsehen.
+
+  </Card>
+  <Card title="💚 Direkt via Creem.io">
+    Kein Konto nötig, bezahle per Kreditkarte, Apple Pay oder Google Pay, weitere Zahlungsarten folgen.
+
+    - **[Einmalig 150 €](https://sponsor.evcc.io)**: Dasselbe unbefristete Sponsortoken.
+    - **[Mengenrabatt](https://sponsor.evcc.io/business)**: Token-Pakete für Elektriker und Installateure.
+
+    Dein Token kommt per E-Mail.
+
+  </Card>
+</CardGrid>
 
 Als kleines Dankeschön wird in der evcc UI **digitales Supporter-Konfetti 🎉** freigeschaltet und du kannst dir einmal ein cooles Set an **evcc Stickern ☀️** per Post zuschicken lassen.
 
@@ -77,9 +91,9 @@ Bei freien Beträgen (bspw. einmalig $2) wird kein Token erstellt.
 #### Ich habe ein Gewerbe und möchte evcc kommerziell einsetzen. Kann ich das machen?
 
 Ja, das ist kein Problem.
-Deine Kunden müssen dafür jeweils ein Sponsortoken erstellen.
-Alternativ können wir dir auch mehrere Sponsortoken auf einmal ausstellen und dir eine Rechnung mit entsprechender Umsatzsteuer schreiben.
-[Melde dich dafür bei uns](mailto:info@evcc.io).
+Du kannst Sponsortoken-Pakete direkt über [sponsor.evcc.io/business](https://sponsor.evcc.io/business) kaufen, mit Mengenrabatt für Elektriker und Installateure.
+Die Token sind für den Einsatz bei deinen Endkunden gedacht und dürfen nicht einzeln weiterverkauft werden.
+Bei individuellen Anforderungen [melde dich bei uns](mailto:info@evcc.io).
 
 _Hinweis: Für weitere Funktionen wie bspw. [Lastmanagement](/de/features/loadmanagement) werden wir explizite kommerzielle Unterstützungsmodelle anbieten.
 Dazu aber später mehr._

--- a/src/content/docs/en/sponsorship.mdx
+++ b/src/content/docs/en/sponsorship.mdx
@@ -5,6 +5,7 @@ sidebar:
 ---
 
 import SponsorToken from "@components/SponsorToken.astro";
+import { Card, CardGrid } from "@astrojs/starlight/components";
 
 We at evcc believe in open source software.
 Our goal is to enable local, cloud-free, privacy-friendly and manufacturer-independent charging of electric vehicles.
@@ -25,16 +26,30 @@ This ensures that the project develops according to the needs of its users and i
 
 ## Sponsor Tokens
 
-We have chosen to use GitHub Sponsoring, as it is easy to integrate and does not include any commission to be paid by any party.
-Your contribution will therefore land directly with the project - without payment or processing fees.
+There are two ways to get a sponsor token.
+Direct payment comes with a proper EU invoice with VAT, downloadable afterwards.
 
-We offer two models:
+<CardGrid>
+  <Card title="🩷 GitHub Sponsors">
+    The full amount lands with the project, without payment or processing fees.
 
-- **[Monthly $4](https://github.com/sponsors/evcc-io?frequency=recurring)**: Support the project with a small monthly contribution.
-  This gives us planning security and you have the freedom to change the sponsorship monthly or stop it at any time.
-- **[One-time $150](https://github.com/sponsors/evcc-io?frequency=one-time)**: For a one-time contribution, you'll receive a sponsor token with unlimited validity.
+    - **[Monthly $4](https://github.com/sponsors/evcc-io?frequency=recurring)**: A small monthly contribution.
+      Gives us planning security, and you can change or stop it any time.
+    - **[One-time $150](https://github.com/sponsors/evcc-io?frequency=one-time)**: A lifetime sponsor token with unlimited validity.
 
-Your sponsor token can be viewed at [sponsor.evcc.io](https://sponsor.evcc.io).
+    Your token can be viewed at [sponsor.evcc.io](https://sponsor.evcc.io).
+
+  </Card>
+  <Card title="💚 Direct via Creem.io">
+    No account needed, pay by credit card, Apple Pay or Google Pay, with more payment options on the way.
+
+    - **[One-time €150](https://sponsor.evcc.io)**: The same lifetime sponsor token.
+    - **[Volume discounts](https://sponsor.evcc.io/business)**: Token bundles for electricians and installers.
+
+    Your token is delivered by email.
+
+  </Card>
+</CardGrid>
 
 As a small thank you, you'll receive **digital supporter confetti 🎉** inside evcc and can order a cool set of **evcc stickers ☀️** which we'll ship to you.
 
@@ -76,9 +91,9 @@ If you've entered a lower custom amount (e.g. $2 one-time), no token will be cre
 #### I have a business and want to use evcc commercially. Can I do that?
 
 Yes, that's no problem.
-Your customers will then each need to create a sponsor token.
-Alternatively, we can also issue you several sponsor tokens at once and send you an invoice with the corresponding VAT.
-[Write us an email](mailto:info@evcc.io) with your requirements and we'll get back to you.
+You can buy sponsor token bundles directly at [sponsor.evcc.io/business](https://sponsor.evcc.io/business), with volume discounts for electricians and installers.
+The tokens are meant for use at your end customers and may not be traded individually.
+For custom requirements, [write us an email](mailto:info@evcc.io) and we'll get back to you.
 
 #### Where do I enter my token?
 

--- a/src/content/docs/en/sponsorship.mdx
+++ b/src/content/docs/en/sponsorship.mdx
@@ -27,7 +27,7 @@ This ensures that the project develops according to the needs of its users and i
 ## Sponsor Tokens
 
 There are two ways to get a sponsor token.
-Direct payment comes with a proper EU invoice with VAT, downloadable afterwards.
+Direct payment comes with a proper EU invoice, downloadable afterwards.
 
 <CardGrid>
   <Card title="🩷 GitHub Sponsors">


### PR DESCRIPTION
Rework the **Sponsor Tokens** section into a side-by-side card layout and document the new direct sponsoring path.

- **Sponsor Tokens** section is now a `CardGrid` with two cards:
  - **🩷 GitHub Sponsors** — monthly \$4 / one-time \$150, full amount reaches the project, token viewed at sponsor.evcc.io.
  - **💚 Direct via Creem.io** — no account needed, pay by card / Apple Pay / Google Pay (more options coming), one-time €150 for the same lifetime token, volume discounts for electricians, token delivered by email.
- Intro notes direct payment comes with a proper EU invoice (VAT included, downloadable afterwards).
- **Business FAQ** now points to sponsor.evcc.io/business with volume discounts for electricians/installers instead of email-only.

<img width="1634" height="1428" alt="Bildschirmfoto 2026-07-09 um 17 41 31" src="https://github.com/user-attachments/assets/1fbda6f1-c56b-432b-a83a-8cb6d64b7ff8" />

\cc @andig @premultiply 