### PR TITLE
Config UI: update section name and loadpoint requirement

### DIFF
--- a/src/content/docs/de/features/loadmanagement.mdx
+++ b/src/content/docs/de/features/loadmanagement.mdx
@@ -21,7 +21,7 @@ Stromkreise können unter **Konfiguration → Lastmanagement** angelegt werden.
 Die Eingabe erfolgt im YAML-Format und entspricht dem Inhalt unterhalb von `circuits:` in den folgenden Beispielen.
 Wir arbeiten daran, dies durch eine formularbasierte Eingabe zu ersetzen.
 
-Jeder Ladepunkt kann anschließend (Neustart erforderlich) unter **Konfiguration → Laden & Heizen → [Name]** einem Stromkreis zugeordnet werden.
+Jeder Ladepunkt kann anschließend (Neustart erforderlich) unter **Konfiguration → Ladepunkte & Heizungen → [Name]** einem Stromkreis zugeordnet werden.
 :::
 
 ## Konfiguration

--- a/src/content/docs/de/features/solar-charging.mdx
+++ b/src/content/docs/de/features/solar-charging.mdx
@@ -52,7 +52,7 @@ Bei Anlagen mit abgeregelter Netzeinspeisung („Nulleinspeisung“) funktionier
 ### Nicht genügend Überschuss?
 
 Standardmäßig wird versucht, möglichst keinen Strom aus dem Netz zu beziehen.
-Dieses Verhalten kannst du unter **Konfiguration → Laden & Heizen → [Mein Ladepunkt]** anpassen.
+Dieses Verhalten kannst du unter **Konfiguration → Ladepunkte & Heizungen → [Mein Ladepunkt]** anpassen.
 Stelle im Abschnitt **Verhalten** die Option **PV-Überschuss** von **nur Sonne** auf **manuell**.
 Damit lassen sich eigene Schwellen und Verzögerungen festlegen.
 

--- a/src/content/docs/de/features/vehicle.mdx
+++ b/src/content/docs/de/features/vehicle.mdx
@@ -58,7 +58,7 @@ Für die Zuordnung von Fahrzeugen zu Ladepunkten gibt es verschiedene Möglichke
 
 Hat jedes Fahrzeug einen eigenen Ladepunkt, kannst du das Fahrzeug als Standardfahrzeug am Ladepunkt konfigurieren.
 Das ist die einfachste und empfohlene Konfiguration.
-Gehe zu **Konfiguration → Laden & Heizen → [Mein Ladepunkt]**.
+Gehe zu **Konfiguration → Ladepunkte & Heizungen → [Mein Ladepunkt]**.
 Wähle im Abschnitt **Fahrzeuge** dein Fahrzeug als **Standard-Fahrzeug** aus.
 evcc geht bei einem neuen Ladevorgang davon aus, dass es sich um das Standardfahrzeug handelt.
 Ist dies einmal nicht der Fall (bspw. Gastfahrzeug), kannst du das Fahrzeug in der UI umschalten.
@@ -88,7 +88,7 @@ Jedes Mal, wenn das Fahrzeug wieder an die Wallbox angeschlossen wird, muss der 
 
 evcc bekommt von der Wallbox eine eindeutige Identifikationskennung.
 Abhängig vom Hersteller ist das direkt die RFID-Kennung oder eine abgeleitete interne Kennung wie bspw. ein Benutzername aus der Wallboxkonfiguration.
-Nach dem Freischalten mit der Karte wird die aktuelle Kennung am Ladepunkt unter **Konfiguration → Laden & Heizen** angezeigt.
+Nach dem Freischalten mit der Karte wird die aktuelle Kennung am Ladepunkt unter **Konfiguration → Ladepunkte & Heizungen** angezeigt.
 Trage diesen Wert im Feld **RFID-Identifikation** des gewünschten Fahrzeugs unter **Konfiguration → Fahrzeuge** ein.
 Pro Fahrzeug kannst du mehrere Kennungen hinterlegen.
 
@@ -103,7 +103,7 @@ In der Wallbox muss das Feature "PLC-Verbindung zum Fahrzeug" aktiviert sein.
 
 Die Einrichtung erfolgt hier ähnlich wie bei der RFID-Erkennung.
 Das Fahrzeug muss mit der Wallbox verbunden sein.
-Die Kennung (z. B. `01:23:45:67:89:00`) wird dann am Ladepunkt unter **Konfiguration → Laden & Heizen** angezeigt.
+Die Kennung (z. B. `01:23:45:67:89:00`) wird dann am Ladepunkt unter **Konfiguration → Ladepunkte & Heizungen** angezeigt.
 Trage diesen Wert im Feld **RFID-Identifikation** des Fahrzeugs ein.
 
 :::note[Hinweis]

--- a/src/content/docs/de/installation/configuration.mdx
+++ b/src/content/docs/de/installation/configuration.mdx
@@ -31,10 +31,12 @@ Die Weboberfläche ist der einfachste und schnellste Weg, evcc einzurichten.
 
 Im Konfigurationsbereich kannst du folgende Komponenten einrichten:
 
-- **Laden & Heizen** (erforderlich): Wallboxen und Wärmepumpen – mindestens ein Gerät muss konfiguriert werden
+- **Ladepunkte & Heizungen** (empfohlen): Wallboxen und Wärmepumpen
 - **Netzanschluss** (empfohlen): Hauszähler und Stromtarife – wichtig für korrektes Energiemanagement
 - **PV & Batterie** (optional): Solaranlagen und Batteriespeicher
 - **Fahrzeuge** (optional): Fahrzeugintegrationen für Akkugröße und Ladestand, ermöglicht intelligenteres Laden
+
+Mindestens ein Zähler oder Ladepunkt muss konfiguriert sein, damit das System läuft.
 
 ### Integrationen
 

--- a/src/content/docs/en/features/loadmanagement.mdx
+++ b/src/content/docs/en/features/loadmanagement.mdx
@@ -22,7 +22,7 @@ Circuits can be defined under **Configuration → Load Management**.
 The input uses YAML format and corresponds to the content below `circuits:` in the examples that follow.
 We are working on replacing this with a form-based approach.
 
-Each charging point can then (restart required) be assigned to a circuit under **Configuration → Charging & Heating → [name]**.
+Each charging point can then (restart required) be assigned to a circuit under **Configuration → Charging points & Heaters → [name]**.
 :::
 
 ## Configuration

--- a/src/content/docs/en/features/solar-charging.mdx
+++ b/src/content/docs/en/features/solar-charging.mdx
@@ -52,7 +52,7 @@ Note: The value on the grid meter is the decisive factor.
 ### Not enough surplus?
 
 By default, the system tries to avoid drawing any power from the grid.
-You can adjust this behaviour under **Configuration → Charging & Heating → [My Charging Point]**.
+You can adjust this behaviour under **Configuration → Charging points & Heaters → [My Charging Point]**.
 In the **Behaviour** section, switch the **Solar** setting from **maximum solar** to **custom**.
 You can then set your own thresholds and delays.
 

--- a/src/content/docs/en/features/vehicle.mdx
+++ b/src/content/docs/en/features/vehicle.mdx
@@ -58,7 +58,7 @@ There are various options for assigning vehicles to charging points:
 
 If each vehicle has its own charging point, you can configure the vehicle as the standard vehicle at the charging point.
 This is the simplest and recommended configuration.
-Go to **Configuration → Charging & Heating → [My Charging Point]**.
+Go to **Configuration → Charging points & Heaters → [My Charging Point]**.
 In the **Vehicles** section, select your vehicle as **Default vehicle**.
 When a new charging process starts, evcc assumes that it is the standard vehicle.
 If this is not the case (e.g. guest vehicle), you can switch the vehicle in the UI.
@@ -88,7 +88,7 @@ Every time the vehicle is connected to the wallbox again, the charging process m
 
 evcc receives a unique identification code from the wallbox.
 Depending on the manufacturer, this is either the RFID code or a derived internal code such as a user name from the wallbox configuration.
-After activating with the card, the current identifier is shown on the charging point card under **Configuration → Charging & Heating**.
+After activating with the card, the current identifier is shown on the charging point card under **Configuration → Charging points & Heaters**.
 Enter this value in the **RFID identification** field of the desired vehicle under **Configuration → Vehicles**.
 You can store multiple identifiers per vehicle.
 
@@ -103,7 +103,7 @@ The "PLC connection to the vehicle" feature must be activated in the wallbox.
 
 The setup is similar to RFID detection.
 The vehicle must be connected to the wallbox.
-The identifier (e.g. `01:23:45:67:89:00`) is then shown on the charging point card under **Configuration → Charging & Heating**.
+The identifier (e.g. `01:23:45:67:89:00`) is then shown on the charging point card under **Configuration → Charging points & Heaters**.
 Enter this value in the **RFID identification** field of the vehicle.
 
 :::note[Note]

--- a/src/content/docs/en/installation/configuration.mdx
+++ b/src/content/docs/en/installation/configuration.mdx
@@ -31,10 +31,12 @@ The web interface is the easiest and fastest way to set up evcc.
 
 In the configuration area, you can set up the following components:
 
-- **Charging & Heating** (required): Wallboxes and heat pumps – at least one device must be configured
+- **Charging points & Heaters** (recommended): Wallboxes and heat pumps
 - **Grid** (recommended): Grid connection meter and electricity tariffs – important for proper energy management
 - **Solar & Battery** (optional): Solar systems and battery storage
 - **Vehicles** (optional): Vehicle integrations for battery capacity and state of charge, enables smarter charging
+
+At least one meter or charging point must be configured for the system to run.
 
 ### Integrations
 


### PR DESCRIPTION
Updates docs for evcc-io/evcc#31658.

- Rename navigation label **Charging & Heating** to **Charging points & Heaters** (DE: **Laden & Heizen** to **Ladepunkte & Heizungen**) in all non-blog pages, matching the new UI wording.
- Installation/configuration: charging points are now recommended instead of required; note that at least one meter or charging point must be configured for the system to run.

Closes #1116