### PR TITLE
Limits: document min temperature for heating devices

### DIFF
--- a/src/content/docs/de/features/limits.mdx
+++ b/src/content/docs/de/features/limits.mdx
@@ -47,6 +47,13 @@ Grundlage ist hier die am [Fahrzeug](./vehicle) hinterlegte Akkukapazität.
 Tritt dies regelmäßig auf, bspw. weil der Empfang am Ladepunkt schlecht ist, solltest du die Mindestladung deaktivieren.
 :::
 
+### Heizgeräte
+
+Für Ladepunkte mit einem Heizgerät kannst du stattdessen eine Mindesttemperatur definieren.
+Liegt die gemessene Temperatur unter diesem Wert, wird im PV-Modus auch mit Batterie- und Netzstrom geheizt, um diese Temperatur zu halten.
+
+Die Einstellung **Min. Temperatur** findest du im Einstellungsdialog des Ladepunkts im Bereich **Heizen**.
+
 ## Ladelimit
 
 Das Ladelimit legt die obere Ladegrenze fest.

--- a/src/content/docs/en/features/limits.mdx
+++ b/src/content/docs/en/features/limits.mdx
@@ -47,6 +47,13 @@ The basis here is the battery capacity stored on the [vehicle](./vehicle).
 If this occurs regularly, e.g. because the reception at the charging point is poor, you should deactivate the minimum charge.
 :::
 
+### Heating devices
+
+For charging points with a heating device, you can define a minimum temperature instead.
+If the measured temperature is below this value, battery and grid power are also used in solar mode to maintain this temperature.
+
+You can find the **Min. temperature** setting in the settings dialog of the charging point under **Heating**.
+
 ## Charging limit
 
 The charging limit sets the upper charging limit.


### PR DESCRIPTION
Documents the new loadpoint-level minimum temperature for heating devices in both locales.

Below this value, battery and grid power are also used in solar mode to maintain the temperature. Wording aligned with the UI labels from evcc-io/evcc#31749.