### PR TITLE
Clarify that OFF for heat pump does control the heat pump

### DIFF
--- a/src/components/intros/HeatingIntro.astro
+++ b/src/components/intros/HeatingIntro.astro
@@ -38,8 +38,7 @@ const sgreadySrc = lang === "de" ? sgreadyDe : sgreadyEn;
       Für den <strong>Dim-Betrieb</strong> wird die Leistungsaufnahme gesenkt, nützlich bei Netzengpässen oder im Rahmen von § 14a EnWG.
     </p>
     <p>
-      Ist der Ladepunkt auf <strong>Aus</strong> gestellt, wird die Wärmepumpe nicht mehr angesteuert.
-      Sie läuft dann unbeeinflusst in ihrem Normalbetrieb weiter.
+      Ist der Ladepunkt auf <strong>Aus</strong> gestellt, wird die Wärmepumpe in ihrem <strong>Normalbetrieb</strong> gehalten.
     </p>
 
     <h3>Direkte Kommunikation</h3>
@@ -101,8 +100,7 @@ const sgreadySrc = lang === "de" ? sgreadyDe : sgreadyEn;
       For <strong>dim</strong>, the power consumption is reduced, useful during grid constraints or within § 14a EnWG.
     </p>
     <p>
-      With the loadpoint set to <strong>Off</strong>, the heat pump is no longer controlled.
-      It then keeps running unaffected in its normal operation.
+      With the loadpoint set to <strong>Off</strong>, the heat pump is hold in <strong>normal operation</strong>.
     </p>
 
     <h3>Direct communication</h3>


### PR DESCRIPTION
In mode OFF, evcc continously sends commands to the heat pump to keep it in mode normal operation. Thus, "no control" and "unaffected" are replaced.

See discussion in #1112, especially https://github.com/evcc-io/docs/pull/1112#issuecomment-4938714484:
> It doesn't. It establishes "normal" operation mode (per SG ready) or whatever the device implements as equivalent.