### PR TITLE
Remove CLI docs generation hint from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,15 +41,6 @@ npm run build
 This builds the static site into `dist/` and runs the legacy-redirect generator.
 The output can be served by any static host.
 
-### Update CLI docs
-
-CLI documentation is auto-generated and pushed to this repository by the `documentation.yml` workflow in the main evcc repository on every release.
-It can also be triggered manually via workflow dispatch.
-Do not edit the files in `src/content/docs/en/reference/cli/` by hand.
-
-CLI docs only live in the English (default-locale) directory.
-German pages fall back to the English content automatically.
-
 ## Contributing
 
 ### Code formatting

--- a/README.md
+++ b/README.md
@@ -43,13 +43,9 @@ The output can be served by any static host.
 
 ### Update CLI docs
 
-CLI documentation is auto-generated.
-Generation needs to be triggered manually.
-Run this command inside the evcc core repository (e.g. `./evcc`):
-
-```sh
-go run main.go gendoc ../evcc-docs/src/content/docs/en/reference/cli/
-```
+CLI documentation is auto-generated and pushed to this repository by the `documentation.yml` workflow in the main evcc repository on every release.
+It can also be triggered manually via workflow dispatch.
+Do not edit the files in `src/content/docs/en/reference/cli/` by hand.
 
 CLI docs only live in the English (default-locale) directory.
 German pages fall back to the English content automatically.


### PR DESCRIPTION
pairs with evcc-io/evcc#31846

CLI reference pages are now generated and pushed automatically by a workflow in the main repository, so the manual generation instructions no longer apply.