### PR TITLE
Add OCPP Forward integration page

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -221,6 +221,11 @@ export default defineConfig({
               slug: "integrations/sma-sunny-home-manager",
             },
             {
+              label: "OCPP Forward",
+              translations: { de: "OCPP-Weiterleitung" },
+              slug: "integrations/ocpp-forwarding",
+            },
+            {
               label: "Notifications",
               translations: { de: "Benachrichtigungen" },
               link: "/notifications",

--- a/src/content/docs/de/integrations/ocpp-forwarding.md
+++ b/src/content/docs/de/integrations/ocpp-forwarding.md
@@ -1,0 +1,37 @@
+---
+title: "OCPP-Weiterleitung"
+---
+
+Manchmal sollen Ladevorgänge zusätzlich in einem externen OCPP-Backend landen, z. B. bei einer Abrechnungsplattform für die Erstattung durch den Arbeitgeber oder einem Charge Point Operator.
+Eine Wallbox kann normalerweise nur mit einem OCPP-Server sprechen.
+Mit der Weiterleitung bleibt die Wallbox mit deiner evcc-Instanz verbunden, die ihre Nachrichten zusätzlich an den externen Server weitergibt.
+evcc steuert das Laden weiterhin.
+Der externe Server erhält Ladevorgänge und Zählerwerte live und kann die Wallbox, wenn erlaubt, auch steuern.
+
+## Einrichtung {#setup}
+
+Die Weiterleitung gibt es für Wallboxen, die per OCPP eingebunden sind, also evcc als OCPP-Server nutzen.
+Richte die Wallbox zuerst ein, danach kannst du die Weiterleitung für sie konfigurieren.
+
+1. Öffne **Konfiguration → OCPP Server**.
+2. Die Liste **Station-IDs** zeigt deine verbundenen OCPP-Wallboxen. Klicke auf die Wolken-Schaltfläche neben der Wallbox, um den Dialog **OCPP-Weiterleitung** zu öffnen.
+3. Trage die **Upstream-Server-URL** ein, die Adresse des Servers, an den weitergeleitet wird, z. B. `wss://billing.example.com/ocpp`.
+4. Wenn der externe Server eine Anmeldung verlangt, trage **Benutzername** und **Passwort** ein (HTTP Basic Auth). Erwartet er eine andere Wallbox-Kennung, setze die **Station-ID**.
+5. Klicke auf **Speichern**. Die Weiterleitung startet sofort, ein Neustart ist nicht nötig.
+
+Das Wolken-Symbol neben der Wallbox zeigt, ob die Weiterleitung funktioniert.
+Verbindungsprobleme werden im Dialog angezeigt.
+
+Um die Weiterleitung zu beenden, öffne den Dialog erneut und klicke auf **Entfernen**.
+
+## Upstream-Befehle {#upstream-commands}
+
+Standardmäßig kann der externe Server Befehle an die Wallbox senden.
+Um Konflikte mit der Ladesteuerung zu vermeiden, aktiviere **Befehle vom Upstream-Server blockieren** in den erweiterten Einstellungen.
+Der Server erhält weiterhin jede Nachricht der Wallbox, evcc behält aber die alleinige Kontrolle.
+
+## Zertifikate {#certificates}
+
+In den erweiterten Einstellungen finden sich auch die TLS-Optionen.
+Aktiviere **Selbstsignierte Zertifikate erlauben** für Testumgebungen ohne gültiges Zertifikat.
+Hinterlege ein **Serverzertifikat (CA)**, wenn der externe Server ein Zertifikat einer privaten Zertifizierungsstelle verwendet.

--- a/src/content/docs/en/integrations/ocpp-forwarding.md
+++ b/src/content/docs/en/integrations/ocpp-forwarding.md
@@ -1,0 +1,37 @@
+---
+title: "OCPP Forward"
+---
+
+Sometimes charging sessions need to reach an external OCPP backend, e.g. a billing platform for employer reimbursement or a charge point operator.
+A charger can normally talk to only one OCPP server.
+With forwarding, the charger stays connected to your evcc instance, which passes its messages on to the external server as well.
+evcc keeps managing the charging.
+The external server receives charging sessions and meter values live and can, if allowed, also control the charger.
+
+## Setup {#setup}
+
+Forwarding is available for chargers that are integrated via OCPP, i.e. chargers that use evcc as their OCPP server.
+Set up the charger first, then you can configure forwarding for it.
+
+1. Open **Configuration → OCPP Server**.
+2. The **Station IDs** list shows your connected OCPP chargers. Click the cloud button next to the charger to open the **OCPP Forward** dialog.
+3. Enter the **Upstream server URL**, the address of the server to forward to, e.g. `wss://billing.example.com/ocpp`.
+4. If the external server requires authentication, enter **Username** and **Password** (HTTP Basic Auth). If it expects a different charger identifier, set the **Station ID**.
+5. Click **Save**. Forwarding starts immediately, no restart needed.
+
+The cloud icon next to the charger shows whether forwarding is working.
+Connection problems are shown in the dialog.
+
+To stop forwarding, open the dialog again and click **Remove**.
+
+## Upstream Commands {#upstream-commands}
+
+By default, the external server can send commands to the charger.
+To avoid conflicts with charging control, enable **Block commands from the upstream server** in the advanced settings.
+The server still receives every charger message, but evcc retains exclusive control.
+
+## Certificates {#certificates}
+
+The advanced settings also cover TLS.
+Enable **Allow self-signed certificates** for test setups without a valid certificate.
+Provide a **Server certificate (CA)** if the external server uses a certificate from a private certificate authority.


### PR DESCRIPTION
Documents OCPP forwarding (evcc-io/evcc#29154) from the UI perspective under Integrations, en + de, using the UI wording from i18n.

Replaces #1043.