### PR TITLE
Charger (FoxESS AC EV Charger): document Modbus variant

### DIFF
--- a/templates/nightly/de/charger/foxess-ac-ev-charger-modbus.yaml
+++ b/templates/nightly/de/charger/foxess-ac-ev-charger-modbus.yaml
@@ -1,0 +1,55 @@
+template: foxess-modbus
+product:
+  identifier: foxess-ac-ev-charger-modbus
+  brand: FoxESS
+  description: AC EV Charger (Modbus)
+capabilities: ["mA", "rfid", "meter", "1p3p"]
+requirements: ["sponsorship"]
+description: |
+  Verbindet sich über Modbus TCP mit der Wallbox. Unterstützt feinstufige Stromregelung (mA), einen integrierten Zähler (Leistung, Energie, Ströme und Spannungen je Phase) sowie RFID-Fahrzeugidentifikation.
+
+  Die automatische Umschaltung zwischen 1- und 3-phasigem Laden erfordert eine optionale FoxESS Phasenumschaltbox (PBOX). Ist eine PBOX angeschlossen, sollte die entsprechende Option unten aktiviert werden, damit evcc die Phasenumschaltung gezielt steuern kann. Ohne PBOX schaltet die Wallbox die Phasen weiterhin selbstständig anhand der Leistungsvorgabe um, evcc kann dabei jedoch keine bestimmte Phasenzahl anfordern.
+render:
+  - default: |
+      type: template
+      template: foxess-modbus
+
+      # Modbus TCP
+      modbus: tcpip
+      id: 1
+      host:  # Hostname
+      port: 502 # Port
+    advanced: |
+      type: template
+      template: foxess-modbus
+
+      # Modbus TCP
+      modbus: tcpip
+      id: 1
+      host:  # Hostname
+      port: 502 # Port
+      pbox: true # Phasenumschaltbox (PBOX) angeschlossen, Aktivieren, wenn eine externe Phasenumschaltbox angeschlossen ist. Nur dann kann evcc zwischen ein- und dreiphasigem Laden umschalten. (optional)
+params:
+  - name: modbus
+    example:
+    default:
+    choice: ["tcpip"]
+    unit:
+    description: Modbus Type
+    help:
+    advanced: false
+    optional: false
+  - name: pbox
+    example:
+    default:
+    choice: []
+    unit:
+    description: Phasenumschaltbox (PBOX) angeschlossen
+    help: Aktivieren, wenn eine externe Phasenumschaltbox angeschlossen ist. Nur dann kann evcc zwischen ein- und dreiphasigem Laden umschalten.
+    advanced: true
+    optional: true
+modbus:
+  host:
+  id: 1
+  port: 502
+  tcpip: true

--- a/templates/nightly/en/charger/foxess-ac-ev-charger-modbus.yaml
+++ b/templates/nightly/en/charger/foxess-ac-ev-charger-modbus.yaml
@@ -1,0 +1,55 @@
+template: foxess-modbus
+product:
+  identifier: foxess-ac-ev-charger-modbus
+  brand: FoxESS
+  description: AC EV Charger (Modbus)
+capabilities: ["mA", "rfid", "meter", "1p3p"]
+requirements: ["sponsorship"]
+description: |
+  Connects to the charger via Modbus TCP. Supports fine-grained (mA) current regulation, an integrated meter (power, energy, per-phase currents and voltages) and RFID vehicle identification.
+
+  Automatic 1-phase/3-phase switching requires an optional FoxESS Phase Switching Box (PBOX). If a PBOX is connected, enable the corresponding option below so evcc can control phase switching explicitly. Without a PBOX, the charger still switches phases autonomously based on the power setpoint, but evcc cannot request a specific phase count.
+render:
+  - default: |
+      type: template
+      template: foxess-modbus
+
+      # Modbus TCP
+      modbus: tcpip
+      id: 1
+      host:  # Hostname
+      port: 502 # Port
+    advanced: |
+      type: template
+      template: foxess-modbus
+
+      # Modbus TCP
+      modbus: tcpip
+      id: 1
+      host:  # Hostname
+      port: 502 # Port
+      pbox: true # Phase switching box (PBOX) connected, Enable when an external phase switching box is connected. Only then can evcc switch between single- and three-phase charging. (optional)
+params:
+  - name: modbus
+    example:
+    default:
+    choice: ["tcpip"]
+    unit:
+    description: Modbus Type
+    help:
+    advanced: false
+    optional: false
+  - name: pbox
+    example:
+    default:
+    choice: []
+    unit:
+    description: Phase switching box (PBOX) connected
+    help: Enable when an external phase switching box is connected. Only then can evcc switch between single- and three-phase charging.
+    advanced: true
+    optional: true
+modbus:
+  host:
+  id: 1
+  port: 502
+  tcpip: true


### PR DESCRIPTION
Added documentation for the modbus variant of the FoxESS A EV charger.

These two files are generated using Claude (the english version looks fine - my german is very limited, so I cannot say if that is correct).

Marking as draft, since it needs to wait for evcc-io/evcc#31412 to be merged.