### PR TITLE
External limit: document custom type

### DIFF
--- a/src/content/docs/de/user-defined-devices.mdx
+++ b/src/content/docs/de/user-defined-devices.mdx
@@ -536,8 +536,7 @@ Zahlt eine feste Einspeisevergütung von 7 ct/kWh, außer wenn der Börsenstromp
 Eine benutzerdefinierte Integration für die [Externe Begrenzung](/de/external-limit) bindet eine Steuerbox oder ein Energiemanagementsystem an, das nicht durch eine integrierte Integration abgedeckt ist.
 Wähle dazu in der Oberfläche unter **Konfiguration → Externe Begrenzung** die Option **Benutzerdefinierte Integration**.
 
-Anders als bei anderen Gerätetypen gibt es hier kein `type: custom`.
-Stattdessen beschreibt einer von drei Typen, wie das Begrenzungssignal empfangen wird: `relay` (einzelner Schaltkontakt), `fnn` (FNN-Steuerbox mit mehreren Schaltkontakten) oder `eebus` (EEBus-Protokoll).
+Einer von vier Typen beschreibt, wie das Begrenzungssignal empfangen wird: `relay` (einzelner Schaltkontakt), `fnn` (FNN-Steuerbox mit mehreren Schaltkontakten), `eebus` (EEBus-Protokoll) oder `custom` (dynamische Limitwerte über Plugins).
 Jedes Signal wird über eine [Plugin](/de/reference/plugins)-Konfiguration ausgelesen (GPIO, MQTT, HTTP, Modbus).
 Siehe auch die [`hems`-Konfigurationsreferenz](/de/reference/configuration/hems).
 
@@ -689,6 +688,35 @@ Steuerbox und evcc müssen einmalig [gekoppelt](/de/external-limit#eebus-pairing
 ```yaml
 type: eebus
 ski: "1234-5678-90AB-CDEF" # SKI der Steuerbox
+```
+
+<a id="external-limit-custom"></a>
+
+### Custom
+
+Die generische Integration für Steuerungssysteme, die dynamische Limitwerte statt Schaltkontakten liefern.
+Verbrauchslimit und Abregelung der Einspeisung werden über Plugins ausgelesen und arbeiten unabhängig voneinander.
+Mindestens eines der Attribute `maxConsumptionPower` oder `curtailedPercent` muss konfiguriert sein.
+
+| Attribut               | Typ        | Erforderlich | Beschreibung                                                                                                |
+| ---------------------- | ---------- | ------------ | ----------------------------------------------------------------------------------------------------------- |
+| `maxConsumptionPower`  | Plugin     | nein¹        | Liest das Gesamtleistungslimit in Watt. `0` = kein Limit.                                                   |
+| `curtailedPercent`     | Plugin     | nein¹        | Liest die erlaubte Einspeisung in Prozent von `productionNominalMax` (0 bis 100). `100` = keine Abregelung. |
+| `productionNominalMax` | `int` (W)  | nein²        | Installierte Generatorleistung (Wp).                                                                        |
+| `interval`             | `duration` | nein         | Abfrageintervall für die Plugins. Standard `10s`.                                                           |
+
+¹ mindestens eines von beiden ist erforderlich, ² erforderlich, wenn `curtailedPercent` konfiguriert ist.
+
+```yaml
+type: custom
+maxConsumptionPower:
+  source: http
+  uri: http://steuerbox.local/api/limit
+  jq: .maxPower # Leistungslimit in Watt, 0 = kein Limit
+curtailedPercent:
+  source: mqtt
+  topic: hems/curtail/percent # Erlaubte Einspeisung in Prozent, 100 = keine Abregelung
+productionNominalMax: 10000 # Installierte Generatorleistung (Wp)
 ```
 
 <a id="notification-service"></a>

--- a/src/content/docs/en/reference/cli/evcc_completion_zsh.md
+++ b/src/content/docs/en/reference/cli/evcc_completion_zsh.md
@@ -9,7 +9,7 @@ Generate the autocompletion script for zsh
 Generate the autocompletion script for the zsh shell.
 
 If shell completion is not already enabled in your environment you will need
-to enable it.  You can execute the following once:
+to enable it. You can execute the following once:
 
 ```
 echo "autoload -U compinit; compinit" >> ~/.zshrc

--- a/src/content/docs/en/user-defined-devices.mdx
+++ b/src/content/docs/en/user-defined-devices.mdx
@@ -535,8 +535,7 @@ Pays a fixed feed-in tariff of 7 ct/kWh, except when the day-ahead market price 
 A user-defined integration for the [External Limit](/en/external-limit) feature connects a control box or energy management system that isn't covered by a built-in integration.
 In the UI, pick **User-defined integration** under **Configuration → External Limit**.
 
-Unlike other device types, there is no `type: custom` here.
-Instead, one of three types describes how the limit signal is received: `relay` (single switch contact), `fnn` (FNN control box with multiple switch contacts) or `eebus` (EEBus protocol).
+One of four types describes how the limit signal is received: `relay` (single switch contact), `fnn` (FNN control box with multiple switch contacts), `eebus` (EEBus protocol) or `custom` (dynamic limit values via plugins).
 Each signal is read via a [plugin](/en/reference/plugins) configuration (GPIO, MQTT, HTTP, Modbus).
 See also the [`hems` configuration reference](/en/reference/configuration/hems).
 
@@ -688,6 +687,35 @@ Control box and evcc need to be [paired](/en/external-limit#eebus-pairing) once.
 ```yaml
 type: eebus
 ski: "1234-5678-90AB-CDEF" # SKI of the control box
+```
+
+<a id="external-limit-custom"></a>
+
+### Custom
+
+The generic integration for control systems that provide dynamic limit values instead of switch contacts.
+Consumption limit and feed-in curtailment are read via plugins and work independently of each other.
+At least one of `maxConsumptionPower` or `curtailedPercent` must be configured.
+
+| Attribute              | Type       | Required | Description                                                                                           |
+| ---------------------- | ---------- | -------- | ----------------------------------------------------------------------------------------------------- |
+| `maxConsumptionPower`  | plugin     | no¹      | Reads the total power limit in watts. `0` = no limit.                                                 |
+| `curtailedPercent`     | plugin     | no¹      | Reads the allowed feed-in as percentage of `productionNominalMax` (0 to 100). `100` = no curtailment. |
+| `productionNominalMax` | `int` (W)  | no²      | Installed generator power (Wp).                                                                       |
+| `interval`             | `duration` | no       | Polling interval for the plugins. Default `10s`.                                                      |
+
+¹ at least one of the two is required, ² required when `curtailedPercent` is configured.
+
+```yaml
+type: custom
+maxConsumptionPower:
+  source: http
+  uri: http://steuerbox.local/api/limit
+  jq: .maxPower # Power limit in watts, 0 = no limit
+curtailedPercent:
+  source: mqtt
+  topic: hems/curtail/percent # Allowed feed-in in percent, 100 = no curtailment
+productionNominalMax: 10000 # Installed generator power (Wp)
 ```
 
 <a id="notification-service"></a>


### PR DESCRIPTION
Documents the new user-defined `custom` external limit type (dynamic limits via plugins).

- `Custom` section on the user-defined devices page (EN/DE)
- intro updated: four types, `type: custom` now exists

Ref evcc-io/evcc#32182, implementation in evcc-io/evcc#32187.