### PR TITLE
fix: redirect legacy /docs URLs to new structure

### DIFF
--- a/src/scripts/lang-redirect.js
+++ b/src/scripts/lang-redirect.js
@@ -1,4 +1,16 @@
 (function () {
+  // legacy Docusaurus URLs: /docs/* (default locale de) and /{en,de}/docs/*
+  var legacy = location.pathname.match(/^\/(?:(en|de)\/)?docs\/(.+)/);
+  if (legacy) {
+    var rest = legacy[2]
+      .replace(/^devices\//, "")
+      .replace(/^features\/external-control\/?$/, "external-limit")
+      .replace(/^reference\/api\/?$/, "integrations/rest-api");
+    location.replace(
+      "/" + (legacy[1] || "de") + "/" + rest + location.search + location.hash,
+    );
+    return;
+  }
   var m = location.pathname.match(/^\/(en|de)(\/|$)/);
   if (!m) return;
   var current = m[1];


### PR DESCRIPTION
Old Docusaurus URLs (`/docs/*` and `/{en,de}/docs/*`) 404 since the Starlight migration — currently only masked by stale files from the previous deploy, which the next deploy will remove.

Extends `lang-redirect.js` (injected into every page head, including 404.html) to client-side-redirect legacy paths:
- `/docs/*` → `/de/*` (old default locale)
- `/{en,de}/docs/*` → `/{lang}/*`
- slug renames: `devices/*` → `/*`, `features/external-control` → `external-limit`, `reference/api` → `integrations/rest-api`

Covers external deep links and search engine results on GitHub Pages, which has no server-side redirects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)