### PR TITLE
Add API State reference page

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -127,6 +127,8 @@ export default defineConfig({
             "/{en,de}/{chargers,meters,vehicles,smartswitches,heating,tariffs,external-limit,notifications,nightly}",
             "/{en,de}/{chargers,meters,vehicles,smartswitches,heating,tariffs,external-limit,notifications,nightly}/**",
             "/{en,de}/{chargers,meters,vehicles,smartswitches,heating,tariffs,external-limit,notifications,nightly}#*",
+            "/{en,de}/reference/state",
+            "/{en,de}/reference/state#*",
             // starlight-openapi and starlight-blog routes are not visible to the validator
             "/integrations/rest-api",
             "/integrations/rest-api/**",
@@ -267,6 +269,7 @@ export default defineConfig({
             { label: "Plugins", slug: "reference/plugins" },
             { label: "Modbus", slug: "reference/modbus" },
             { label: "Web UI", slug: "reference/web-ui" },
+            { label: "API State", link: "/reference/state" },
             { label: "evcc App", slug: "reference/app" },
             {
               label: "CLI",

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,8 @@
         "sharp": "^0.35.0",
         "starlight-blog": "^0.28.0",
         "starlight-llms-txt": "^0.11.0",
-        "starlight-openapi": "^0.26.0"
+        "starlight-openapi": "^0.26.0",
+        "yaml": "^2.9.0"
       },
       "devDependencies": {
         "prettier": "^3.8.1",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "sharp": "^0.35.0",
     "starlight-blog": "^0.28.0",
     "starlight-llms-txt": "^0.11.0",
-    "starlight-openapi": "^0.26.0"
+    "starlight-openapi": "^0.26.0",
+    "yaml": "^2.9.0"
   },
   "engines": {
     "node": ">=26.0.0"

--- a/public/openapi.yaml
+++ b/public/openapi.yaml
@@ -2,14 +2,17 @@ openapi: 3.1.0
 info:
   title: evcc
   description: Solar charging. Super simple.
-  version: "0.2.0"
+  version: 0.2.0
   contact:
     url: https://github.com/evcc-io/evcc
 servers:
   - url: https://demo.evcc.io/api
 tags:
+  - name: state
   - name: auth
   - name: battery
+  - name: db
+  - name: experimental
   - name: general
   - name: loadpoints
   - name: sessions
@@ -21,7 +24,7 @@ paths:
     post:
       operationId: login
       summary: Login
-      description: "Administrator login. Returns authorization cookie required for all protected endpoints."
+      description: Administrator login. Returns authorization cookie required for all protected endpoints.
       tags:
         - auth
       requestBody:
@@ -41,9 +44,7 @@ paths:
               description: The authorization cookie
               schema:
                 type: string
-                example: >-
-                  auth=ey...qY; Path=/; Expires=Fri, 04 Apr 2025 14:35:37 GMT;
-                  HttpOnly; SameSite=Strict
+                example: auth=ey...qY; Path=/; Expires=Fri, 04 Apr 2025 14:35:37 GMT; HttpOnly; SameSite=Strict
         "401":
           description: Invalid password provided
   /auth/logout:
@@ -67,7 +68,7 @@ paths:
     put:
       operationId: changePassword
       summary: Change admin password
-      description: "Changes the admin password."
+      description: Changes the admin password.
       tags:
         - auth
       requestBody:
@@ -98,13 +99,93 @@ paths:
                 enum:
                   - "true"
                   - "false"
+  /auth/apikey:
+    get:
+      operationId: getApiKeyStatus
+      summary: API key status
+      description: |
+        Reports whether an API key has been generated. The key itself is
+        only returned once at creation time (POST), never on subsequent
+        reads.
+      tags:
+        - auth
+      security:
+        - cookieAuth: []
+        - bearerAuth: []
+      responses:
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  configured:
+                    type: boolean
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+    post:
+      operationId: regenerateApiKey
+      summary: Generate or rotate the API key
+      description: |
+        Generates a fresh API key, replacing any existing one. The
+        returned key is shown only once; store it immediately.
+
+        Even when the request is authenticated via API key (Bearer), the
+        admin password must be supplied in the request body to prevent a
+        leaked key from rotating itself. The password check is skipped
+        when the server is started with `--disable-auth`.
+      tags:
+        - auth
+      security:
+        - cookieAuth: []
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                password:
+                  $ref: "#/components/schemas/Password"
+      responses:
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  key:
+                    type: string
+                    description: The new API key (cleartext, shown once).
+                    example: evcc_aB3xYz7k0Pq2sN5mWtR4
+        "401":
+          description: Invalid admin password
+        "403":
+          description: Forbidden in demo mode
   /batterydischargecontrol/{enable}:
     post:
       operationId: setBatteryDischargeControl
       summary: Control battery-discharge
-      description: "Prevent home battery discharge during vehicle fast charging."
+      description: Prevent home battery discharge during vehicle fast charging.
       externalDocs:
-        url: https://docs.evcc.io/en/docs/features/battery
+        url: https://docs.evcc.io/en/features/battery
+      tags:
+        - battery
+      parameters:
+        - $ref: "#/components/parameters/enable"
+      responses:
+        "200":
+          $ref: "#/components/responses/BooleanResult"
+  /batterygriddischarge/{enable}:
+    post:
+      operationId: setBatteryGridDischarge
+      summary: Control battery grid discharge
+      description: Allow the home battery to discharge to the grid (experimental).
+      externalDocs:
+        url: https://docs.evcc.io/en/features/battery
       tags:
         - battery
       parameters:
@@ -116,9 +197,9 @@ paths:
     delete:
       operationId: removeBatteryGridChargeLimit
       summary: Remove battery grid charge limit
-      description: "Remove battery grid charge limit."
+      description: Remove battery grid charge limit.
       externalDocs:
-        url: https://docs.evcc.io/en/docs/features/battery
+        url: https://docs.evcc.io/en/features/battery
       tags:
         - battery
       responses:
@@ -128,9 +209,9 @@ paths:
     post:
       operationId: setBatteryGridChargeLimit
       summary: Set battery grid charge limit
-      description: "Charge home battery from grid when price or emissions are below the threshold. Uses price if a dynamic tariff exists. Uses emissions if a CO₂-tariff is configured. Ignored otherwise."
+      description: Charge home battery from grid when price or emissions are below the threshold. Uses price if a dynamic tariff exists. Uses emissions if a CO₂-tariff is configured. Ignored otherwise.
       externalDocs:
-        url: https://docs.evcc.io/en/docs/features/battery
+        url: https://docs.evcc.io/en/features/battery
       tags:
         - battery
       parameters:
@@ -152,7 +233,7 @@ paths:
     post:
       operationId: setExternalBatteryMode
       summary: Set external battery mode
-      description: "Directly controls the mode of all controllable batteries. evcc behavior like 'price limit' or 'prevent discharge while fast charging' is overruled. External mode resets after 60s. The external system has to call this endpoint regularly."
+      description: Directly controls the mode of all controllable batteries. evcc behavior like 'price limit' or 'prevent discharge while fast charging' is overruled. External mode resets after 60s. The external system has to call this endpoint regularly.
       tags:
         - battery
       parameters:
@@ -164,9 +245,9 @@ paths:
     post:
       operationId: setBufferSoc
       summary: Set battery buffer SoC
-      description: "Set battery buffer SoC."
+      description: Set battery buffer SoC.
       externalDocs:
-        url: https://docs.evcc.io/en/docs/features/battery
+        url: https://docs.evcc.io/en/features/battery
       tags:
         - battery
       parameters:
@@ -178,9 +259,9 @@ paths:
     post:
       operationId: setBufferStartSoc
       summary: Set battery buffer start SoC
-      description: "Set battery buffer start SoC."
+      description: Set battery buffer start SoC.
       externalDocs:
-        url: https://docs.evcc.io/en/docs/features/battery
+        url: https://docs.evcc.io/en/features/battery
       tags:
         - battery
       parameters:
@@ -194,7 +275,7 @@ paths:
       summary: Set battery boost
       description: "Enable or disable battery boost. When active, the maximum available home battery power is added until the home battery is drained to configured SoC limit. Note: boost will not work while the battery is on hold (e.g. during fast charging or planned charging with discharge prevention enabled)."
       externalDocs:
-        url: https://docs.evcc.io/en/docs/features/battery#battery-boost
+        url: https://docs.evcc.io/en/features/battery#battery-boost
       tags:
         - loadpoints
       parameters:
@@ -207,9 +288,9 @@ paths:
     post:
       operationId: setLoadpointBatteryBoostLimit
       summary: Set battery boost SoC limit
-      description: "Set the SoC limit for battery boost. Home battery will be used to support charging up to this SoC level. A value of 100 (default) disabled the boost feature in UI and API."
+      description: Set the SoC limit for battery boost. Home battery will be used to support charging up to this SoC level. A value of 100 (default) disabled the boost feature in UI and API.
       externalDocs:
-        url: https://docs.evcc.io/en/docs/features/battery#battery-boost
+        url: https://docs.evcc.io/en/features/battery#battery-boost
       tags:
         - loadpoints
       parameters:
@@ -222,9 +303,9 @@ paths:
     post:
       operationId: setLoadpointDisableDelay
       summary: Disable threshold-delay
-      description: "Delay before charging stops in solar mode."
+      description: Delay before charging stops in solar mode.
       externalDocs:
-        url: https://docs.evcc.io/en/docs/reference/configuration/loadpoints
+        url: https://docs.evcc.io/en/reference/configuration/loadpoints
       tags:
         - loadpoints
       parameters:
@@ -237,9 +318,9 @@ paths:
     post:
       operationId: setLoadpointDisableThreshold
       summary: Disable threshold
-      description: "Specifies the grid draw power to stop charging in solar mode."
+      description: Specifies the grid draw power to stop charging in solar mode.
       externalDocs:
-        url: https://docs.evcc.io/en/docs/reference/configuration/loadpoints#threshold-1
+        url: https://docs.evcc.io/en/reference/configuration/loadpoints#threshold-1
       tags:
         - loadpoints
       parameters:
@@ -252,9 +333,9 @@ paths:
     post:
       operationId: setLoadpointEnableDelay
       summary: Enable threshold-delay
-      description: "Delay before charging starts in solar mode."
+      description: Delay before charging starts in solar mode.
       externalDocs:
-        url: https://docs.evcc.io/en/docs/reference/configuration/loadpoints#delay
+        url: https://docs.evcc.io/en/reference/configuration/loadpoints#delay
       tags:
         - loadpoints
       parameters:
@@ -267,9 +348,9 @@ paths:
     post:
       operationId: setLoadpointEnableThreshold
       summary: Enable threshold
-      description: "Specifies the available surplus power to start charging in solar mode."
+      description: Specifies the available surplus power to start charging in solar mode.
       externalDocs:
-        url: https://docs.evcc.io/en/docs/reference/configuration/loadpoints#threshold
+        url: https://docs.evcc.io/en/reference/configuration/loadpoints#threshold
       tags:
         - loadpoints
       parameters:
@@ -282,9 +363,9 @@ paths:
     post:
       operationId: setLoadpointEnergyLimit
       summary: Update energy limit
-      description: "Updates the energy limit of the loadpoint. Only available for guest vehicles and vehicles with unknown SoC. Limit is removed on vehicle disconnect."
+      description: Updates the energy limit of the loadpoint. Only available for guest vehicles and vehicles with unknown SoC. Limit is removed on vehicle disconnect.
       externalDocs:
-        url: https://docs.evcc.io/en/docs/features/limit
+        url: https://docs.evcc.io/en/features/limits
       tags:
         - loadpoints
       parameters:
@@ -297,9 +378,9 @@ paths:
     post:
       operationId: setLoadpointSocLimit
       summary: Update session SoC limit
-      description: "Sets the session SoC limit. Cleared on disconnect. Takes precedence over the vehicle's configured limit while set; once cleared (set to 0), the vehicle limit applies again."
+      description: Sets the session SoC limit. Cleared on disconnect. Takes precedence over the vehicle's configured limit while set; once cleared (set to 0), the vehicle limit applies again.
       externalDocs:
-        url: https://docs.evcc.io/en/docs/features/limit
+        url: https://docs.evcc.io/en/features/limits
       tags:
         - loadpoints
       parameters:
@@ -312,7 +393,7 @@ paths:
     post:
       operationId: setLoadpointMaxCurrent
       summary: Update maximum current
-      description: "Updates the maximum current of the loadpoint."
+      description: Updates the maximum current of the loadpoint.
       tags:
         - loadpoints
       parameters:
@@ -325,7 +406,7 @@ paths:
     post:
       operationId: setLoadpointMinCurrent
       summary: Update minimum current
-      description: "Updates the minimum current of the loadpoint."
+      description: Updates the minimum current of the loadpoint.
       tags:
         - loadpoints
       parameters:
@@ -334,13 +415,28 @@ paths:
       responses:
         "200":
           $ref: "#/components/responses/NumberResult"
+  /loadpoints/{id}/mintemp/{temp}:
+    post:
+      operationId: setLoadpointMinTemp
+      summary: Update minimum temperature
+      description: Sets the minimum temperature for heating devices. The device is heated as fast as possible while below this value. Set to 0 to disable.
+      externalDocs:
+        url: https://docs.evcc.io/en/features/limits
+      tags:
+        - loadpoints
+      parameters:
+        - $ref: "#/components/parameters/id"
+        - $ref: "#/components/parameters/temp"
+      responses:
+        "200":
+          $ref: "#/components/responses/NumberResult"
   /loadpoints/{id}/mode/{mode}:
     post:
       operationId: setLoadpointMode
       summary: Update charge mode
-      description: "Changes the charging behavior of the loadpoint."
+      description: Changes the charging behavior of the loadpoint.
       externalDocs:
-        url: https://docs.evcc.io/en/docs/features/solar-charging
+        url: https://docs.evcc.io/en/features/solar-charging
       tags:
         - loadpoints
       parameters:
@@ -352,17 +448,14 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  result:
-                    $ref: "#/components/schemas/Mode"
+                $ref: "#/components/schemas/ChargeMode"
   /loadpoints/{id}/phases/{phases}:
     post:
       operationId: setLoadpointPhases
       summary: Update allowed phases
-      description: "Updates the allowed phases of the loadpoint. Selects the desired phase mode for chargers with automatic phase switching. For manual phase switching chargers (via cable or Lasttrennschalter) this value tells evcc the actual phases."
+      description: Updates the allowed phases of the loadpoint. Selects the desired phase mode for chargers with automatic phase switching. For manual phase switching chargers (via cable or Lasttrennschalter) this value tells evcc the actual phases.
       externalDocs:
-        url: https://docs.evcc.io/en/docs/reference/configuration/loadpoints#phases
+        url: https://docs.evcc.io/en/reference/configuration/loadpoints#phases
       tags:
         - loadpoints
       parameters:
@@ -372,14 +465,14 @@ paths:
         "200":
           $ref: "#/components/responses/NumberResult"
         "400":
-          description: "Invalid phases-value. You have most likely entered the value 0 for a wallbox that cannot switch phases automatically."
+          description: Invalid phases-value. You have most likely entered the value 0 for a wallbox that cannot switch phases automatically.
   /loadpoints/{id}/plan:
     get:
       operationId: getLoadpointPlan
       summary: Get charging plan
-      description: "Returns the current charging plan for this loadpoint."
+      description: Returns the current charging plan for this loadpoint.
       externalDocs:
-        url: https://docs.evcc.io/en/docs/features/plans
+        url: https://docs.evcc.io/en/features/plans
       tags:
         - loadpoints
       parameters:
@@ -390,22 +483,19 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  result:
-                    allOf:
-                      - type: object
-                        properties:
-                          planId:
-                            $ref: "#/components/schemas/Id"
-                      - $ref: "#/components/schemas/PlanRates"
+                allOf:
+                  - type: object
+                    properties:
+                      planId:
+                        $ref: "#/components/schemas/Id"
+                  - $ref: "#/components/schemas/PlanRates"
   /loadpoints/{id}/plan/energy:
     delete:
       operationId: deleteLoadpointEnergyPlan
       summary: Delete energy-based charging plan
-      description: "Delete charging plan. Only available when a vehicle without SoC is connected."
+      description: Delete charging plan. Only available when a vehicle without SoC is connected.
       externalDocs:
-        url: https://docs.evcc.io/en/docs/features/plans
+        url: https://docs.evcc.io/en/features/plans
       tags:
         - loadpoints
       parameters:
@@ -417,9 +507,9 @@ paths:
     post:
       operationId: setLoadpointEnergyPlan
       summary: Set energy-based charging plan
-      description: "Create charging plan with fixed time and energy target. Only available when a vehicle without SoC is connected."
+      description: Create charging plan with fixed time and energy target. Only available when a vehicle without SoC is connected.
       externalDocs:
-        url: https://docs.evcc.io/en/docs/features/plans
+        url: https://docs.evcc.io/en/features/plans
       tags:
         - loadpoints
       parameters:
@@ -432,17 +522,14 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  result:
-                    $ref: "#/components/schemas/StaticEnergyPlan"
+                $ref: "#/components/schemas/StaticEnergyPlan"
   /loadpoints/{id}/plan/repeating/preview/{soc}/{weekdays}/{hourMinuteTime}/{timezone}:
     get:
       operationId: previewLoadpointRepeatingPlan
       summary: Repeating plan preview
-      description: "Simulate repeating charging plan and return the result. Does not alter the actual charging plan."
+      description: Simulate repeating charging plan and return the result. Does not alter the actual charging plan.
       externalDocs:
-        url: https://docs.evcc.io/en/docs/features/plans
+        url: https://docs.evcc.io/en/features/plans
       tags:
         - loadpoints
       parameters:
@@ -458,9 +545,9 @@ paths:
     get:
       operationId: previewLoadpointSocPlan
       summary: Simulate soc-based charging plan
-      description: "Simulate charging plan based on SoC goal. Does not alter the actual charging plan."
+      description: Simulate charging plan based on SoC goal. Does not alter the actual charging plan.
       externalDocs:
-        url: https://docs.evcc.io/en/docs/features/plans
+        url: https://docs.evcc.io/en/features/plans
       tags:
         - loadpoints
       parameters:
@@ -474,9 +561,9 @@ paths:
     get:
       operationId: previewLoadpointEnergyPlan
       summary: Simulate energy-based charging plan
-      description: "Simulate charging plan based on energy goal. Does not alter the actual charging plan."
+      description: Simulate charging plan based on energy goal. Does not alter the actual charging plan.
       externalDocs:
-        url: https://docs.evcc.io/en/docs/features/plans
+        url: https://docs.evcc.io/en/features/plans
       tags:
         - loadpoints
       parameters:
@@ -490,9 +577,9 @@ paths:
     post:
       operationId: setLoadpointPlanStrategy
       summary: Set plan strategy
-      description: "Updates the charging plan strategy for the loadpoint."
+      description: Updates the charging plan strategy for the loadpoint.
       externalDocs:
-        url: https://docs.evcc.io/en/docs/features/plans
+        url: https://docs.evcc.io/en/features/plans
       tags:
         - loadpoints
       parameters:
@@ -504,22 +591,19 @@ paths:
             schema:
               $ref: "#/components/schemas/PlanStrategy"
       responses:
-        200:
+        "200":
           description: Success
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  result:
-                    $ref: "#/components/schemas/PlanStrategy"
+                $ref: "#/components/schemas/PlanStrategy"
   /loadpoints/{id}/priority/{priority}:
     post:
       operationId: setLoadpointPriority
       summary: Set priority
-      description: "Set loadpoint priority."
+      description: Set loadpoint priority.
       externalDocs:
-        url: https://docs.evcc.io/en/docs/reference/configuration/loadpoints#priority
+        url: https://docs.evcc.io/en/reference/configuration/loadpoints#priority
       tags:
         - loadpoints
       parameters:
@@ -539,9 +623,9 @@ paths:
     delete:
       operationId: deleteLoadpointSmartCostLimit
       summary: Delete smart charging cost limit
-      description: "Delete cost or emission limit for fast-charging with grid energy."
+      description: Delete cost or emission limit for fast-charging with grid energy.
       externalDocs:
-        url: https://docs.evcc.io/en/docs/features/dynamic-prices
+        url: https://docs.evcc.io/en/features/dynamic-prices
       tags:
         - loadpoints
       parameters:
@@ -553,9 +637,9 @@ paths:
     post:
       operationId: setLoadpointSmartCostLimit
       summary: Set smart charging cost limit
-      description: "Set cost or emission limit for fast-charging with grid energy."
+      description: Set cost or emission limit for fast-charging with grid energy.
       externalDocs:
-        url: https://docs.evcc.io/en/docs/features/dynamic-prices
+        url: https://docs.evcc.io/en/features/dynamic-prices
       tags:
         - loadpoints
       parameters:
@@ -568,7 +652,7 @@ paths:
     delete:
       operationId: deleteLoadpointSmartFeedInPriorityLimit
       summary: Delete smart feed-in priority limit
-      description: "Delete limit for feed-in priority optimization."
+      description: Delete limit for feed-in priority optimization.
       tags:
         - loadpoints
       parameters:
@@ -580,7 +664,7 @@ paths:
     post:
       operationId: setLoadpointSmartFeedInPriorityLimit
       summary: Set smart feed-in priority limit
-      description: "Set limit for feed-in priority optimization."
+      description: Set limit for feed-in priority optimization.
       tags:
         - loadpoints
       parameters:
@@ -593,9 +677,9 @@ paths:
     delete:
       operationId: removeLoadpointVehicle
       summary: Remove vehicle
-      description: "Remove vehicle from loadpoint. Connected vehicle is treated as guest vehicle."
+      description: Remove vehicle from loadpoint. Connected vehicle is treated as guest vehicle.
       externalDocs:
-        url: https://docs.evcc.io/en/docs/features/vehicle
+        url: https://docs.evcc.io/en/features/vehicle
       tags:
         - loadpoints
       parameters:
@@ -606,9 +690,9 @@ paths:
     patch:
       operationId: startLoadpointVehicleDetection
       summary: Start vehicle detection
-      description: "Starts the automatic vehicle detection process."
+      description: Starts the automatic vehicle detection process.
       externalDocs:
-        url: https://docs.evcc.io/en/docs/features/vehicle
+        url: https://docs.evcc.io/en/features/vehicle
       tags:
         - loadpoints
       parameters:
@@ -620,9 +704,9 @@ paths:
     post:
       operationId: assignLoadpointVehicle
       summary: Assign vehicle
-      description: "Assigns vehicle to loadpoint."
+      description: Assigns vehicle to loadpoint.
       externalDocs:
-        url: https://docs.evcc.io/en/docs/features/vehicle
+        url: https://docs.evcc.io/en/features/vehicle
       tags:
         - loadpoints
       parameters:
@@ -636,18 +720,15 @@ paths:
               schema:
                 type: object
                 properties:
-                  result:
-                    type: object
-                    properties:
-                      vehicle:
-                        $ref: "#/components/schemas/VehicleTitle"
+                  vehicle:
+                    $ref: "#/components/schemas/VehicleTitle"
   /prioritysoc/{soc}:
     post:
       operationId: setPrioritySoc
       summary: Set battery priority SoC
-      description: "Set battery priority SoC."
+      description: Set battery priority SoC.
       externalDocs:
-        url: https://docs.evcc.io/en/docs/features/battery
+        url: https://docs.evcc.io/en/features/battery
       tags:
         - battery
       parameters:
@@ -659,9 +740,9 @@ paths:
     post:
       operationId: setResidualPower
       summary: Set grid residual power
-      description: "Set grid connection operating point."
+      description: Set grid connection operating point.
       externalDocs:
-        url: https://docs.evcc.io/en/docs/reference/configuration/site#residualpower
+        url: https://docs.evcc.io/en/reference/configuration/site#residualpower
       tags:
         - battery
       parameters:
@@ -669,11 +750,23 @@ paths:
       responses:
         "200":
           $ref: "#/components/responses/NumberResult"
+  /solaradjusted/{enable}:
+    post:
+      operationId: setSolarAdjusted
+      summary: Adjust solar forecast
+      description: Adjust the solar forecast to real production data of the current day.
+      tags:
+        - experimental
+      parameters:
+        - $ref: "#/components/parameters/enable"
+      responses:
+        "200":
+          $ref: "#/components/responses/BooleanResult"
   /smartfeedinprioritylimit:
     delete:
       operationId: removeGlobalSmartFeedInPriorityLimit
       summary: Remove smart feed-in priority limit for all loadpoints.
-      description: "Convenience method to remove limit for all loadpoints at once. Value is applied to each individual loadpoint."
+      description: Convenience method to remove limit for all loadpoints at once. Value is applied to each individual loadpoint.
       tags:
         - general
       responses:
@@ -683,7 +776,7 @@ paths:
     post:
       operationId: setGlobalSmartFeedInPriorityLimit
       summary: Set smart feed-in priority limit for all loadpoints
-      description: "Convenience method to set smart feed-in priority limit for all loadpoints at once. Value is applied to each individual loadpoint."
+      description: Convenience method to set smart feed-in priority limit for all loadpoints at once. Value is applied to each individual loadpoint.
       tags:
         - general
       parameters:
@@ -696,10 +789,10 @@ paths:
       - $ref: "#/components/parameters/id"
     put:
       operationId: updateSession
-      summary: Update vehicle of charging session
-      description: "Update vehicle of charging session."
+      summary: Update charging session
+      description: Update vehicle, loadpoint or odometer of a charging session. Only provided fields are changed; a null odometer clears the stored value.
       externalDocs:
-        url: https://docs.evcc.io/en/docs/features/sessions
+        url: https://docs.evcc.io/en/features/sessions
       tags:
         - sessions
       requestBody:
@@ -713,15 +806,17 @@ paths:
                   $ref: "#/components/schemas/VehicleName"
                 loadpoint:
                   $ref: "#/components/schemas/LoadpointName"
+                odometer:
+                  $ref: "#/components/schemas/Odometer"
       responses:
         "200":
           description: Success
     delete:
       operationId: deleteSession
       summary: Delete charging session
-      description: "Delete charging session."
+      description: Delete charging session.
       externalDocs:
-        url: https://docs.evcc.io/en/docs/features/sessions
+        url: https://docs.evcc.io/en/features/sessions
       tags:
         - sessions
       responses:
@@ -731,7 +826,7 @@ paths:
     get:
       operationId: getGridSessions
       summary: Grid limitation sessions
-      description: "Returns a list of HEMS grid limitation events."
+      description: Returns a list of HEMS grid limitation events.
       tags:
         - sessions
       parameters:
@@ -754,10 +849,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  result:
-                    $ref: "#/components/schemas/GridSessions"
+                $ref: "#/components/schemas/GridSessions"
             text/csv:
               schema:
                 description: Download csv-file
@@ -767,9 +859,9 @@ paths:
     get:
       operationId: getSessions
       summary: Charging sessions
-      description: "Returns a list of charging sessions."
+      description: Returns a list of charging sessions.
       externalDocs:
-        url: https://docs.evcc.io/en/docs/features/sessions
+        url: https://docs.evcc.io/en/features/sessions
       tags:
         - sessions
       parameters:
@@ -806,10 +898,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  result:
-                    $ref: "#/components/schemas/ChargingSessions"
+                $ref: "#/components/schemas/ChargingSessions"
             text/csv:
               schema:
                 description: Download csv-file
@@ -821,7 +910,7 @@ paths:
       summary: Enable/disable telemetry
       description: "Enable or disable telemetry. Note: Telemetry requires sponsorship."
       externalDocs:
-        url: https://docs.evcc.io/en/docs/reference/configuration/telemetry
+        url: https://docs.evcc.io/en/reference/configuration/telemetry
       tags:
         - system
       parameters:
@@ -835,7 +924,7 @@ paths:
     delete:
       operationId: removeGlobalSmartCostLimit
       summary: Remove smart charging cost limit for all loadpoints.
-      description: "Convenience method to remove limit for all loadpoints at once. Value is applied to each individual loadpoint."
+      description: Convenience method to remove limit for all loadpoints at once. Value is applied to each individual loadpoint.
       tags:
         - general
       responses:
@@ -845,7 +934,7 @@ paths:
     post:
       operationId: setGlobalSmartCostLimit
       summary: Set smart charging cost limit for all loadpoints
-      description: "Convenience method to set smart charging cost limit for all loadpoints at once. Value is applied to each individual loadpoint."
+      description: Convenience method to set smart charging cost limit for all loadpoints at once. Value is applied to each individual loadpoint.
       tags:
         - general
       parameters:
@@ -857,11 +946,11 @@ paths:
     get:
       operationId: getState
       summary: System state
-      description: "Returns the complete state of the system. This structure is used by the UI. It can be filtered by JQ to only return a subset of the data."
+      description: "Returns the complete state of the system. This structure is used by the UI and also published via websocket and MQTT. It can be filtered by JQ to only return a subset of the data. Note: the response mirrors the internal UI state and carries no compatibility promise. Fields may change or disappear between releases."
       externalDocs:
-        url: https://docs.evcc.io/en/docs/reference/configuration/state
+        url: https://docs.evcc.io/en/reference/state
       tags:
-        - general
+        - state
       parameters:
         - name: jq
           in: query
@@ -881,19 +970,17 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  result:
-                    $ref: "#/components/schemas/State"
+                $ref: "#/components/schemas/State"
   /system/log:
     get:
       operationId: getSystemLogs
       summary: Logs
-      description: "Returns the latest log lines."
+      description: Returns the latest log lines.
       externalDocs:
-        url: https://docs.evcc.io/en/docs/reference/configuration/log
+        url: https://docs.evcc.io/en/reference/configuration/log
       security:
         - cookieAuth: []
+        - bearerAuth: []
       tags:
         - system
       parameters:
@@ -918,12 +1005,9 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  result:
-                    type: array
-                    items:
-                      type: string
+                type: array
+                items:
+                  type: string
             text/plain:
               schema:
                 description: Download txt-file
@@ -935,9 +1019,10 @@ paths:
     get:
       operationId: getLogAreas
       summary: List of all log areas
-      description: "Returns a list of all log areas (e.g. `lp-1`, `site`, `db`)."
+      description: Returns a list of all log areas (e.g. `lp-1`, `site`, `db`).
       security:
         - cookieAuth: []
+        - bearerAuth: []
       tags:
         - system
       responses:
@@ -946,19 +1031,17 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  result:
-                    $ref: "#/components/schemas/LogAreas"
+                $ref: "#/components/schemas/LogAreas"
         "401":
           $ref: "#/components/responses/Unauthorized"
   /system/cache:
     delete:
       operationId: clearCache
       summary: Clear cache
-      description: "Clears all cached data. This resets all cached values from tariffs, vehicle APIs, and other components that use caching."
+      description: Clears all cached data. This resets all cached values from tariffs, vehicle APIs, and other components that use caching.
       security:
         - cookieAuth: []
+        - bearerAuth: []
       tags:
         - system
       responses:
@@ -970,9 +1053,10 @@ paths:
     post:
       operationId: shutdownSystem
       summary: Shutdown evcc
-      description: "Shut down instance. There is no reboot command. We expect the underlying system (docker, systemd, etc.) to restart the evcc instance once it's terminated."
+      description: Shut down instance. There is no reboot command. We expect the underlying system (docker, systemd, etc.) to restart the evcc instance once it's terminated.
       security:
         - cookieAuth: []
+        - bearerAuth: []
       tags:
         - system
       responses:
@@ -984,9 +1068,9 @@ paths:
     get:
       operationId: getTariffInfo
       summary: Tariff information
-      description: "Returns the prices or emission values for the upcoming hours"
+      description: Returns the prices or emission values for the upcoming hours
       externalDocs:
-        url: https://docs.evcc.io/en/docs/devices/tariffs
+        url: https://docs.evcc.io/en/tariffs
       tags:
         - tariffs
       parameters:
@@ -1010,20 +1094,17 @@ paths:
               schema:
                 type: object
                 properties:
-                  result:
-                    type: object
-                    properties:
-                      rates:
-                        $ref: "#/components/schemas/Rates"
+                  rates:
+                    $ref: "#/components/schemas/Rates"
         "404":
           description: Tariff not defined
   /vehicles/{name}/limitsoc/{soc}:
     post:
       operationId: setVehicleSocLimit
       summary: Set SoC limit
-      description: "Charging will stop when this SoC is reached."
+      description: Charging will stop when this SoC is reached.
       externalDocs:
-        url: https://docs.evcc.io/en/docs/features/limits
+        url: https://docs.evcc.io/en/features/limits
       tags:
         - vehicles
       parameters:
@@ -1036,9 +1117,9 @@ paths:
     post:
       operationId: setVehicleMinSoc
       summary: Set minimum SoC
-      description: "Vehicle will be fast-charged until this SoC is reached."
+      description: Vehicle will be fast-charged until this SoC is reached.
       externalDocs:
-        url: https://docs.evcc.io/en/docs/features/limits
+        url: https://docs.evcc.io/en/features/limits
       tags:
         - vehicles
       parameters:
@@ -1047,13 +1128,49 @@ paths:
       responses:
         "200":
           $ref: "#/components/responses/SocResult"
+  /vehicles/{name}/mode:
+    delete:
+      operationId: deleteVehicleMode
+      summary: Reset charge mode
+      description: Resets the vehicle charge mode to keep the last selected mode.
+      externalDocs:
+        url: https://docs.evcc.io/en/features/solar-charging
+      tags:
+        - vehicles
+      parameters:
+        - $ref: "#/components/parameters/vehicleName"
+      responses:
+        "200":
+          $ref: "#/components/responses/NullResult"
+  /vehicles/{name}/mode/{mode}:
+    post:
+      operationId: setVehicleMode
+      summary: Set charge mode
+      description: Sets the charge mode applied when this vehicle becomes active on a loadpoint.
+      externalDocs:
+        url: https://docs.evcc.io/en/features/solar-charging
+      tags:
+        - vehicles
+      parameters:
+        - $ref: "#/components/parameters/vehicleName"
+        - $ref: "#/components/parameters/mode"
+      responses:
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  mode:
+                    $ref: "#/components/schemas/ChargeMode"
   /vehicles/{name}/plan/repeating:
     post:
       operationId: updateVehicleRepeatingPlans
       summary: Update repeating plans
-      description: "Updates the repeating charging plan."
+      description: Updates the repeating charging plan.
       externalDocs:
-        url: https://docs.evcc.io/en/docs/features/plans
+        url: https://docs.evcc.io/en/features/plans
       tags:
         - vehicles
       parameters:
@@ -1072,19 +1189,16 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  result:
-                    type: array
-                    items:
-                      $ref: "#/components/schemas/RepeatingPlan"
+                type: array
+                items:
+                  $ref: "#/components/schemas/RepeatingPlan"
   /vehicles/{name}/plan/soc:
     delete:
       operationId: deleteVehicleSocPlan
       summary: Delete a SoC-based charging plan
-      description: "Delete the charging plan"
+      description: Delete the charging plan
       externalDocs:
-        url: https://docs.evcc.io/en/docs/features/plans
+        url: https://docs.evcc.io/en/features/plans
       tags:
         - vehicles
       parameters:
@@ -1096,9 +1210,9 @@ paths:
     post:
       operationId: setVehicleSocPlan
       summary: Set a SoC-based charging plan
-      description: "Create charging plan with fixed time and SoC target."
+      description: Create charging plan with fixed time and SoC target.
       externalDocs:
-        url: https://docs.evcc.io/en/docs/features/plans
+        url: https://docs.evcc.io/en/features/plans
       tags:
         - vehicles
       parameters:
@@ -1113,20 +1227,17 @@ paths:
               schema:
                 type: object
                 properties:
-                  result:
-                    type: object
-                    properties:
-                      soc:
-                        $ref: "#/components/schemas/Soc"
-                      time:
-                        $ref: "#/components/schemas/Timestamp"
+                  soc:
+                    $ref: "#/components/schemas/Soc"
+                  time:
+                    $ref: "#/components/schemas/Timestamp"
   /vehicles/{name}/plan/strategy:
     post:
       operationId: setVehiclePlanStrategy
       summary: Set plan strategy
-      description: "Updates the charging plan strategy for the vehicle."
+      description: Updates the charging plan strategy for the vehicle.
       externalDocs:
-        url: https://docs.evcc.io/en/docs/features/plans
+        url: https://docs.evcc.io/en/features/plans
       tags:
         - vehicles
       parameters:
@@ -1138,26 +1249,189 @@ paths:
             schema:
               $ref: "#/components/schemas/PlanStrategy"
       responses:
-        200:
+        "200":
           description: Success
           content:
             application/json:
               schema:
+                $ref: "#/components/schemas/PlanStrategy"
+  /db/backup:
+    get:
+      operationId: downloadBackup
+      summary: Download database backup
+      description: Downloads the SQLite database as a backup file. Session users must supply the admin password in the X-Admin-Password header. API key holders via Bearer token are exempt.
+      tags:
+        - db
+      security:
+        - cookieAuth: []
+        - bearerAuth: []
+      parameters:
+        - $ref: "#/components/parameters/adminPassword"
+      responses:
+        "200":
+          description: SQLite database file
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+  /db/restore:
+    post:
+      operationId: restoreBackup
+      summary: Restore database backup
+      description: Restores the database from a previously downloaded backup file. Session users must supply the admin password in the X-Admin-Password header. API key holders via Bearer token are exempt. The instance restarts after a successful restore.
+      tags:
+        - db
+      security:
+        - cookieAuth: []
+        - bearerAuth: []
+      parameters:
+        - $ref: "#/components/parameters/adminPassword"
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required:
+                - file
+              properties:
+                file:
+                  type: string
+                  format: binary
+                  description: SQLite database backup file
+      responses:
+        "204":
+          description: Restore successful, instance is restarting
+        "400":
+          description: Invalid file or missing fields
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+  /db/reset:
+    post:
+      operationId: resetDatabase
+      summary: Reset database
+      description: Selectively deletes sessions and/or settings from the database. Session users must supply the admin password in the X-Admin-Password header. API key holders via Bearer token are exempt. The instance restarts after a successful reset.
+      tags:
+        - db
+      security:
+        - cookieAuth: []
+        - bearerAuth: []
+      parameters:
+        - $ref: "#/components/parameters/adminPassword"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                sessions:
+                  type: boolean
+                  description: Delete all charging sessions
+                settings:
+                  type: boolean
+                  description: Delete all settings, configs, and meters
+      responses:
+        "204":
+          description: Reset successful, instance is restarting
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+  /history/energy:
+    get:
+      operationId: getEnergyHistory
+      summary: Energy history
+      description: Returns aggregated energy history data. Aggregate granularity defaults to 15 minutes. Supports CSV export.
+      tags:
+        - experimental
+      parameters:
+        - name: from
+          in: query
+          description: Start time (RFC3339)
+          schema:
+            type: string
+            format: date-time
+            example: 2026-07-01T00:00:00Z
+        - name: to
+          in: query
+          description: End time (RFC3339)
+          schema:
+            type: string
+            format: date-time
+            example: 2026-07-02T00:00:00Z
+        - name: aggregate
+          in: query
+          description: "Aggregation interval. Examples: 15m, 1h, day, month"
+          schema:
+            type: string
+            default: 15m
+            example: 1h
+        - name: grouped
+          in: query
+          description: Group results by loadpoint
+          schema:
+            type: boolean
+            default: false
+            example: false
+        - name: group
+          in: query
+          description: Filter by entity group
+          schema:
+            type: string
+            example: battery
+            enum:
+              - forecast
+              - battery
+              - grid
+              - pv
+              - home
+              - loadpoint
+              - meter
+              - consumer
+        - name: name
+          in: query
+          description: Filter by entity name
+          schema:
+            type: string
+            example: db:8
+        - name: title
+          in: query
+          description: Filter by entity title
+          schema:
+            type: string
+            example: Battery
+        - name: format
+          in: query
+          description: Response format
+          schema:
+            type: string
+            enum:
+              - json
+              - csv
+            default: json
+            example: json
+        - name: lang
+          in: query
+          description: Language for CSV column headers (BCP 47, e.g. de, en). Defaults to Accept-Language header.
+          schema:
+            type: string
+            example: de
+      responses:
+        "200":
+          description: Energy history data
+          content:
+            application/json:
+              schema:
                 type: object
-                properties:
-                  result:
-                    $ref: "#/components/schemas/PlanStrategy"
+            text/csv:
+              schema:
+                type: string
+        "400":
+          description: Invalid parameters or database offline
 components:
   schemas:
-    BatteryMode:
-      description: Battery mode
-      type: string
-      example: normal
-      enum:
-        - unknown
-        - normal
-        - hold
-        - charge
     ChangePassword:
       type: object
       properties:
@@ -1182,16 +1456,14 @@ components:
           vehicle:
             $ref: "#/components/schemas/VehicleName"
           odometer:
-            nullable: true
-            type: "number"
-            description: Vehicle odometer reading in kilometers
+            $ref: "#/components/schemas/Odometer"
           meterStart:
             nullable: true
-            type: "number"
+            type: number
             description: Meter reading at start of charging session
           meterStop:
             nullable: true
-            type: "number"
+            type: number
             description: Meter reading at end of charging session
           chargedEnergy:
             type: number
@@ -1246,7 +1518,7 @@ components:
       example: 25.5
       minimum: 0
     Delay:
-      description: "Duration in seconds."
+      description: Duration in seconds.
       type: integer
       example: 60
     HourMinuteTime:
@@ -1268,16 +1540,16 @@ components:
       minimum: 1
     LoadpointName:
       externalDocs:
-        url: https://docs.evcc.io/en/docs/reference/configuration/loadpoints#title
+        url: https://docs.evcc.io/en/reference/configuration/loadpoints#title
       type: string
       example: Garage
     LogArea:
       externalDocs:
-        url: https://docs.evcc.io/en/docs/reference/configuration/log#levels
+        url: https://docs.evcc.io/en/reference/configuration/log#levels
       type: string
     LogAreas:
       externalDocs:
-        url: https://docs.evcc.io/en/docs/reference/configuration/log#levels
+        url: https://docs.evcc.io/en/reference/configuration/log#levels
       type: array
       example:
         - lp-1
@@ -1287,7 +1559,7 @@ components:
         $ref: "#/components/schemas/LogArea"
     LogLevel:
       externalDocs:
-        url: https://docs.evcc.io/en/docs/reference/configuration/log#log
+        url: https://docs.evcc.io/en/reference/configuration/log#log
       type: string
       example: DEBUG
       enum:
@@ -1297,14 +1569,10 @@ components:
         - INFO
         - DEBUG
         - TRACE
-    Mode:
-      description: "Charging mode."
-      type: string
-      enum:
-        - "off"
-        - "now"
-        - "minpv"
-        - "pv"
+    Odometer:
+      nullable: true
+      type: number
+      description: Vehicle odometer reading in kilometers
     Password:
       description: Admin password
       type: string
@@ -1335,101 +1603,43 @@ components:
       minimum: 0
       example: 2500
     Precondition:
-      description: "Late charging duration in seconds."
+      description: Late charging duration in seconds.
       type: integer
       example: 3600
       minimum: 0
-    Rate:
-      type: object
-      description: A charging interval
-      properties:
-        start:
-          description: Start
-          $ref: "#/components/schemas/Timestamp"
-        end:
-          description: End
-          $ref: "#/components/schemas/Timestamp"
-        value:
-          description: Cost
-          type: number
-          minimum: 0
     Rates:
       type: array
       items:
         $ref: "#/components/schemas/Rate"
-    PlanStrategy:
-      description: Charging plan strategy configuration
-      type: object
-      properties:
-        continuous:
-          description: "Force continuous planning"
-          type: boolean
-        precondition:
-          description: "Precondition duration in seconds"
-          type: integer
-          minimum: 0
-    RepeatingPlan:
-      externalDocs:
-        url: https://docs.evcc.io/en/docs/features/plans#repeating-plans
-      type: object
-      properties:
-        active:
-          description: "Set plan active."
-          type: boolean
-        soc:
-          $ref: "#/components/schemas/Soc"
-        time:
-          $ref: "#/components/schemas/HourMinuteTime"
-        tz:
-          $ref: "#/components/schemas/IANATimeZone"
-        weekdays:
-          $ref: "#/components/schemas/Weekdays"
     Soc:
       description: SOC in %
       type: number
       example: 60
       minimum: 0
       maximum: 100
-    State:
-      description: "The actual state structure is not documented yet. Most values should be self-explanatory. Note: While the overall structure is quite stable, details may change between releases."
-      type: object
-    StaticEnergyPlan:
-      externalDocs:
-        url: https://docs.evcc.io/en/docs/features/plans#energy-amount-plan
-      type: object
-      properties:
-        energy:
-          $ref: "#/components/schemas/Energy"
-        time:
-          $ref: "#/components/schemas/Timestamp"
-    StaticSocPlan:
-      externalDocs:
-        url: https://docs.evcc.io/en/docs/features/plans#create-charging-plan
-      type: object
-      properties:
-        soc:
-          $ref: "#/components/schemas/Soc"
-        time:
-          $ref: "#/components/schemas/Timestamp"
+    Temp:
+      description: Temperature in °C
+      type: number
+      example: 50
+      minimum: 0
     Timestamp:
       description: Timestamp in RFC3339 format
       type: string
       format: date-time
-      example: 2025-07-19T12:30:00.000Z
     VehicleName:
       externalDocs:
-        url: https://docs.evcc.io/en/docs/reference/configuration/vehicles#name
+        url: https://docs.evcc.io/en/reference/configuration/vehicles#name
       type: string
       minLength: 1
       pattern: "[a-zA-Z0-9_.:-]+"
       example: vehicle_1
     VehicleTitle:
       externalDocs:
-        url: https://docs.evcc.io/en/docs/reference/configuration/vehicles#title
+        url: https://docs.evcc.io/en/reference/configuration/vehicles#title
       type: string
       example: blauer e-Golf
     Weekdays:
-      description: "The Weekdays"
+      description: The Weekdays
       type: array
       uniqueItems: true
       example:
@@ -1441,7 +1651,1823 @@ components:
         type: integer
         minimum: 0
         maximum: 6
+    BatteryMode:
+      description: Battery operation mode.
+      type: string
+      enum:
+        - unknown
+        - normal
+        - hold
+        - charge
+        - holdcharge
+    ChargeMode:
+      description: Charging mode.
+      type: string
+      enum:
+        - off
+        - now
+        - minpv
+        - pv
+    Rate:
+      description: A time slot with an associated price or emission value.
+      type: object
+      properties:
+        start:
+          description: Start of the time slot.
+          type: string
+          format: date-time
+        end:
+          description: End of the time slot.
+          type: string
+          format: date-time
+        value:
+          description: Price per kWh in the configured currency or emissions in g/kWh.
+          type: number
+      required:
+        - start
+        - end
+        - value
+    StaticEnergyPlan:
+      description: Charging plan with an energy goal.
+      type: object
+      properties:
+        energy:
+          description: Energy goal in kWh.
+          type: number
+        time:
+          description: Target time.
+          type: string
+          format: date-time
+      required:
+        - energy
+        - time
+    PlanStrategy:
+      description: Charging plan strategy.
+      type: object
+      properties:
+        continuous:
+          description: Force continuous charging without gaps.
+          type: boolean
+        precondition:
+          description: Duration of uninterrupted charging directly before the target time, in seconds.
+          type: number
+      required:
+        - continuous
+        - precondition
+    ChargerStatusReason:
+      description: Reason why the charger is waiting.
+      type: string
+      enum:
+        - unknown
+        - waitingforauthorization
+        - disconnectrequired
+    PhaseAction:
+      description: Pending phase switching action in solar mode.
+      type: string
+      enum:
+        - inactive
+        - scale1p
+        - scale3p
+    PvAction:
+      description: Pending charge start or stop action in solar mode.
+      type: string
+      enum:
+        - inactive
+        - enable
+        - disable
+    LoadpointSuggestion:
+      description: Battery optimizer suggestion for a loadpoint.
+      type: object
+      properties:
+        action:
+          description: Suggested charging action.
+          type: string
+          enum:
+            - charge
+            - stop
+        charge:
+          description: Recommended charge power in W.
+          type: number
+        discharge:
+          description: Recommended discharge power in W.
+          type: number
+        actionable:
+          description: Suggestion differs from the current operating mode.
+          type: boolean
+      required:
+        - action
+    LoadpointUi:
+      description: Display-only UI settings of a loadpoint.
+      type: object
+      properties:
+        minTemp:
+          description: Lower bound of the temperature scale for heating devices, in degrees.
+          type: number
+        maxTemp:
+          description: Upper bound of the temperature scale for heating devices, in degrees.
+          type: number
+      required:
+        - minTemp
+        - maxTemp
+    Loadpoint:
+      description: A charging location with a charger, an optional dedicated meter and an optional vehicle.
+      type: object
+      properties:
+        name:
+          description: Unique loadpoint identifier used in API routes and configuration.
+          type: string
+        batteryBoost:
+          description: Battery boost is active. When enabled, home battery power is used for fast charging.
+          type: boolean
+        chargeCurrents:
+          description: Charging current per phase in A.
+          type: array
+          items:
+            type: number
+        chargeDuration:
+          description: Duration of the current charging session in seconds.
+          type: number
+        chargePower:
+          description: Current charging power in W.
+          type: number
+        chargeRemainingDuration:
+          description: Estimated remaining charging time in seconds.
+          type: number
+        chargeRemainingEnergy:
+          description: Estimated remaining energy in kWh.
+          type: number
+        chargeTotalImport:
+          description: Total energy imported by the charge meter in kWh.
+          type: number
+        chargeVoltages:
+          description: Charging voltage per phase in V.
+          type: array
+          items:
+            type: number
+        chargedEnergy:
+          description: Energy charged in the current charging session in kWh.
+          type: number
+        chargerFeatureAutodetectDisabled:
+          description: The connected vehicle is not identified automatically by its status.
+          type: boolean
+        chargerFeatureAverage:
+          description: Values are averaged.
+          type: boolean
+        chargerFeatureCacheable:
+          description: Values are cached.
+          type: boolean
+        chargerFeatureClimaterDisabled:
+          description: The climater state of the connected vehicle is ignored for charge control.
+          type: boolean
+        chargerFeatureCoarseCurrent:
+          description: Charger only supports full ampere steps for current control.
+          type: boolean
+        chargerFeatureContinuous:
+          description: Charger is a heating device where disabled means normal operation.
+          type: boolean
+        chargerFeatureHeating:
+          description: Charger is a heating device. SoC values represent temperature in degrees.
+          type: boolean
+        chargerFeatureIntegratedDevice:
+          description: Charger is an always-connected device without vehicles and charging sessions, like a heat pump.
+          type: boolean
+        chargerFeatureOffline:
+          description: The connected vehicle only provides data while charging.
+          type: boolean
+        chargerFeatureRetryable:
+          description: Vehicle API calls are retried on failure.
+          type: boolean
+        chargerFeatureStreaming:
+          description: The connected vehicle pushes data updates instead of being polled.
+          type: boolean
+        chargerFeatureSwitchDevice:
+          description: Charger is a switchable device without current control, like a heat pump or switch socket.
+          type: boolean
+        chargerFeatureWakeUpDisabled:
+          description: No wake-up calls are sent to the connected vehicle.
+          type: boolean
+        chargerFeatureWelcomeCharge:
+          description: The connected vehicle may need a short welcome charge to start communicating.
+          type: boolean
+        chargerIcon:
+          description: Charger icon name for UI display.
+          type: string
+          nullable: true
+        chargerPhases1p3p:
+          description: Charger supports automatic switching between 1-phase and 3-phase charging.
+          type: boolean
+        chargerSinglePhase:
+          description: Charger is physically connected with a single phase.
+          type: boolean
+        chargerStatusReason:
+          description: Reason why the charger is waiting, like a pending authorization or a required disconnect.
+          nullable: true
+          allOf:
+            - $ref: "#/components/schemas/ChargerStatusReason"
+        charging:
+          description: A vehicle is connected and charging.
+          type: boolean
+        connected:
+          description: A vehicle is connected to the charger.
+          type: boolean
+        connectedDuration:
+          description: Duration since the vehicle was connected, in seconds.
+          type: number
+        disableDelay:
+          description: Delay before charging stops in solar mode, in seconds.
+          type: number
+        disableThreshold:
+          description: Grid draw power above which charging stops in solar mode, in W.
+          type: number
+        effectiveLimitSoc:
+          description: Currently applied SoC limit in %.
+          type: number
+        effectiveMaxCurrent:
+          description: Currently applied maximum charging current in A.
+          type: number
+        effectiveMinCurrent:
+          description: Currently applied minimum charging current in A.
+          type: number
+        effectiveMinSoc:
+          description: Currently applied minimum SoC in %.
+          type: number
+        effectivePlanId:
+          description: Id of the currently applied charging plan. Zero if no plan is active.
+          type: number
+        effectivePlanSoc:
+          description: SoC goal in % of the currently applied charging plan.
+          type: number
+        effectivePlanTime:
+          description: Target time of the currently applied charging plan.
+          type: string
+          nullable: true
+          format: date-time
+        effectivePlanStrategy:
+          $ref: "#/components/schemas/PlanStrategy"
+          description: Currently applied charging plan strategy.
+        effectivePriority:
+          description: Currently applied priority.
+          type: number
+        enableDelay:
+          description: Delay before charging starts in solar mode, in seconds.
+          type: number
+        enableThreshold:
+          description: Available surplus power above which charging starts in solar mode, in W.
+          type: number
+        enabled:
+          description: Charger is currently allowed to charge.
+          type: boolean
+        limitEnergy:
+          description: Session energy limit in kWh. Zero means no limit.
+          type: number
+        limitSoc:
+          description: Session SoC limit in %. Zero means no limit.
+          type: number
+        maxCurrent:
+          description: Maximum charging current in A.
+          type: number
+        minCurrent:
+          description: Minimum charging current in A.
+          type: number
+        minSoc:
+          description: Minimum SoC in %. Vehicle is fast-charged until this level is reached.
+          type: number
+        minSocNotReached:
+          description: Vehicle SoC is below the configured minimum SoC.
+          type: boolean
+        mode:
+          $ref: "#/components/schemas/ChargeMode"
+          description: Charging behavior.
+        offeredCurrent:
+          description: Current offered to the vehicle in A.
+          type: number
+        phaseAction:
+          $ref: "#/components/schemas/PhaseAction"
+          description: Pending phase switching action in solar mode.
+        phaseRemaining:
+          description: Remaining time until the pending phase switching action executes, in seconds.
+          type: number
+        phasesActive:
+          description: Number of phases expected to be used for charging.
+          type: number
+        phasesConfigured:
+          description: Configured phase mode. 0 is automatic switching, 1 and 3 select a fixed phase count.
+          type: number
+        plan:
+          description: Time slots of the current charging plan.
+          type: array
+          nullable: true
+          items:
+            $ref: "#/components/schemas/Rate"
+        planActive:
+          description: The current time slot is an active charging slot of the plan.
+          type: boolean
+        planEnergy:
+          description: Energy goal of the charging plan in kWh.
+          type: number
+        planOverrun:
+          description: Duration in seconds the charging plan is projected to miss its target time.
+          type: number
+        planStrategy:
+          $ref: "#/components/schemas/PlanStrategy"
+          description: Charging plan strategy.
+        planProjectedEnd:
+          description: Projected end of the charging plan. End of the last planned slot.
+          type: string
+          nullable: true
+          format: date-time
+        planProjectedStart:
+          description: Projected start of the charging plan. Start of the earliest planned slot.
+          type: string
+          nullable: true
+          format: date-time
+        planTime:
+          description: Target time of the charging plan.
+          type: string
+          nullable: true
+          format: date-time
+        priority:
+          description: Priority for surplus distribution. Higher number means higher priority.
+          type: number
+        pvAction:
+          $ref: "#/components/schemas/PvAction"
+          description: Pending charge start or stop action in solar mode.
+        pvRemaining:
+          description: Remaining time until the pending charge start or stop action executes, in seconds.
+          type: number
+        last24hEnergy:
+          description: Energy used in the last 24 hours in kWh.
+          type: number
+        last7dEnergy:
+          description: Energy used in the last 7 days in kWh.
+          type: number
+        sessionCo2PerKWh:
+          description: Average CO₂ emissions of the current charging session in g/kWh.
+          type: number
+          nullable: true
+        sessionEnergy:
+          description: Energy charged in the current charging session in kWh.
+          type: number
+        sessionPrice:
+          description: Total cost of the current charging session in the configured currency.
+          type: number
+          nullable: true
+        sessionPricePerKWh:
+          description: Average energy price of the current charging session per kWh in the configured currency.
+          type: number
+          nullable: true
+        sessionSolarPercentage:
+          description: Share of solar energy in the current charging session in %.
+          type: number
+        smartCostActive:
+          description: Fast charging with cheap or clean grid energy is currently active.
+          type: boolean
+        smartCostLimit:
+          description: Price or emission limit for fast charging with grid energy.
+          type: number
+          nullable: true
+        smartCostNextStart:
+          description: Start of the next fast charging period with cheap or clean grid energy.
+          type: string
+          nullable: true
+          format: date-time
+        smartFeedInPriorityActive:
+          description: Charging pause for prioritized feed-in is currently active.
+          type: boolean
+        smartFeedInPriorityLimit:
+          description: Feed-in rate limit above which charging is paused.
+          type: number
+          nullable: true
+        smartFeedInPriorityNextStart:
+          description: Start of the next charging pause for prioritized feed-in.
+          type: string
+          nullable: true
+          format: date-time
+        suggestion:
+          description: Charging suggestion from the battery optimizer.
+          nullable: true
+          allOf:
+            - $ref: "#/components/schemas/LoadpointSuggestion"
+        title:
+          description: Loadpoint title for UI display.
+          type: string
+        todayEnergy:
+          description: Energy used since midnight in kWh.
+          type: number
+        vehicleClimaterActive:
+          description: Climater of the connected vehicle is active.
+          type: boolean
+          nullable: true
+        vehicleDetectionActive:
+          description: Automatic vehicle detection is running.
+          type: boolean
+        vehicleLimitSoc:
+          description: SoC limit configured in the vehicle itself, in %.
+          type: number
+        vehicleName:
+          description: Unique name of the connected vehicle. Empty for guest vehicles.
+          type: string
+        vehicleOdometer:
+          description: Odometer reading of the connected vehicle in km.
+          type: number
+        vehicleRange:
+          description: Range of the connected vehicle in km.
+          type: number
+        vehicleSoc:
+          description: Charge level of the connected vehicle in %. Temperature in degrees for heating devices.
+          type: number
+        vehicleTitle:
+          description: Title of the connected vehicle for UI display.
+          type: string
+        vehicleWelcomeActive:
+          description: A short welcome charge is active to enable vehicle communication.
+          type: boolean
+        batteryBoostLimit:
+          description: SoC limit for battery boost in %.
+          type: number
+        ui:
+          $ref: "#/components/schemas/LoadpointUi"
+          description: Display-only UI settings.
+      required:
+        - name
+        - batteryBoost
+        - chargeDuration
+        - chargePower
+        - chargedEnergy
+        - chargerFeatureAutodetectDisabled
+        - chargerFeatureAverage
+        - chargerFeatureCacheable
+        - chargerFeatureClimaterDisabled
+        - chargerFeatureCoarseCurrent
+        - chargerFeatureContinuous
+        - chargerFeatureHeating
+        - chargerFeatureIntegratedDevice
+        - chargerFeatureOffline
+        - chargerFeatureRetryable
+        - chargerFeatureStreaming
+        - chargerFeatureSwitchDevice
+        - chargerFeatureWakeUpDisabled
+        - chargerFeatureWelcomeCharge
+        - chargerIcon
+        - chargerPhases1p3p
+        - chargerSinglePhase
+        - charging
+        - connected
+        - connectedDuration
+        - disableDelay
+        - disableThreshold
+        - effectiveLimitSoc
+        - effectiveMaxCurrent
+        - effectiveMinCurrent
+        - effectiveMinSoc
+        - effectivePlanId
+        - effectivePlanSoc
+        - effectivePlanTime
+        - effectivePlanStrategy
+        - effectivePriority
+        - enableDelay
+        - enableThreshold
+        - enabled
+        - limitEnergy
+        - limitSoc
+        - maxCurrent
+        - minCurrent
+        - minSoc
+        - minSocNotReached
+        - mode
+        - offeredCurrent
+        - phaseAction
+        - phaseRemaining
+        - phasesActive
+        - phasesConfigured
+        - plan
+        - planActive
+        - planEnergy
+        - planOverrun
+        - planStrategy
+        - planProjectedEnd
+        - planProjectedStart
+        - planTime
+        - priority
+        - pvAction
+        - pvRemaining
+        - sessionCo2PerKWh
+        - sessionEnergy
+        - sessionPrice
+        - sessionPricePerKWh
+        - sessionSolarPercentage
+        - smartCostActive
+        - smartCostLimit
+        - smartCostNextStart
+        - smartFeedInPriorityActive
+        - smartFeedInPriorityLimit
+        - smartFeedInPriorityNextStart
+        - title
+        - vehicleClimaterActive
+        - vehicleDetectionActive
+        - vehicleLimitSoc
+        - vehicleName
+        - vehicleOdometer
+        - vehicleRange
+        - vehicleSoc
+        - vehicleTitle
+        - vehicleWelcomeActive
+        - batteryBoostLimit
+    ForecastSlot:
+      description: A forecast time slot as [start, end, value] array. Start and end are unix seconds. Value unit depends on the forecast type.
+      type: array
+      items:
+        type: number
+      minItems: 3
+      maxItems: 3
+    EnergyByDay:
+      description: Expected solar production energy of a day.
+      type: object
+      properties:
+        energy:
+          description: Expected production energy in kWh.
+          type: number
+        complete:
+          description: Forecast data covers the whole day.
+          type: boolean
+      required:
+        - energy
+        - complete
+    TimeseriesEntry:
+      description: A forecast value at a point in time as [ts, val] array. ts is unix seconds, val is power in W.
+      type: array
+      items:
+        type: number
+      minItems: 2
+      maxItems: 2
+    SolarDetails:
+      description: Solar production forecast.
+      type: object
+      properties:
+        scale:
+          description: Correction factor applied to the forecast based on past production.
+          type: number
+        today:
+          $ref: "#/components/schemas/EnergyByDay"
+          description: Expected production today.
+        tomorrow:
+          $ref: "#/components/schemas/EnergyByDay"
+          description: Expected production tomorrow.
+        dayAfterTomorrow:
+          $ref: "#/components/schemas/EnergyByDay"
+          description: Expected production the day after tomorrow.
+        timeseries:
+          description: Expected production power over time.
+          type: array
+          items:
+            $ref: "#/components/schemas/TimeseriesEntry"
+    Forecast:
+      description: Price, CO₂ and solar production forecasts.
+      type: object
+      properties:
+        grid:
+          description: Grid price forecast. Price per kWh in the configured currency per time slot.
+          type: array
+          items:
+            $ref: "#/components/schemas/ForecastSlot"
+        co2:
+          description: CO₂ emission forecast in g/kWh per time slot.
+          type: array
+          items:
+            $ref: "#/components/schemas/ForecastSlot"
+        solar:
+          $ref: "#/components/schemas/SolarDetails"
+          description: Solar production forecast.
+        planner:
+          description: Charging cost forecast used by the plan optimizer per time slot.
+          type: array
+          items:
+            $ref: "#/components/schemas/ForecastSlot"
+        feedin:
+          description: Feed-in rate forecast. Rate per kWh in the configured currency per time slot.
+          type: array
+          items:
+            $ref: "#/components/schemas/ForecastSlot"
+        temperature:
+          description: Temperature forecast in °C per time slot.
+          type: array
+          items:
+            $ref: "#/components/schemas/ForecastSlot"
+    Currency:
+      description: Currency in ISO 4217 format.
+      type: string
+      enum:
+        - AUD
+        - BGN
+        - BRL
+        - CAD
+        - CHF
+        - CNY
+        - CZK
+        - EUR
+        - GBP
+        - HUF
+        - ILS
+        - JPY
+        - NZD
+        - NOK
+        - PLN
+        - RON
+        - USD
+        - DKK
+        - SEK
+        - ZAR
+        - TRY
+        - MYR
+        - THB
+    FatalError:
+      description: A fatal startup error.
+      type: object
+      properties:
+        error:
+          description: Error message.
+          type: string
+        class:
+          description: Device class the error originates from, like meter or charger.
+          type: string
+        device:
+          description: Name of the device that caused the error.
+          type: string
+      required:
+        - error
+    AuthProviders:
+      description: Status of configured vehicle authentication providers, keyed by provider name.
+      type: object
+      additionalProperties:
+        type: object
+        properties:
+          id:
+            type: string
+          authenticated:
+            type: boolean
+        required:
+          - id
+          - authenticated
+    BatterySuggestion:
+      description: Battery optimizer suggestion for a home battery.
+      type: object
+      properties:
+        action:
+          description: Suggested operation mode.
+          type: string
+          enum:
+            - normal
+            - hold
+            - charge
+            - holdcharge
+            - discharge
+        charge:
+          description: Recommended charge power in W.
+          type: number
+        discharge:
+          description: Recommended discharge power in W.
+          type: number
+        actionable:
+          description: Suggestion differs from the current operating mode.
+          type: boolean
+      required:
+        - action
+    BatteryMeter:
+      description: Measurement data of a single home battery meter.
+      type: object
+      properties:
+        name:
+          description: Unique device name of the meter.
+          type: string
+        power:
+          description: Current power in W.
+          type: number
+        title:
+          description: Meter title for UI display.
+          type: string
+        icon:
+          description: Meter icon name for UI display.
+          type: string
+        energy:
+          description: Total energy in kWh.
+          type: number
+        returnEnergy:
+          description: Total exported energy in kWh.
+          type: number
+        powers:
+          description: Power per phase in W.
+          type: array
+          items:
+            type: number
+        currents:
+          description: Current per phase in A.
+          type: array
+          items:
+            type: number
+        soc:
+          description: Charge level in %.
+          type: number
+        controllable:
+          description: Battery supports external control of its operation mode.
+          type: boolean
+        capacity:
+          description: Battery capacity in kWh. Zero when not specified.
+          type: number
+        suggestion:
+          $ref: "#/components/schemas/BatterySuggestion"
+          description: Battery optimizer suggestion.
+      required:
+        - capacity
+        - controllable
+        - power
+        - soc
+    BatteryForecastPoint:
+      description: A projected home battery charge level at a point in time.
+      type: object
+      properties:
+        soc:
+          description: Projected charge level in %.
+          type: number
+        time:
+          description: Time of the projected charge level.
+          type: string
+          format: date-time
+        limit:
+          description: The projection hits the upper or lower battery limit.
+          type: boolean
+      required:
+        - soc
+        - time
+    BatteryForecast:
+      description: Projected home battery charge levels based on the solar and price forecast.
+      type: object
+      properties:
+        highest:
+          $ref: "#/components/schemas/BatteryForecastPoint"
+          description: Projected highest charge level.
+        lowest:
+          $ref: "#/components/schemas/BatteryForecastPoint"
+          description: Projected lowest charge level.
+    Battery:
+      description: Home battery state. Aggregated across all battery meters.
+      type: object
+      properties:
+        power:
+          description: Current battery power in W. Positive means discharging, negative means charging.
+          type: number
+        capacity:
+          description: Total battery capacity in kWh.
+          type: number
+        soc:
+          description: Charge level in %. Weighted by capacity across all batteries.
+          type: number
+        energy:
+          description: Total battery energy in kWh.
+          type: number
+        devices:
+          description: Measurement data per battery meter.
+          type: array
+          items:
+            $ref: "#/components/schemas/BatteryMeter"
+        forecast:
+          $ref: "#/components/schemas/BatteryForecast"
+          description: Projected charge levels based on the solar and price forecast.
+      required:
+        - power
+        - capacity
+        - soc
+    Meter:
+      description: Measurement data of a single meter.
+      type: object
+      properties:
+        name:
+          description: Unique device name of the meter.
+          type: string
+        power:
+          description: Current power in W.
+          type: number
+        title:
+          description: Meter title for UI display.
+          type: string
+        icon:
+          description: Meter icon name for UI display.
+          type: string
+        energy:
+          description: Total energy in kWh.
+          type: number
+        returnEnergy:
+          description: Total exported energy in kWh.
+          type: number
+        powers:
+          description: Power per phase in W.
+          type: array
+          items:
+            type: number
+        currents:
+          description: Current per phase in A.
+          type: array
+          items:
+            type: number
+      required:
+        - power
+    GenericConfigStatus:
+      description: Configuration and runtime status of an integration. Structure depends on configuration.
+      type: object
+      properties:
+        config:
+          description: Static configuration.
+        status:
+          description: Runtime status.
+        yamlSource:
+          description: Source of the configuration, evcc.yaml file or database.
+          type: string
+          enum:
+            - file
+            - db
+    MqttConfig:
+      description: MQTT integration configuration.
+      type: object
+      properties:
+        broker:
+          description: Broker address.
+          type: string
+        topic:
+          description: Root topic all values are published under.
+          type: string
+        user:
+          description: Broker username.
+          type: string
+        password:
+          description: Broker password. Redacted.
+          type: string
+        clientID:
+          description: MQTT client id.
+          type: string
+        insecure:
+          description: Skip TLS certificate verification.
+          type: boolean
+        caCert:
+          description: CA certificate for TLS connections.
+          type: string
+        clientCert:
+          description: Client certificate for TLS connections.
+          type: string
+        clientKey:
+          description: Client key for TLS connections.
+          type: string
+      required:
+        - broker
+        - topic
+    InfluxConfig:
+      description: InfluxDB integration configuration.
+      type: object
+      properties:
+        url:
+          description: InfluxDB server URL.
+          type: string
+        database:
+          description: Database name (InfluxDB 1.x) or bucket (InfluxDB 2.x).
+          type: string
+        org:
+          description: Organization (InfluxDB 2.x).
+          type: string
+        token:
+          description: Access token (InfluxDB 2.x). Redacted.
+          type: string
+        user:
+          description: Username (InfluxDB 1.x).
+          type: string
+        password:
+          description: Password (InfluxDB 1.x). Redacted.
+          type: string
+        insecure:
+          description: Skip TLS certificate verification.
+          type: boolean
+      required:
+        - url
+        - database
+        - org
+    Network:
+      description: Network configuration.
+      type: object
+      properties:
+        schema:
+          description: URL schema, http or https.
+          type: string
+        host:
+          description: Hostname.
+          type: string
+        port:
+          description: HTTP port.
+          type: number
+        externalUrl:
+          description: Externally reachable URL.
+          type: string
+        internalUrl:
+          description: URL in the local network.
+          type: string
+      required:
+        - host
+        - port
+    HemsConfig:
+      description: Home energy management system configuration.
+      type: object
+      properties:
+        configured:
+          description: A home energy management system is configured.
+          type: boolean
+      required:
+        - configured
+    HemsStatus:
+      description: Current external limits imposed by the home energy management system.
+      type: object
+      properties:
+        dimmed:
+          description: Consumption is currently limited.
+          type: boolean
+        curtailed:
+          description: Allowed feed-in in %. Values below 100 mean production is curtailed.
+          type: number
+        maxConsumptionPower:
+          description: Maximum allowed consumption power in W.
+          type: number
+        maxProductionPower:
+          description: Maximum allowed production power in W.
+          type: number
+    Hems:
+      description: Home energy management system integration.
+      type: object
+      properties:
+        config:
+          $ref: "#/components/schemas/HemsConfig"
+          description: Static configuration.
+        status:
+          $ref: "#/components/schemas/HemsStatus"
+          description: Runtime status.
+        yamlSource:
+          description: Source of the configuration, evcc.yaml file or database.
+          type: string
+          enum:
+            - file
+            - db
+    ShmConfig:
+      description: SMA Home Manager configuration.
+      type: object
+      properties:
+        vendorId:
+          description: SMA vendor id.
+          type: string
+        deviceId:
+          description: SMA device id.
+          type: string
+        deviceSerial:
+          description: SMA device serial.
+          type: string
+      required:
+        - vendorId
+        - deviceId
+    SponsorStatus:
+      description: Sponsorship status.
+      type: object
+      properties:
+        name:
+          description: Name of the sponsor.
+          type: string
+        expiresAt:
+          description: Expiry time of the sponsor token.
+          type: string
+          format: date-time
+        expiresSoon:
+          description: Sponsor token expires soon.
+          type: boolean
+        token:
+          description: Sponsor token. Redacted.
+          type: string
+    Sponsor:
+      description: Sponsorship status.
+      type: object
+      properties:
+        config:
+          description: Static configuration.
+        status:
+          $ref: "#/components/schemas/SponsorStatus"
+          description: Runtime status.
+        yamlSource:
+          description: Source of the configuration, evcc.yaml file or database.
+          type: string
+          enum:
+            - file
+            - db
+    Certificate:
+      description: A TLS certificate key pair.
+      type: object
+      properties:
+        public:
+          description: Public certificate in PEM format.
+          type: string
+        private:
+          description: Private key in PEM format. Redacted.
+          type: string
+      required:
+        - public
+        - private
+    EebusConfig:
+      description: EEBus integration configuration.
+      type: object
+      properties:
+        uri:
+          description: URI the EEBus service listens on.
+          type: string
+        port:
+          description: Port the EEBus service listens on.
+          type: number
+        shipid:
+          description: SHIP id.
+          type: string
+        interfaces:
+          description: Network interfaces the EEBus service uses.
+          type: array
+          items:
+            type: string
+        certificate:
+          $ref: "#/components/schemas/Certificate"
+          description: TLS certificate.
+      required:
+        - port
+        - shipid
+    EebusStatus:
+      description: EEBus runtime status.
+      type: object
+      properties:
+        ski:
+          description: SKI (subject key identifier) used for pairing.
+          type: string
+        qr:
+          description: QR code payload for pairing.
+          type: string
+      required:
+        - ski
+    Eebus:
+      description: EEBus integration configuration and status.
+      type: object
+      properties:
+        config:
+          $ref: "#/components/schemas/EebusConfig"
+          description: Static configuration.
+        status:
+          $ref: "#/components/schemas/EebusStatus"
+          description: Runtime status.
+        yamlSource:
+          description: Source of the configuration, evcc.yaml file or database.
+          type: string
+          enum:
+            - file
+            - db
+    RemoteConfig:
+      description: Remote access configuration.
+      type: object
+      properties:
+        enabled:
+          description: Remote access is enabled.
+          type: boolean
+      required:
+        - enabled
+    RemoteStatus:
+      description: Remote access connection status.
+      type: object
+      properties:
+        connected:
+          description: Connection to the remote access server is established.
+          type: boolean
+        url:
+          description: Remote access URL.
+          type: string
+        loginBlocked:
+          description: Remote login attempts are currently blocked by the rate limiter.
+          type: boolean
+        lastSeen:
+          description: Last remote activity per client, keyed by username. RFC3339 timestamps.
+          type: object
+          additionalProperties:
+            type: string
+        error:
+          description: Last connection error.
+          type: string
+      required:
+        - connected
+        - loginBlocked
+    Remote:
+      description: Remote access configuration and connection status.
+      type: object
+      properties:
+        config:
+          $ref: "#/components/schemas/RemoteConfig"
+          description: Static configuration.
+        status:
+          $ref: "#/components/schemas/RemoteStatus"
+          description: Runtime status.
+        yamlSource:
+          description: Source of the configuration, evcc.yaml file or database.
+          type: string
+          enum:
+            - file
+            - db
+    ModbusProxyReadonly:
+      description: How the Modbus proxy handles write requests.
+      type: string
+      enum:
+        - "false"
+        - "true"
+        - deny
+    ModbusBaudrate:
+      description: Serial baud rate.
+      type: number
+      enum:
+        - 1200
+        - 9600
+        - 19200
+        - 38400
+        - 57600
+        - 115200
+    ModbusComset:
+      description: Serial communication parameters.
+      type: string
+      enum:
+        - 8N1
+        - "8E1"
+        - 8N2
+    ModbusProxySettings:
+      description: Connection settings of a Modbus device.
+      type: object
+      properties:
+        uri:
+          description: Device address for TCP connections.
+          type: string
+        rtu:
+          description: Use RTU protocol over TCP.
+          type: boolean
+        device:
+          description: Serial device path.
+          type: string
+        baudrate:
+          $ref: "#/components/schemas/ModbusBaudrate"
+          description: Serial baud rate.
+        comset:
+          $ref: "#/components/schemas/ModbusComset"
+          description: Serial communication parameters.
+    ModbusProxy:
+      description: A Modbus proxy forwarding requests to a physical device.
+      type: object
+      properties:
+        port:
+          description: Port the proxy listens on.
+          type: number
+        readonly:
+          $ref: "#/components/schemas/ModbusProxyReadonly"
+          description: How write requests are handled.
+        settings:
+          $ref: "#/components/schemas/ModbusProxySettings"
+          description: Connection settings of the physical device.
+      required:
+        - port
+        - readonly
+        - settings
+    MessagingEvent:
+      description: A configured notification message.
+      type: object
+      properties:
+        title:
+          description: Message title template.
+          type: string
+        msg:
+          description: Message body template.
+          type: string
+        disabled:
+          description: Notifications for this event are disabled.
+          type: boolean
+      required:
+        - title
+        - msg
+        - disabled
+    MessagingEvents:
+      description: Configured notification messages, keyed by event type.
+      type: object
+      properties:
+        start:
+          $ref: "#/components/schemas/MessagingEvent"
+        stop:
+          $ref: "#/components/schemas/MessagingEvent"
+        connect:
+          $ref: "#/components/schemas/MessagingEvent"
+        disconnect:
+          $ref: "#/components/schemas/MessagingEvent"
+        soc:
+          $ref: "#/components/schemas/MessagingEvent"
+        guest:
+          $ref: "#/components/schemas/MessagingEvent"
+        asleep:
+          $ref: "#/components/schemas/MessagingEvent"
+        planoverrun:
+          $ref: "#/components/schemas/MessagingEvent"
+        suggestion:
+          $ref: "#/components/schemas/MessagingEvent"
+      required:
+        - start
+        - stop
+        - connect
+        - disconnect
+        - soc
+        - guest
+        - asleep
+        - planoverrun
+        - suggestion
+      additionalProperties: false
+    Circuit:
+      description: A load management circuit limiting power and current of its assigned loadpoints.
+      type: object
+      properties:
+        title:
+          description: Circuit title for UI display.
+          type: string
+        icon:
+          description: Circuit icon name for UI display.
+          type: string
+        parent:
+          description: Name of the parent circuit.
+          type: string
+        power:
+          description: Current power in W.
+          type: number
+        current:
+          description: Current in A.
+          type: number
+        maxPower:
+          description: Maximum allowed power in W.
+          type: number
+        maxCurrent:
+          description: Maximum allowed current in A.
+          type: number
+      required:
+        - power
+    SmartCostType:
+      description: Type of the smart charging limit.
+      type: string
+      enum:
+        - co2
+        - pricedynamic
+        - priceforecast
+    DeviceColorEntry:
+      description: Color assigned to a device for consistent UI display.
+      type: object
+      properties:
+        title:
+          description: Device title the color is assigned to.
+          type: string
+        color:
+          description: Assigned color as CSS value.
+          type: string
+      required:
+        - title
+        - color
+    StaticSocPlan:
+      description: Charging plan with a SoC goal.
+      type: object
+      properties:
+        soc:
+          description: SoC goal in %.
+          type: number
+        time:
+          description: Target time.
+          type: string
+          format: date-time
+      required:
+        - soc
+        - time
+    StaticPlan:
+      description: Charging plan with a fixed target time and a SoC or energy goal.
+      anyOf:
+        - $ref: "#/components/schemas/StaticSocPlan"
+        - $ref: "#/components/schemas/StaticEnergyPlan"
+    RepeatingPlan:
+      description: A repeating charging plan.
+      type: object
+      properties:
+        weekdays:
+          description: Weekdays the plan is active. 0 is Sunday, 6 is Saturday.
+          type: array
+          items:
+            type: number
+        time:
+          description: Target time in HH:MM format.
+          type: string
+        tz:
+          description: Time zone of the target time, like Europe/Berlin.
+          type: string
+        soc:
+          description: SoC goal in %.
+          type: number
+        active:
+          description: Plan is active.
+          type: boolean
+      required:
+        - weekdays
+        - time
+        - tz
+        - soc
+        - active
+    Vehicle:
+      description: A configured vehicle.
+      type: object
+      properties:
+        name:
+          description: Unique vehicle name used in API routes and configuration.
+          type: string
+        mode:
+          description: Charge mode applied when the vehicle connects.
+          anyOf:
+            - $ref: "#/components/schemas/ChargeMode"
+            - type: string
+              enum:
+                - ""
+        minSoc:
+          description: Minimum SoC in %. Vehicle is fast-charged until this level is reached.
+          type: number
+        limitSoc:
+          description: SoC limit in %. Charging stops when reached.
+          type: number
+        plan:
+          $ref: "#/components/schemas/StaticPlan"
+          description: Charging plan with a fixed target time and SoC or energy goal.
+        repeatingPlans:
+          description: Repeating charging plans.
+          type: array
+          nullable: true
+          items:
+            $ref: "#/components/schemas/RepeatingPlan"
+        planStrategy:
+          $ref: "#/components/schemas/PlanStrategy"
+          description: Charging plan strategy.
+        title:
+          description: Vehicle title for UI display.
+          type: string
+        features:
+          description: Feature flags of the vehicle implementation.
+          type: array
+          items:
+            type: string
+        capacity:
+          description: Usable battery capacity in kWh.
+          type: number
+        icon:
+          description: Vehicle icon name for UI display.
+          type: string
+      required:
+        - repeatingPlans
+        - planStrategy
+        - title
+    StatisticsData:
+      description: Aggregated charging statistics for a time period.
+      type: object
+      properties:
+        avgCo2:
+          description: Average CO₂ emissions in g/kWh.
+          type: number
+        avgPrice:
+          description: Average energy price per kWh in the configured currency.
+          type: number
+        chargedKWh:
+          description: Total charged energy in kWh.
+          type: number
+        solarPercentage:
+          description: Share of solar energy in %.
+          type: number
+      required:
+        - avgCo2
+        - avgPrice
+        - chargedKWh
+        - solarPercentage
+    Statistics:
+      description: Charging statistics, keyed by time period.
+      type: object
+      properties:
+        30d:
+          $ref: "#/components/schemas/StatisticsData"
+        365d:
+          $ref: "#/components/schemas/StatisticsData"
+        thisYear:
+          $ref: "#/components/schemas/StatisticsData"
+        total:
+          $ref: "#/components/schemas/StatisticsData"
+      required:
+        - 30d
+        - 365d
+        - thisYear
+        - total
+    OcppConfig:
+      description: OCPP server configuration.
+      type: object
+      properties:
+        port:
+          description: Port the OCPP server listens on.
+          type: number
+      required:
+        - port
+    OcppConnectionStatus:
+      description: Connection status of an OCPP station.
+      type: string
+      enum:
+        - unknown
+        - configured
+        - connected
+    OcppStationStatus:
+      description: Connection status of an OCPP station.
+      type: object
+      properties:
+        id:
+          description: Station id.
+          type: string
+        status:
+          $ref: "#/components/schemas/OcppConnectionStatus"
+          description: Connection status.
+      required:
+        - id
+        - status
+    OcppStatus:
+      description: OCPP server status.
+      type: object
+      properties:
+        externalUrl:
+          description: Externally reachable URL of the OCPP server.
+          type: string
+        stations:
+          description: Connection status per configured station.
+          type: array
+          items:
+            $ref: "#/components/schemas/OcppStationStatus"
+      required:
+        - stations
+    Ocpp:
+      description: OCPP server configuration and status.
+      type: object
+      properties:
+        config:
+          $ref: "#/components/schemas/OcppConfig"
+          description: OCPP server configuration.
+        status:
+          $ref: "#/components/schemas/OcppStatus"
+          description: OCPP server status.
+      required:
+        - config
+        - status
+    OcppForwarderRule:
+      description: A rule forwarding an OCPP station to an upstream backend.
+      type: object
+      properties:
+        stationId:
+          description: Station id to forward.
+          type: string
+        upstreamUrl:
+          description: URL of the upstream OCPP backend.
+          type: string
+        password:
+          description: Password for upstream authentication. Redacted.
+          type: string
+        upstreamStationId:
+          description: Station id used towards the upstream backend.
+          type: string
+        username:
+          description: Username for upstream authentication.
+          type: string
+        insecure:
+          description: Skip TLS certificate verification.
+          type: boolean
+        caCert:
+          description: CA certificate for TLS connections.
+          type: string
+        readOnly:
+          description: Only forward read operations to the station.
+          type: boolean
+      required:
+        - stationId
+        - upstreamUrl
+    OcppForwarderSession:
+      description: Connection status of an OCPP forwarder rule.
+      type: object
+      properties:
+        chargerId:
+          description: Charger id.
+          type: string
+        upstreamUrl:
+          description: URL of the upstream OCPP backend.
+          type: string
+        upstreamConnected:
+          description: Connection to the upstream backend is established.
+          type: boolean
+        error:
+          description: Last connection error.
+          type: string
+      required:
+        - chargerId
+        - upstreamUrl
+        - upstreamConnected
+    OcppForwarder:
+      description: OCPP forwarder rules and upstream connection status.
+      type: object
+      properties:
+        config:
+          description: Static configuration.
+          type: array
+          items:
+            $ref: "#/components/schemas/OcppForwarderRule"
+        status:
+          description: Runtime status.
+          type: array
+          items:
+            $ref: "#/components/schemas/OcppForwarderSession"
+        yamlSource:
+          description: Source of the configuration, evcc.yaml file or database.
+          type: string
+          enum:
+            - file
+            - db
+    State:
+      description: Complete system state as returned by /api/state and pushed via websocket and MQTT. This structure mirrors the internal UI state and carries no compatibility promise. Fields may change or disappear between releases.
+      type: object
+      properties:
+        telemetry:
+          description: Telemetry is enabled.
+          type: boolean
+        experimental:
+          description: Experimental UI features are enabled.
+          type: boolean
+        setupRequired:
+          description: Initial setup is required.
+          type: boolean
+        startupCompleted:
+          description: Startup has completed.
+          type: boolean
+        apiReady:
+          description: HTTP API is ready to accept requests.
+          type: boolean
+        loadpoints:
+          description: Charging locations. One entry per configured loadpoint.
+          type: array
+          items:
+            $ref: "#/components/schemas/Loadpoint"
+        forecast:
+          $ref: "#/components/schemas/Forecast"
+          description: Price, CO₂ and solar production forecasts.
+        currency:
+          $ref: "#/components/schemas/Currency"
+          description: Configured currency for all monetary values.
+        fatal:
+          description: Fatal startup errors.
+          type: array
+          items:
+            $ref: "#/components/schemas/FatalError"
+        authProviders:
+          $ref: "#/components/schemas/AuthProviders"
+          description: Status of configured vehicle authentication providers, keyed by provider name.
+        version:
+          description: Running evcc version.
+          type: string
+        availableVersion:
+          description: Latest available evcc version.
+          type: string
+        system:
+          description: Operating system and architecture.
+          type: string
+          example: linux/amd64
+        timezone:
+          description: Server time zone abbreviation and UTC offset.
+          type: string
+          example: CEST +02:00
+        battery:
+          $ref: "#/components/schemas/Battery"
+          description: Aggregated home battery state.
+        batteryMode:
+          $ref: "#/components/schemas/BatteryMode"
+          description: Current operation mode of the home battery.
+        grid:
+          $ref: "#/components/schemas/Meter"
+          description: Grid meter data.
+        gridConfigured:
+          description: A grid meter is configured.
+          type: boolean
+        pv:
+          description: Solar generation meters. One entry per configured pv meter.
+          type: array
+          items:
+            $ref: "#/components/schemas/Meter"
+        pvPower:
+          description: Total solar generation power in W. Sum of all pv meters.
+          type: number
+        pvEnergy:
+          description: Total solar generation energy in kWh.
+          type: number
+        aux:
+          description: Auxiliary consumption meters. Their power is treated as available for charging.
+          type: array
+          items:
+            $ref: "#/components/schemas/Meter"
+        auxPower:
+          description: Total power of all auxiliary meters in W.
+          type: number
+        ext:
+          description: Additional meters for monitoring purposes.
+          type: array
+          items:
+            $ref: "#/components/schemas/Meter"
+        consumers:
+          description: Consumption meters of individual devices for monitoring purposes.
+          type: array
+          items:
+            $ref: "#/components/schemas/Meter"
+        homePower:
+          description: Home consumption power in W.
+          type: number
+        residualPower:
+          description: Configured grid operating point in W. Positive values maintain grid import.
+          type: number
+        greenShareHome:
+          description: Share of green energy in home consumption, between 0 and 1.
+          type: number
+        greenShareLoadpoints:
+          description: Share of green energy used for charging, between 0 and 1.
+          type: number
+        tariffs:
+          $ref: "#/components/schemas/GenericConfigStatus"
+          description: Configured tariffs. Structure depends on configuration.
+        tariffGrid:
+          description: Current grid energy price per kWh in the configured currency.
+          type: number
+        tariffFeedIn:
+          description: Current feed-in rate per kWh in the configured currency.
+          type: number
+        tariffCo2:
+          description: Current grid CO₂ emissions in g/kWh.
+          type: number
+        tariffSolar:
+          description: Current cost of solar generation per kWh in the configured currency.
+          type: number
+        tariffPriceHome:
+          description: Current energy price of home consumption per kWh, taking the green energy share into account.
+          type: number
+        tariffPriceLoadpoints:
+          description: Current energy price of charging per kWh, taking the green energy share into account.
+          type: number
+        tariffCo2Home:
+          description: Current CO₂ emissions of home consumption in g/kWh, taking the green energy share into account.
+          type: number
+        tariffCo2Loadpoints:
+          description: Current CO₂ emissions of charging in g/kWh, taking the green energy share into account.
+          type: number
+        tariffTemperature:
+          description: Current outside temperature in °C.
+          type: number
+        mqtt:
+          $ref: "#/components/schemas/MqttConfig"
+          description: MQTT integration configuration.
+        influx:
+          $ref: "#/components/schemas/InfluxConfig"
+          description: InfluxDB integration configuration.
+        network:
+          $ref: "#/components/schemas/Network"
+          description: Network configuration.
+        hems:
+          $ref: "#/components/schemas/Hems"
+          description: Home energy management system integration.
+        shm:
+          $ref: "#/components/schemas/ShmConfig"
+          description: SMA Home Manager configuration.
+        sponsor:
+          $ref: "#/components/schemas/Sponsor"
+          description: Sponsorship status.
+        eebus:
+          $ref: "#/components/schemas/Eebus"
+          description: EEBus integration configuration and status.
+        remote:
+          $ref: "#/components/schemas/Remote"
+          description: Remote access configuration and connection status.
+        modbusproxy:
+          description: Modbus proxy configuration.
+          type: array
+          nullable: true
+          items:
+            $ref: "#/components/schemas/ModbusProxy"
+        messaging:
+          $ref: "#/components/schemas/GenericConfigStatus"
+          description: Messaging services configuration. Structure depends on configuration.
+        messagingEvents:
+          description: Configured notification messages per event type.
+          nullable: true
+          allOf:
+            - $ref: "#/components/schemas/MessagingEvents"
+        interval:
+          description: Update interval of the control loop in seconds.
+          type: number
+        circuits:
+          description: Load management circuits, keyed by circuit name.
+          type: object
+          additionalProperties:
+            $ref: "#/components/schemas/Circuit"
+        bufferSoc:
+          description: Battery buffer SoC in %. Energy above this level may be used for charging in solar mode.
+          type: number
+        prioritySoc:
+          description: Battery priority SoC in %. Home battery is charged first while below this level.
+          type: number
+        bufferStartSoc:
+          description: Battery buffer start SoC in %. Solar charging starts automatically above this level.
+          type: number
+        batteryDischargeControl:
+          description: Home battery discharge is prevented during fast charging and planned charging.
+          type: boolean
+        batteryGridDischarge:
+          description: Home battery is allowed to discharge to the grid (experimental).
+          type: boolean
+        solarAdjusted:
+          description: Solar forecast is adjusted to real production data (experimental).
+          type: boolean
+        batteryGridChargeLimit:
+          description: Price or emission limit for charging the home battery from grid.
+          type: number
+          nullable: true
+        batteryGridChargeActive:
+          description: Home battery is currently charged from grid.
+          type: boolean
+        smartCostAvailable:
+          description: A dynamic grid price or CO₂ forecast is configured.
+          type: boolean
+        smartCostType:
+          $ref: "#/components/schemas/SmartCostType"
+          description: Type of the smart charging limit, price based or emission based.
+        smartFeedInPriorityAvailable:
+          description: A feed-in tariff with forecast is configured.
+          type: boolean
+        historyUpdated:
+          description: Time of the last energy history update.
+          type: string
+          format: date-time
+        siteTitle:
+          description: Configured site title.
+          type: string
+        deviceColors:
+          description: Colors assigned to devices for consistent UI display.
+          type: array
+          items:
+            $ref: "#/components/schemas/DeviceColorEntry"
+        vehicles:
+          description: Configured vehicles, keyed by vehicle name.
+          type: object
+          additionalProperties:
+            $ref: "#/components/schemas/Vehicle"
+        statistics:
+          $ref: "#/components/schemas/Statistics"
+          description: Charging statistics over different time periods.
+        authDisabled:
+          description: Authentication is disabled.
+          type: boolean
+        config:
+          description: Path of the evcc configuration file.
+          type: string
+        database:
+          description: Path of the evcc database.
+          type: string
+        ocpp:
+          $ref: "#/components/schemas/Ocpp"
+          description: OCPP server configuration and connected stations.
+        ocppforwarder:
+          $ref: "#/components/schemas/OcppForwarder"
+          description: OCPP forwarder rules and upstream connection status.
+        optimizer:
+          description: Battery optimizer is enabled.
+          type: boolean
+        optimizerChargingStrategy:
+          description: Selected battery optimizer charging strategy.
+          type: string
+        optimizerChargingStrategies:
+          description: Available battery optimizer charging strategies.
+          type: array
+          items:
+            type: string
+        mcp:
+          description: Built-in MCP server is enabled.
+          type: boolean
+        demoMode:
+          description: Instance runs in demo mode.
+          type: boolean
+      required:
+        - loadpoints
+        - forecast
+        - vehicles
   parameters:
+    adminPassword:
+      name: X-Admin-Password
+      in: header
+      description: Admin password (required for session auth, not needed for API key)
+      schema:
+        $ref: "#/components/schemas/Password"
     id:
       name: id
       description: Loadpoint index starting at 1
@@ -1458,7 +3484,7 @@ components:
         $ref: "#/components/schemas/Phases"
     weekdays:
       name: weekdays
-      description: "The Weekdays"
+      description: The Weekdays
       in: path
       required: true
       schema:
@@ -1478,7 +3504,7 @@ components:
         $ref: "#/components/schemas/IANATimeZone"
     logAreas:
       name: areas
-      description: "Comma-separated list of log areas"
+      description: Comma-separated list of log areas
       in: query
       explode: true
       schema:
@@ -1492,7 +3518,7 @@ components:
         $ref: "#/components/schemas/LogLevel"
     delay:
       name: delay
-      description: "Duration in seconds."
+      description: Duration in seconds.
       in: path
       required: true
       schema:
@@ -1502,7 +3528,7 @@ components:
       in: path
       required: true
       schema:
-        $ref: "#/components/schemas/Mode"
+        $ref: "#/components/schemas/ChargeMode"
     soc:
       name: soc
       description: SOC in %
@@ -1510,6 +3536,13 @@ components:
       required: true
       schema:
         $ref: "#/components/schemas/Soc"
+    temp:
+      name: temp
+      description: Temperature in °C
+      in: path
+      required: true
+      schema:
+        $ref: "#/components/schemas/Temp"
     timestamp:
       name: timestamp
       description: Timestamp in RFC3339 format
@@ -1568,7 +3601,7 @@ components:
         type: number
     enable:
       name: enable
-      description: "Charging mode."
+      description: Charging mode.
       in: path
       required: true
       schema:
@@ -1584,28 +3617,19 @@ components:
       content:
         application/json:
           schema:
-            type: object
-            properties:
-              result:
-                type: integer
+            type: integer
     NumberResult:
       description: Success - Number result
       content:
         application/json:
           schema:
-            type: object
-            properties:
-              result:
-                type: number
+            type: number
     IntegerResult:
       description: Success - Integer result
       content:
         application/json:
           schema:
-            type: object
-            properties:
-              result:
-                type: integer
+            type: integer
     SocResult:
       description: Success - Soc result
       content:
@@ -1613,40 +3637,28 @@ components:
           schema:
             type: object
             properties:
-              result:
-                type: object
-                properties:
-                  soc:
-                    $ref: "#/components/schemas/Soc"
+              soc:
+                $ref: "#/components/schemas/Soc"
     PlanRatesResult:
       description: Success - PlanRates result
       content:
         application/json:
           schema:
-            type: object
-            properties:
-              result:
-                $ref: "#/components/schemas/PlanRates"
+            $ref: "#/components/schemas/PlanRates"
     BooleanResult:
       description: Success - Boolean result
       content:
         application/json:
           schema:
-            type: object
-            properties:
-              result:
-                type: boolean
+            type: boolean
     NullResult:
       description: Success - Null result
       content:
         application/json:
           schema:
+            description: Value is always null
+            nullable: true
             type: object
-            properties:
-              result:
-                description: Value is always null
-                nullable: true
-                type: "object"
     BlankResponse:
       description: Success - Blank response
     SuccessResult:
@@ -1654,11 +3666,8 @@ components:
       content:
         application/json:
           schema:
-            type: object
-            properties:
-              result:
-                type: string
-                example: "OK"
+            type: string
+            example: OK
     EmptyResult:
       description: Success - Empty result
       content:
@@ -1678,15 +3687,18 @@ components:
       content:
         application/json:
           schema:
-            type: object
-            properties:
-              result:
-                type: integer
-                description: "Battery mode. 0: unknown, 1: normal, 2: hold, 3: charge"
-                minimum: 0
-                maximum: 3
+            type: integer
+            description: "Battery mode. 0: unknown, 1: normal, 2: hold, 3: charge, 4: holdcharge"
+            minimum: 0
+            maximum: 4
   securitySchemes:
     cookieAuth:
       type: apiKey
       in: cookie
       name: auth
+    bearerAuth:
+      type: http
+      scheme: bearer
+      description: |
+        Long-lived API key (prefixed `evcc_`, managed via /auth/apikey).
+        Grants access to /api/db/* without requiring the X-Admin-Password header.

--- a/src/content/docs/de/integrations/mqtt-api.md
+++ b/src/content/docs/de/integrations/mqtt-api.md
@@ -4,8 +4,8 @@ sidebar:
   order: 2
 ---
 
-Alle Daten des [REST API](/integrations/rest-api) Endpunkts `/api/state` werden auch per MQTT veröffentlicht.
-Listen werden dabei in einzelne Sub-Topics aufgelöst (Index beginnt bei `1`).
+Der [API State](/de/reference/state) wird auch per MQTT veröffentlicht.
+Jedes Feld wird zu einem eigenen Topic, verschachtelte Objekte und Listen werden in einzelne Sub-Topics aufgelöst (Index beginnt bei `1`).
 
 ## Lesbare Topics
 

--- a/src/content/docs/en/integrations/mqtt-api.md
+++ b/src/content/docs/en/integrations/mqtt-api.md
@@ -4,8 +4,8 @@ sidebar:
   order: 2
 ---
 
-All data from the [REST API](/integrations/rest-api) endpoint `/api/state` is also published via MQTT.
-Lists are converted into individual sub-topics (index starts at `1`).
+The [API State](/en/reference/state) is also published via MQTT.
+Every field becomes its own topic, nested objects and lists are converted into individual sub-topics (index starts at `1`).
 
 ## Read-Only Topics
 

--- a/src/pages/[lang]/reference/state.astro
+++ b/src/pages/[lang]/reference/state.astro
@@ -1,0 +1,374 @@
+---
+import fs from "node:fs";
+import { parse } from "yaml";
+import StarlightPage from "@astrojs/starlight/components/StarlightPage.astro";
+
+export async function getStaticPaths() {
+  return [{ params: { lang: "en" } }, { params: { lang: "de" } }];
+}
+
+const lang = Astro.params.lang as "de" | "en";
+
+// The state schemas are part of the bundled OpenAPI spec (synced from the main
+// evcc repository, generated there from assets/js/types/evcc.ts).
+type Raw = Record<string, any>;
+const doc = parse(fs.readFileSync("public/openapi.yaml", "utf8"));
+const allSchemas: Record<string, Raw> = doc.components.schemas;
+
+// Only show schemas reachable from State — the rest belong to other endpoints.
+const collectRefs = (node: any, refs: Set<string>) => {
+  if (Array.isArray(node)) {
+    node.forEach((entry) => collectRefs(entry, refs));
+  } else if (node && typeof node === "object") {
+    if (typeof node.$ref === "string") refs.add(node.$ref.split("/").pop()!);
+    Object.values(node).forEach((value) => collectRefs(value, refs));
+  }
+};
+const reachable = new Set(["State"]);
+let queue = ["State"];
+while (queue.length) {
+  const refs = new Set<string>();
+  collectRefs(allSchemas[queue.shift()!], refs);
+  queue = queue.concat([...refs].filter((name) => !reachable.has(name) && allSchemas[name]));
+  refs.forEach((name) => allSchemas[name] && reachable.add(name));
+}
+
+const anchor = (name: string) => name.toLowerCase();
+
+interface TypeToken {
+  text: string;
+  href?: string;
+}
+
+const refToken = (ref: string): TypeToken => {
+  const name = ref.split("/").pop()!;
+  return { text: name, href: `#${anchor(name)}` };
+};
+
+const typeTokens = (schema: Raw): TypeToken[] => {
+  if (schema.$ref) return [refToken(schema.$ref)];
+  // nullable refs are wrapped in allOf with a single $ref
+  if (schema.allOf?.length === 1 && schema.allOf[0].$ref) return [refToken(schema.allOf[0].$ref)];
+  const variants: Raw[] | undefined = schema.anyOf ?? schema.oneOf;
+  if (variants) {
+    return variants.flatMap((variant, i): TypeToken[] => {
+      const tokens = variant.enum
+        ? [{ text: variant.enum.map((v: any) => JSON.stringify(v)).join(" | ") }]
+        : typeTokens(variant);
+      return i > 0 ? [{ text: " | " }, ...tokens] : tokens;
+    });
+  }
+  if (schema.type === "array") {
+    return [...(schema.items ? typeTokens(schema.items) : [{ text: "any" }]), { text: "[]" }];
+  }
+  if (schema.type === "object" && schema.additionalProperties) {
+    if (schema.additionalProperties === true) return [{ text: "object" }];
+    return [
+      { text: "Record<string, " },
+      ...typeTokens(schema.additionalProperties),
+      { text: ">" },
+    ];
+  }
+  if (schema.type === "string" && schema.format) return [{ text: `string (${schema.format})` }];
+  return [{ text: String(schema.type ?? "object") }];
+};
+
+// reverse index: type name → list of "Schema.property" usage sites
+const usedBy = new Map<string, { label: string; href: string }[]>();
+for (const name of reachable) {
+  const schema = allSchemas[name];
+  for (const [propName, prop] of Object.entries(schema.properties ?? {})) {
+    const refs = new Set<string>();
+    collectRefs(prop, refs);
+    for (const ref of refs) {
+      if (!usedBy.has(ref)) usedBy.set(ref, []);
+      usedBy.get(ref)!.push({
+        label: `${name}.${propName}`,
+        href: `#${anchor(name)}-${propName.toLowerCase()}`,
+      });
+    }
+  }
+  // union schemas reference types without properties
+  if (schema.anyOf || schema.oneOf) {
+    const refs = new Set<string>();
+    collectRefs(schema.anyOf ?? schema.oneOf, refs);
+    for (const ref of refs) {
+      if (!usedBy.has(ref)) usedBy.set(ref, []);
+      usedBy.get(ref)!.push({ label: name, href: `#${anchor(name)}` });
+    }
+  }
+}
+usedBy.forEach((sites) => sites.sort((a, b) => a.label.localeCompare(b.label)));
+
+// State first, everything else alphabetical
+const sections = [...reachable]
+  .sort((a, b) => (a === "State" ? -1 : b === "State" ? 1 : a.localeCompare(b)))
+  .map((name) => {
+    const schema = allSchemas[name];
+    const required: string[] = schema.required ?? [];
+    return {
+      name,
+      anchor: anchor(name),
+      description: schema.description as string | undefined,
+      enumValues: schema.enum as string[] | undefined,
+      unionTypes: schema.anyOf || schema.oneOf ? typeTokens(schema) : undefined,
+      usedBy: usedBy.get(name) ?? [],
+      properties: Object.entries(schema.properties ?? {})
+        .sort(([a], [b]) => a.localeCompare(b))
+        .map(([propName, prop]) => {
+        const p = prop as Raw;
+        return {
+          name: propName,
+          anchor: `${anchor(name)}-${propName.toLowerCase()}`,
+          type: typeTokens(p),
+          required: required.includes(propName),
+          nullable: p.nullable === true,
+          description: p.description as string | undefined,
+          enumValues: p.enum as string[] | undefined,
+        };
+      }),
+    };
+  });
+
+const title = "API State";
+const description =
+  lang === "de"
+    ? "Datenstruktur von /api/state, WebSocket und MQTT."
+    : "Data structure of /api/state, websocket and MQTT.";
+
+const demoUrl = "https://demo.evcc.io/api/state";
+const jqExampleUrl = "https://demo.evcc.io/api/state?jq=.loadpoints%5B2%5D.chargePower";
+
+const typesLabel = lang === "de" ? "Typen" : "Types";
+
+const frontmatter = { title, description, template: "doc" as const };
+// root State properties render directly below the intro; referenced types are h3s under "Types"
+const headings = [
+  { depth: 2, slug: "top-level", text: "Top Level" },
+  { depth: 2, slug: "types", text: typesLabel },
+  ...sections.slice(1).map((section) => ({
+    depth: 3,
+    slug: section.anchor,
+    text: section.name,
+  })),
+];
+---
+
+<StarlightPage frontmatter={frontmatter} headings={headings}>
+  {
+    lang === "de" ? (
+      <>
+        <p>
+          Der API State ist die Datenstruktur hinter der UI. Er ist über drei Schnittstellen
+          verfügbar. Es gibt keine Kompatibilitätsgarantie, Felder können sich zwischen Releases
+          ändern.
+        </p>
+        <ul>
+          <li>
+            <a href="/integrations/rest-api">REST-API</a>: <code>GET /api/state</code> liefert den
+            kompletten Zustand als ein JSON-Dokument, eingepackt in ein <code>result</code>-Objekt.
+            Mit dem Query-Parameter <code>jq</code> lässt sich die Antwort per{" "}
+            <a href="https://jqlang.org/">jq</a>-Ausdruck filtern.
+            <ul>
+              <li>
+                Live-Beispiel:{" "}
+                <a href={demoUrl}>
+                  <code>{demoUrl}</code>
+                </a>
+              </li>
+              <li>
+                Gefiltert auf ein einzelnes Feld:{" "}
+                <a href={jqExampleUrl}>
+                  <code>{demoUrl}?jq=.loadpoints[2].chargePower</code>
+                </a>
+              </li>
+            </ul>
+          </li>
+          <li>
+            <a href="/de/integrations/mqtt-api">MQTT</a>: jedes Feld wird als eigenes Topic
+            veröffentlicht. Felder der Site liegen unter <code>evcc/site/&lt;feld&gt;</code>,
+            Ladepunkt-Felder unter <code>evcc/loadpoints/&lt;n&gt;/&lt;feld&gt;</code> mit Index ab
+            1. Verschachtelte Objekte und Listen werden in Sub-Topics aufgelöst, z.&nbsp;B.{" "}
+            <code>evcc/site/pv/1/power</code>. Werte werden als einfache Strings veröffentlicht,
+            Zeitstempel als Unix-Sekunden, Zeitdauern in Sekunden.
+          </li>
+          <li>
+            <strong>WebSocket</strong>: beim Verbinden erhält der Client den kompletten Zustand als
+            ein JSON-Objekt. Ladepunkt-Felder verwenden Schlüssel mit Punktnotation wie{" "}
+            <code>loadpoints.0.chargePower</code>. Danach werden nur noch inkrementelle Updates
+            gesendet: kleine JSON-Objekte mit den geänderten Feldern, die der Client in seine Kopie
+            des Zustands übernimmt.
+          </li>
+        </ul>
+      </>
+    ) : (
+      <>
+        <p>
+          The API State is the data structure behind the UI. It is available over three interfaces.
+          There is no compatibility promise, fields may change between releases.
+        </p>
+        <ul>
+          <li>
+            <a href="/integrations/rest-api">REST API</a>: <code>GET /api/state</code> returns the
+            full state as a single JSON document, wrapped in a <code>result</code> object. The{" "}
+            <code>jq</code> query parameter filters the response with a{" "}
+            <a href="https://jqlang.org/">jq</a> expression.
+            <ul>
+              <li>
+                Live example:{" "}
+                <a href={demoUrl}>
+                  <code>{demoUrl}</code>
+                </a>
+              </li>
+              <li>
+                Filtered to a single field:{" "}
+                <a href={jqExampleUrl}>
+                  <code>{demoUrl}?jq=.loadpoints[2].chargePower</code>
+                </a>
+              </li>
+            </ul>
+          </li>
+          <li>
+            <a href="/en/integrations/mqtt-api">MQTT</a>: every field is published as its own
+            topic. Site-level fields appear under <code>evcc/site/&lt;field&gt;</code>, loadpoint
+            fields under <code>evcc/loadpoints/&lt;n&gt;/&lt;field&gt;</code> with 1-based indexes.
+            Nested objects and arrays flatten into subtopics, e.g.{" "}
+            <code>evcc/site/pv/1/power</code>. Values are published as plain strings, timestamps as
+            unix seconds, durations in seconds.
+          </li>
+          <li>
+            <strong>Websocket</strong>: on connect, the client receives the full state as one JSON
+            object. Loadpoint
+            fields use dotted keys like <code>loadpoints.0.chargePower</code>. After that, only
+            incremental updates are sent: small JSON objects containing the changed fields, which
+            the client merges into its copy of the state.
+          </li>
+        </ul>
+      </>
+    )
+  }
+  {
+    sections.map((section, i) => (
+      <>
+        {i === 0 && <h2 id="top-level">Top Level</h2>}
+        {i === 1 && <h2 id="types">{typesLabel}</h2>}
+        {i > 0 && <h3 id={section.anchor}>{section.name}</h3>}
+        {i > 0 && section.description && <p>{section.description}</p>}
+        {i > 0 && section.usedBy.length > 0 && (
+          <p class="sr-used-by">
+            {"Used by: "}
+            {section.usedBy.map((site, j) => (
+              <>
+                {j > 0 && ", "}
+                <a href={site.href}>
+                  <code>{site.label}</code>
+                </a>
+              </>
+            ))}
+          </p>
+        )}
+        {section.enumValues && (
+          <p class="sr-enum">
+            {section.enumValues.map((value) => (
+              <code>{JSON.stringify(value)}</code>
+            ))}
+          </p>
+        )}
+        {section.unionTypes && (
+          <p>
+            {"One of: "}
+            <span class="sr-type">
+              {section.unionTypes.map((t) => (t.href ? <a href={t.href}>{t.text}</a> : t.text))}
+            </span>
+          </p>
+        )}
+        {section.properties.length > 0 && (
+          <div class="sr-props">
+            {section.properties.map((prop) => (
+              <div class="sr-prop" id={prop.anchor}>
+                <div class="sr-prop-head">
+                  <a class="sr-prop-name" href={`#${prop.anchor}`}>
+                    {prop.name}
+                  </a>
+                  <span class="sr-type">
+                    {prop.type.map((t) => (t.href ? <a href={t.href}>{t.text}</a> : t.text))}
+                  </span>
+                  {prop.required && <span class="sr-tag sr-required">required</span>}
+                  {prop.nullable && <span class="sr-tag">nullable</span>}
+                </div>
+                {prop.description && <p class="sr-prop-desc">{prop.description}</p>}
+                {prop.enumValues && (
+                  <p class="sr-prop-desc sr-enum">
+                    {prop.enumValues.map((value) => (
+                      <code>{JSON.stringify(value)}</code>
+                    ))}
+                  </p>
+                )}
+              </div>
+            ))}
+          </div>
+        )}
+      </>
+    ))
+  }
+</StarlightPage>
+
+<style>
+  .sr-props {
+    margin-top: 1rem;
+  }
+  .sr-prop {
+    border-top: 1px solid var(--sl-color-hairline);
+    padding: 0.6rem 0;
+    scroll-margin-top: calc(var(--sl-nav-height) + 1rem);
+  }
+  .sr-prop-head {
+    display: flex;
+    align-items: baseline;
+    gap: 0.6rem;
+    flex-wrap: wrap;
+  }
+  .sr-prop-name {
+    font-family: var(--__sl-font-mono);
+    font-weight: 600;
+    color: var(--sl-color-white);
+    text-decoration: none;
+  }
+  .sr-prop-name:hover::after {
+    content: " #";
+    color: var(--sl-color-gray-3);
+  }
+  .sr-type {
+    font-family: var(--__sl-font-mono);
+    font-size: var(--sl-text-sm);
+    color: var(--sl-color-gray-3);
+  }
+  .sr-type a {
+    color: var(--sl-color-text-accent);
+  }
+  .sr-tag {
+    font-size: var(--sl-text-xs);
+    border: 1px solid var(--sl-color-gray-5);
+    border-radius: 0.5rem;
+    padding: 0 0.4rem;
+    color: var(--sl-color-gray-3);
+  }
+  .sr-required {
+    color: var(--sl-color-orange);
+    border-color: var(--sl-color-orange-low);
+  }
+  .sr-prop-desc {
+    margin: 0.2rem 0 0;
+    font-size: var(--sl-text-sm);
+  }
+  .sr-used-by {
+    font-size: var(--sl-text-sm);
+    color: var(--sl-color-gray-3);
+  }
+  .sr-used-by code {
+    font-size: var(--sl-text-xs);
+  }
+  .sr-enum code {
+    margin-inline-end: 0.4rem;
+  }
+</style>


### PR DESCRIPTION
Adds a dedicated reference page for the `/api/state` data structure at `/en/reference/state` (and `/de/…`), generated at build time from the bundled OpenAPI spec.

Builds on the generated state schema introduced in evcc-io/evcc#32431.
Replaces #746
Pairs with https://github.com/evcc-io/evcc/pull/32568

- 📄 Long flat page: root fields under **Top Level**, referenced schemas as sections under **Types**, everything alphabetical
- 🔗 Anchor per type and per field, `$ref` types link to their section, reverse **Used by** links per type
- 📡 Intro explains the three transports: REST (with demo and jq examples), MQTT topic mapping, websocket incremental updates
- 🔍 Fully static, indexed by Starlight search
- 📦 `public/openapi.yaml` refreshed from the main repo (nightly state; will be replaced by the next release sync)
- ↪️ MQTT API pages now link to the new page


<img width="1386" height="1449" alt="Bildschirmfoto 2026-08-06 um 12 52 42" src="https://github.com/user-attachments/assets/ddeb3b9a-82c3-4813-8396-91fe79238e54" />

<img width="1386" height="1449" alt="Bildschirmfoto 2026-08-06 um 12 52 22" src="https://github.com/user-attachments/assets/29c7eb51-8132-4467-8ae8-1bbdb44065d4" />

<img width="1386" height="1449" alt="Bildschirmfoto 2026-08-06 um 12 52 30" src="https://github.com/user-attachments/assets/17fc3a55-8a6d-45c4-b51a-251f13a9758d" />
