### PR TITLE
Document macOS Application Firewall blocking OCPP after brew upgrade

### DIFF
--- a/src/content/docs/de/installation/macos.mdx
+++ b/src/content/docs/de/installation/macos.mdx
@@ -69,6 +69,20 @@ Um auf eine neue Version von evcc zu aktualisieren, führe folgende Schritte dur
   brew upgrade evcc
   ```
 
+:::caution[OCPP und die Firewall]
+Bei jedem Upgrade wird eine neue Programmdatei installiert, die die macOS-Firewall als neue Anwendung behandelt.
+Ist die Firewall aktiv, werden eingehende Verbindungen blockiert, bis die neue Version freigegeben wurde.
+OCPP-Wallboxen können sich dann nicht mehr verbinden, während alles andere weiter funktioniert.
+Auf einem Mac ohne Bildschirm bleibt der Freigabedialog unsichtbar.
+Gib die Programmdatei deshalb nach jedem Upgrade über das Terminal frei:
+
+```sh
+sudo /usr/libexec/ApplicationFirewall/socketfilterfw --add "$(brew --prefix)/opt/evcc/bin/evcc"
+brew services restart evcc
+```
+
+:::
+
 ## Weitere Befehle
 
 - Prüfe den Status des evcc-Servers:

--- a/src/content/docs/en/installation/macos.mdx
+++ b/src/content/docs/en/installation/macos.mdx
@@ -69,6 +69,20 @@ To upgrade to a new version of evcc, perform the following steps:
   brew upgrade evcc
   ```
 
+:::caution[OCPP and the Application Firewall]
+Each upgrade installs a new binary, which the macOS Application Firewall treats as a new application.
+If the firewall is enabled, incoming connections are blocked until the new version is approved.
+OCPP chargers can no longer connect, while everything else keeps working.
+On a headless Mac the approval dialog is never seen.
+Approve the binary from the command line after each upgrade:
+
+```sh
+sudo /usr/libexec/ApplicationFirewall/socketfilterfw --add "$(brew --prefix)/opt/evcc/bin/evcc"
+brew services restart evcc
+```
+
+:::
+
 ## Additional Commands
 
 - Check the status of the evcc server:


### PR DESCRIPTION
Fixes #1146

Homebrew installs each evcc version under a new path, so the macOS Application Firewall treats every upgrade as a new, unapproved binary and silently drops incoming connections. This breaks OCPP chargers while everything else keeps working, and on a headless Mac the approval dialog is never seen.

Adds a caution to the upgrade section of the macOS installation page (both locales) with the command-line approval fix. Uses $(brew --prefix) so the path works on both Intel and Apple Silicon.