### PR TITLE
emsesp: add setup guide link to Bosch/Buderus SG Ready device pages

### DIFF
--- a/templates/nightly/de/charger/bosch-sg-ready.yaml
+++ b/templates/nightly/de/charger/bosch-sg-ready.yaml
@@ -6,7 +6,7 @@ product:
   group: Wärmeerzeuger
 capabilities: ["meter", "dim"]
 description: |
-  Eingebunden via [emsesp.org](https://emsesp.org/)
+  Eingebunden via [emsesp.org](https://emsesp.org/). Weitere Hinweise zur Einrichtung: [bosch-buderus-wp.github.io](https://bosch-buderus-wp.github.io/docs/smarthome/evcc)
 render:
   - default: |
       type: template

--- a/templates/nightly/de/charger/buderus-sg-ready.yaml
+++ b/templates/nightly/de/charger/buderus-sg-ready.yaml
@@ -6,7 +6,7 @@ product:
   group: Wärmeerzeuger
 capabilities: ["meter", "dim"]
 description: |
-  Eingebunden via [emsesp.org](https://emsesp.org/)
+  Eingebunden via [emsesp.org](https://emsesp.org/). Weitere Hinweise zur Einrichtung: [bosch-buderus-wp.github.io](https://bosch-buderus-wp.github.io/docs/smarthome/evcc)
 render:
   - default: |
       type: template

--- a/templates/nightly/en/charger/bosch-sg-ready.yaml
+++ b/templates/nightly/en/charger/bosch-sg-ready.yaml
@@ -6,7 +6,7 @@ product:
   group: Heating devices
 capabilities: ["meter", "dim"]
 description: |
-  Integrated via [emsesp.org](https://emsesp.org/)
+  Integrated via [emsesp.org](https://emsesp.org/). Additional setup guidance: [bosch-buderus-wp.github.io](https://bosch-buderus-wp.github.io/docs/smarthome/evcc)
 render:
   - default: |
       type: template

--- a/templates/nightly/en/charger/buderus-sg-ready.yaml
+++ b/templates/nightly/en/charger/buderus-sg-ready.yaml
@@ -6,7 +6,7 @@ product:
   group: Heating devices
 capabilities: ["meter", "dim"]
 description: |
-  Integrated via [emsesp.org](https://emsesp.org/)
+  Integrated via [emsesp.org](https://emsesp.org/). Additional setup guidance: [bosch-buderus-wp.github.io](https://bosch-buderus-wp.github.io/docs/smarthome/evcc)
 render:
   - default: |
       type: template

--- a/templates/release/de/charger/bosch-sg-ready.yaml
+++ b/templates/release/de/charger/bosch-sg-ready.yaml
@@ -6,7 +6,7 @@ product:
   group: Wärmeerzeuger
 capabilities: ["meter", "dim"]
 description: |
-  Eingebunden via [emsesp.org](https://emsesp.org/)
+  Eingebunden via [emsesp.org](https://emsesp.org/). Weitere Hinweise zur Einrichtung: [bosch-buderus-wp.github.io](https://bosch-buderus-wp.github.io/docs/smarthome/evcc)
 render:
   - default: |
       type: template

--- a/templates/release/de/charger/buderus-sg-ready.yaml
+++ b/templates/release/de/charger/buderus-sg-ready.yaml
@@ -6,7 +6,7 @@ product:
   group: Wärmeerzeuger
 capabilities: ["meter", "dim"]
 description: |
-  Eingebunden via [emsesp.org](https://emsesp.org/)
+  Eingebunden via [emsesp.org](https://emsesp.org/). Weitere Hinweise zur Einrichtung: [bosch-buderus-wp.github.io](https://bosch-buderus-wp.github.io/docs/smarthome/evcc)
 render:
   - default: |
       type: template

--- a/templates/release/en/charger/bosch-sg-ready.yaml
+++ b/templates/release/en/charger/bosch-sg-ready.yaml
@@ -6,7 +6,7 @@ product:
   group: Heating devices
 capabilities: ["meter", "dim"]
 description: |
-  Integrated via [emsesp.org](https://emsesp.org/)
+  Integrated via [emsesp.org](https://emsesp.org/). Additional setup guidance: [bosch-buderus-wp.github.io](https://bosch-buderus-wp.github.io/docs/smarthome/evcc)
 render:
   - default: |
       type: template

--- a/templates/release/en/charger/buderus-sg-ready.yaml
+++ b/templates/release/en/charger/buderus-sg-ready.yaml
@@ -6,7 +6,7 @@ product:
   group: Heating devices
 capabilities: ["meter", "dim"]
 description: |
-  Integrated via [emsesp.org](https://emsesp.org/)
+  Integrated via [emsesp.org](https://emsesp.org/). Additional setup guidance: [bosch-buderus-wp.github.io](https://bosch-buderus-wp.github.io/docs/smarthome/evcc)
 render:
   - default: |
       type: template


### PR DESCRIPTION
## Summary

- Adds a link to [bosch-buderus-wp.github.io](https://bosch-buderus-wp.github.io/docs/smarthome/evcc) in the device page description for the Bosch and Buderus SG Ready devices
- Updates all four template variants (nightly/release × en/de) for both brands

This is referenced from evcc-io/evcc#32772 where vendor-specific setup guidance is being moved out of the generic `emsesp` template and into the appropriate device-specific documentation pages.