### PR TITLE
Add direct download links to Linux image install page

### DIFF
--- a/src/content/docs/de/installation/linux-image.mdx
+++ b/src/content/docs/de/installation/linux-image.mdx
@@ -15,16 +15,25 @@ Fertig vorkonfiguriert und einfach über die Web UI einzurichten!
 
 1. ### Datei herunterladen
 
-   Gehe zu den **[evcc Linux Images](https://github.com/evcc-io/images/releases)** und lade die neueste Version für Raspberry Pi herunter (`evcc_{version}_rpi.img.zip`).
+   Lade das aktuelle evcc Image für dein Gerät herunter:
+
+   | Gerät                                 | Download                                                                                                                          |
+   | ------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+   | **Raspberry Pi** (3, 4, 5, Zero 2 W)  | **[evcc_raspberry-pi.img.zip](https://github.com/evcc-io/images/releases/latest/download/evcc_raspberry-pi.img.zip)**              |
+   | NanoPi Zero2                           | [evcc_nanopi-zero2.img.zip](https://github.com/evcc-io/images/releases/latest/download/evcc_nanopi-zero2.img.zip)                  |
+   | NanoPi R3S                             | [evcc_nanopi-r3s.img.zip](https://github.com/evcc-io/images/releases/latest/download/evcc_nanopi-r3s.img.zip)                      |
+   | NanoPi R76S                            | [evcc_nanopi-r76s.img.zip](https://github.com/evcc-io/images/releases/latest/download/evcc_nanopi-r76s.img.zip)                    |
+
+   Diese Links führen immer zur neuesten Version. Prüfsummen und ältere Versionen findest du auf der [Releases-Seite](https://github.com/evcc-io/images/releases).
 
 2. ### SD-Karte beschreiben
 
-   Falls noch nicht vorhanden: **[balenaEtcher herunterladen](https://etcher.balena.io/)**
+   Falls noch nicht vorhanden: **[Armbian Imager herunterladen](https://imager.armbian.com/#downloads)**
    - SD-Karte in den Computer stecken
-   - balenaEtcher öffnen
-   - **Flash from file** → heruntergeladene Datei wählen
-   - **Select target** → deine SD-Karte wählen
-   - **Flash!** → warten bis fertig
+   - Armbian Imager öffnen
+   - **Eigenes Image verwenden** → heruntergeladene Datei wählen
+   - Deine SD-Karte auswählen
+   - Flashen starten → warten bis fertig
 
    :::tip[Alternative]
    Statt „Datei herunterladen & SD-Karte beschreiben“ kann man auch mit Hilfe des **[Raspberry Pi Imager](https://www.raspberrypi.com/software/)** die SD-Karte entsprechend vorbereiten.
@@ -115,9 +124,9 @@ Bereits 1 GB RAM reichen völlig aus.
 
 **Unterstützte Geräte:**
 
-- Raspberry Pi 3, 4 und 5 - alle Modelle funktionieren gleich gut
-- Raspberry Pi Zero 2 W - funktioniert gut
-- NanoPi R3S - kompakt, günstig und kommt mit Gehäuse und integriertem eMMC-Speicher
+- Raspberry Pi 4 und 5 - haben ausreichend Leistung
+- Raspberry Pi 3 und Zero 2 W - ausreichend, wenn evcc die einzige Anwendung ist
+- NanoPi Zero2, R3S und R76S - kompakt, günstig, mit Metallgehäuse und integriertem eMMC erhältlich
 
 **Speicher:**
 Mindestens 16 GB SD-Karte oder eMMC.

--- a/src/content/docs/de/installation/linux-image.mdx
+++ b/src/content/docs/de/installation/linux-image.mdx
@@ -17,12 +17,12 @@ Fertig vorkonfiguriert und einfach über die Web UI einzurichten!
 
    Lade das aktuelle evcc Image für dein Gerät herunter:
 
-   | Gerät                                 | Download                                                                                                                          |
-   | ------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
-   | **Raspberry Pi** (3, 4, 5, Zero 2 W)  | **[evcc_raspberry-pi.img.zip](https://github.com/evcc-io/images/releases/latest/download/evcc_raspberry-pi.img.zip)**              |
-   | NanoPi Zero2                           | [evcc_nanopi-zero2.img.zip](https://github.com/evcc-io/images/releases/latest/download/evcc_nanopi-zero2.img.zip)                  |
-   | NanoPi R3S                             | [evcc_nanopi-r3s.img.zip](https://github.com/evcc-io/images/releases/latest/download/evcc_nanopi-r3s.img.zip)                      |
-   | NanoPi R76S                            | [evcc_nanopi-r76s.img.zip](https://github.com/evcc-io/images/releases/latest/download/evcc_nanopi-r76s.img.zip)                    |
+   | Gerät                                | Download                                                                                                              |
+   | ------------------------------------ | --------------------------------------------------------------------------------------------------------------------- |
+   | **Raspberry Pi** (3, 4, 5, Zero 2 W) | **[evcc_raspberry-pi.img.zip](https://github.com/evcc-io/images/releases/latest/download/evcc_raspberry-pi.img.zip)** |
+   | NanoPi Zero2                         | [evcc_nanopi-zero2.img.zip](https://github.com/evcc-io/images/releases/latest/download/evcc_nanopi-zero2.img.zip)     |
+   | NanoPi R3S                           | [evcc_nanopi-r3s.img.zip](https://github.com/evcc-io/images/releases/latest/download/evcc_nanopi-r3s.img.zip)         |
+   | NanoPi R76S                          | [evcc_nanopi-r76s.img.zip](https://github.com/evcc-io/images/releases/latest/download/evcc_nanopi-r76s.img.zip)       |
 
    Diese Links führen immer zur neuesten Version. Prüfsummen und ältere Versionen findest du auf der [Releases-Seite](https://github.com/evcc-io/images/releases).
 

--- a/src/content/docs/en/installation/linux-image.mdx
+++ b/src/content/docs/en/installation/linux-image.mdx
@@ -17,12 +17,12 @@ Pre-configured and ready to set up via the web UI!
 
    Download the latest evcc image for your device:
 
-   | Device                                | Download                                                                                                                          |
-   | ------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
-   | **Raspberry Pi** (3, 4, 5, Zero 2 W)  | **[evcc_raspberry-pi.img.zip](https://github.com/evcc-io/images/releases/latest/download/evcc_raspberry-pi.img.zip)**              |
-   | NanoPi Zero2                           | [evcc_nanopi-zero2.img.zip](https://github.com/evcc-io/images/releases/latest/download/evcc_nanopi-zero2.img.zip)                  |
-   | NanoPi R3S                             | [evcc_nanopi-r3s.img.zip](https://github.com/evcc-io/images/releases/latest/download/evcc_nanopi-r3s.img.zip)                      |
-   | NanoPi R76S                            | [evcc_nanopi-r76s.img.zip](https://github.com/evcc-io/images/releases/latest/download/evcc_nanopi-r76s.img.zip)                    |
+   | Device                               | Download                                                                                                              |
+   | ------------------------------------ | --------------------------------------------------------------------------------------------------------------------- |
+   | **Raspberry Pi** (3, 4, 5, Zero 2 W) | **[evcc_raspberry-pi.img.zip](https://github.com/evcc-io/images/releases/latest/download/evcc_raspberry-pi.img.zip)** |
+   | NanoPi Zero2                         | [evcc_nanopi-zero2.img.zip](https://github.com/evcc-io/images/releases/latest/download/evcc_nanopi-zero2.img.zip)     |
+   | NanoPi R3S                           | [evcc_nanopi-r3s.img.zip](https://github.com/evcc-io/images/releases/latest/download/evcc_nanopi-r3s.img.zip)         |
+   | NanoPi R76S                          | [evcc_nanopi-r76s.img.zip](https://github.com/evcc-io/images/releases/latest/download/evcc_nanopi-r76s.img.zip)       |
 
    These links always give you the latest version. Checksums and older versions are available on the [releases page](https://github.com/evcc-io/images/releases).
 

--- a/src/content/docs/en/installation/linux-image.mdx
+++ b/src/content/docs/en/installation/linux-image.mdx
@@ -15,16 +15,25 @@ Pre-configured and ready to set up via the web UI!
 
 1. ### Download File
 
-   Go to the **[evcc Linux Images](https://github.com/evcc-io/images/releases)** and download the latest version for Raspberry Pi (`evcc_{version}_rpi.img.zip`).
+   Download the latest evcc image for your device:
+
+   | Device                                | Download                                                                                                                          |
+   | ------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+   | **Raspberry Pi** (3, 4, 5, Zero 2 W)  | **[evcc_raspberry-pi.img.zip](https://github.com/evcc-io/images/releases/latest/download/evcc_raspberry-pi.img.zip)**              |
+   | NanoPi Zero2                           | [evcc_nanopi-zero2.img.zip](https://github.com/evcc-io/images/releases/latest/download/evcc_nanopi-zero2.img.zip)                  |
+   | NanoPi R3S                             | [evcc_nanopi-r3s.img.zip](https://github.com/evcc-io/images/releases/latest/download/evcc_nanopi-r3s.img.zip)                      |
+   | NanoPi R76S                            | [evcc_nanopi-r76s.img.zip](https://github.com/evcc-io/images/releases/latest/download/evcc_nanopi-r76s.img.zip)                    |
+
+   These links always give you the latest version. Checksums and older versions are available on the [releases page](https://github.com/evcc-io/images/releases).
 
 2. ### Flash SD Card
 
-   If not already available: **[Download balenaEtcher](https://etcher.balena.io/)**
+   If not already available: **[Download Armbian Imager](https://imager.armbian.com/#downloads)**
    - Insert SD card into computer
-   - Open balenaEtcher
-   - **Flash from file** → select downloaded file
-   - **Select target** → select your SD card
-   - **Flash!** → wait until finished
+   - Open Armbian Imager
+   - **Use Custom Image** → select downloaded file
+   - Select your SD card
+   - Start flashing → wait until finished
 
    :::tip[Alternative]
    Instead of "Download File & Flash SD Card," you can also prepare the SD card by using the **[Raspberry Pi Imager](https://www.raspberrypi.com/software/)**.
@@ -115,9 +124,9 @@ Even 1 GB RAM is completely sufficient.
 
 **Supported Devices:**
 
-- Raspberry Pi 3, 4, and 5 - all models work equally well
-- Raspberry Pi Zero 2 W - works well
-- NanoPi R3S - compact, affordable, and comes with case and integrated eMMC storage
+- Raspberry Pi 4 and 5 - plenty of performance
+- Raspberry Pi 3 and Zero 2 W - sufficient if evcc is the only application
+- NanoPi Zero2, R3S, and R76S - compact, affordable, available with metal case and integrated eMMC storage
 
 **Storage:**
 At least 16 GB SD card or eMMC.


### PR DESCRIPTION
## Changes (EN + DE)

- **Download step**: per-device table with direct links via the new canonical URLs (`releases/latest/download/evcc_<board>.img.zip`) — Raspberry Pi highlighted as the default, NanoPi Zero2/R3S/R76S included. No more version placeholders that go stale.
- **Flash step**: describes the Armbian Imager flow ("Use Custom Image" → select file → select SD card); Raspberry Pi Imager remains as alternative in the tip.
- **Hardware recommendations**: regrouped — Pi 4/5 (plenty of performance), Pi 3 + Zero 2 W (sufficient if evcc is the only application), NanoPi boards combined into one line.

## Depends on

evcc-io/images#37 — the canonical links 404 until the first release with the new asset names is published. Merge this after that release exists.