### PR TITLE
Sponsorship: add yearly plan, promote test token, extend token FAQ

### DIFF
--- a/src/content/docs/de/sponsorship.mdx
+++ b/src/content/docs/de/sponsorship.mdx
@@ -44,7 +44,7 @@ Bevor du Sponsor wirst, prüfe mit dem [Testtoken](#trial), ob alle deine Gerät
   <Card title="💚 Direkt via Creem.io">
     Kein Konto nötig, bezahle per Kreditkarte, Apple Pay oder Google Pay, weitere Zahlungsarten folgen.
 
-    - **[Jährlich 50 €](https://sponsor.evcc.io)**: Abo, verlängert sich automatisch und ist jederzeit kündbar.
+    - **[Jährlich 50 €](https://sponsor.evcc.io)**: Verlängert sich automatisch und ist jederzeit kündbar.
     - **[Einmalig 150 €](https://sponsor.evcc.io)**: Ein unbefristetes Sponsortoken mit unbegrenzter Gültigkeit.
     - **[Mengenrabatt](https://sponsor.evcc.io/business)**: Token-Pakete für Elektriker und Installateure.
 

--- a/src/content/docs/de/sponsorship.mdx
+++ b/src/content/docs/de/sponsorship.mdx
@@ -12,12 +12,12 @@ Unser Ziel ist es, das Laden von Elektroautos lokal, ohne Cloud, ohne Datensamml
 Die Liste der unterstützten Geräte wächst stetig.
 Wir legen Wert darauf, dass evcc einfach zu bedienen bleibt und dennoch viele Schnittstellen für fortgeschrittene Nutzer bietet.
 
-Um die Weiterentwicklung zu sichern, brauchen wir eure Unterstützung – finanziell oder durch aktive Mitarbeit.
+Um die Weiterentwicklung zu sichern, brauchen wir eure Unterstützung, sei es finanziell oder durch aktive Mitarbeit.
 
 ## Community Finanzierung 🤘💚
 
 Der Code von evcc ist offen auf GitHub verfügbar.
-Für die Verwendung vieler kommerzieller Wallboxen haben wir uns entschieden ein Sponsortoken zu erfordern.
+Für die Verwendung vieler kommerzieller Wallboxen ist ein Sponsortoken erforderlich.
 Ausgenommen von dieser Regel sind Open-Hardware Wallboxen, Produkte mit gutem Community-Karma und Hersteller, die die Entwicklung von evcc aktiv unterstützen.
 Schaltsteckdosen und Plugins sind auch tokenfrei nutzbar.
 
@@ -28,6 +28,7 @@ Damit ist natürlicherweise sichergestellt, dass sich das Projekt nach den Vorst
 
 Es gibt zwei Wege zu einem Sponsortoken.
 Bei direkter Zahlung erhältst du eine ordentliche Rechnung, die du im Anschluss herunterladen kannst.
+Bevor du Sponsor wirst, prüfe mit dem [Testtoken](#trial), ob alle deine Geräte funktionieren.
 
 <CardGrid>
   <Card title="🩷 GitHub Sponsors">
@@ -43,7 +44,8 @@ Bei direkter Zahlung erhältst du eine ordentliche Rechnung, die du im Anschluss
   <Card title="💚 Direkt via Creem.io">
     Kein Konto nötig, bezahle per Kreditkarte, Apple Pay oder Google Pay, weitere Zahlungsarten folgen.
 
-    - **[Einmalig 150 €](https://sponsor.evcc.io)**: Dasselbe unbefristete Sponsortoken.
+    - **[Jährlich 50 €](https://sponsor.evcc.io)**: Abo, verlängert sich automatisch und ist jederzeit kündbar.
+    - **[Einmalig 150 €](https://sponsor.evcc.io)**: Ein unbefristetes Sponsortoken mit unbegrenzter Gültigkeit.
     - **[Mengenrabatt](https://sponsor.evcc.io/business)**: Token-Pakete für Elektriker und Installateure.
 
     Dein Token kommt per E-Mail.
@@ -53,21 +55,23 @@ Bei direkter Zahlung erhältst du eine ordentliche Rechnung, die du im Anschluss
 
 Als kleines Dankeschön wird in der evcc UI **digitales Supporter-Konfetti 🎉** freigeschaltet und du kannst dir einmal ein cooles Set an **evcc Stickern ☀️** per Post zuschicken lassen.
 
-## Contributor's Token
+## Contributor-Token
 
 Du hast Lust, an der Entwicklung mitzuwirken?
 Wir freuen uns über jeden Beitrag.
 Schau dir gerne die Liste an [offenen GitHub Issues](https://github.com/evcc-io/evcc/issues) an oder [melde dich bei uns](mailto:info@evcc.io) mit konkreten Ideen, an denen du gerne mitarbeiten möchtest.
-Auch signifikante Beiträge zur [Dokumentation](https://github.com/evcc-io/docs) oder [Übersetzung](https://github.com/evcc-io/evcc/blob/master/CONTRIBUTING.md#adding-or-modifying-translations) qualifizieren für ein Contributor's Token.
+Auch signifikante Beiträge zur [Dokumentation](https://github.com/evcc-io/docs) oder [Übersetzung](https://github.com/evcc-io/evcc/blob/master/CONTRIBUTING.md#adding-or-modifying-translations) qualifizieren für ein Contributor-Token.
 [Hier](https://github.com/evcc-io/evcc/blob/master/CONTRIBUTING.md) findest du weitere Informationen, wie du loslegen kannst.
 
 Als Contributor zum Projekt stellen wir dir gerne ein unbefristetes Unterstützertoken aus.
 Schreib uns dafür [eine kurze Mail](mailto:info@evcc.io) mit deinem GitHub-Namen.
 
+<a id="trial"></a>
+
 ## Testtoken
 
 Du setzt evcc zum ersten Mal auf und würdest gerne prüfen, ob alle deine Geräte funktionieren?
-Dafür kannst du das Test-Token hier verwenden.
+Dafür kannst du das Testtoken hier verwenden.
 Es hat eine begrenzte Gültigkeit, wird aber regelmäßig erneuert.
 
 <SponsorToken />
@@ -82,7 +86,7 @@ Unter [sponsor.evcc.io](https://sponsor.evcc.io) kannst du dein(e) Token einsehe
 
 Es kann leider vorkommen, dass die Sponsor-Information von GitHub für uns erst nach einigen Minuten (in seltenen Fällen am nächsten Tag) verfügbar ist.
 Hab also etwas Geduld und schau später noch mal rein.
-In der Zwischenzeit kannst du auch mit dem Test-Token arbeiten.
+In der Zwischenzeit kannst du auch mit dem Testtoken arbeiten.
 Sollte dein Token auch später nicht auftauchen, [melde dich bei uns](mailto:info@evcc.io).
 
 Stelle sicher, dass du eine der vordefinierten Stufen bei GitHub ausgewählt hast.
@@ -91,12 +95,11 @@ Bei freien Beträgen (bspw. einmalig $4) wird kein Token erstellt.
 #### Ich habe ein Gewerbe und möchte evcc kommerziell einsetzen. Kann ich das machen?
 
 Ja, das ist kein Problem.
-Du kannst Sponsortoken-Pakete direkt über [sponsor.evcc.io/business](https://sponsor.evcc.io/business) kaufen, mit Mengenrabatt für Elektriker und Installateure.
-Die Token sind für den Einsatz bei deinen Endkunden gedacht und dürfen nicht einzeln weiterverkauft werden.
+Sponsortoken-Pakete gibt es direkt über [sponsor.evcc.io/business](https://sponsor.evcc.io/business), mit Mengenrabatt für Elektriker und Installateure.
+Die Token sind für Hardware-Installationen gedacht, die du bei deinen Kunden einrichtest.
+Der Weiterverkauf einzelner Token ist nicht erlaubt.
+Wenn du Installationen unter eigener Marke ausliefern möchtest, schau dir die [White-Label-Möglichkeiten](/de/reference/white-label) an.
 Bei individuellen Anforderungen [melde dich bei uns](mailto:info@evcc.io).
-
-_Hinweis: Für weitere Funktionen wie bspw. [Lastmanagement](/de/features/loadmanagement) werden wir explizite kommerzielle Unterstützungsmodelle anbieten.
-Dazu aber später mehr._
 
 #### Wo trage ich mein Token ein?
 
@@ -108,37 +111,38 @@ Entferne den Eintrag aus der `evcc.yaml`, um das Token über die Weboberfläche 
 
 #### Kann ich mein Token in mehreren Installationen nutzen?
 
-Ja, solange es deine persönlichen evcc-Instanzen sind, ist eine mehrfache Nutzung kein Problem.
-Wir vertrauen hier auf deine Ehrlichkeit.
+Ja, du kannst dein Token auf bis zu drei Instanzen im selben Haushalt nutzen, z. B. für Tests oder spezielle Setups.
+Details dazu findest du in unseren [Nutzungsbedingungen](https://evcc.io/terms).
 
 #### Ich habe mein Token verloren. Wie bekomme ich ein neues?
 
-Du kannst dein Token jederzeit über [sponsor.evcc.io](https://sponsor.evcc.io) einsehen.
+Als GitHub-Sponsor kannst du dein(e) Token jederzeit über [sponsor.evcc.io](https://sponsor.evcc.io) einsehen.
+Wenn du direkt über Creem gesponsert hast, hast du dein Token per E-Mail mit dem Betreff „Dein evcc Sponsortoken“ erhalten.
+Falls du diese E-Mail nicht mehr findest, [melde dich bei uns](mailto:info@evcc.io) und wir stellen dir dein Token erneut aus.
 
 #### Kann ich mein Token weiterverkaufen oder einen "gebrauchten" Token kaufen?
 
-Die Token sind personalisiert und enthalten deinen GitHub-Namen.
+Die Token sind personalisiert und enthalten deinen GitHub-Namen oder deine E-Mail-Adresse.
 Bitte gib sie nicht an Dritte weiter.
 Kaufe auch keine "gebrauchten" Token auf Online-Plattformen.
 Wenn du das Projekt voranbringen willst, unterstütze uns lieber direkt.
 
 #### Ich benötige eine längere Test-Zeit.
 
-Sollte das Test-Token ablaufen und du bist dir noch nicht sicher, ob evcc für dich wie erwartet funktioniert, kannst du nach Ablauf ein neues Test-Token eintragen.
+Sollte das Testtoken ablaufen und du bist dir noch nicht sicher, ob evcc für dich wie erwartet funktioniert, kannst du nach Ablauf ein neues Testtoken eintragen.
 Wir aktualisieren das Token hier regelmäßig.
 
 #### Mein Token funktioniert nicht. Woran liegt das?
 
 Sollte dein Token nicht funktionieren, kann das verschiedene Gründe haben:
 
-- **Monatliches Sponsoring ausgelaufen:** Prüfe deinen Sponsor-Status bei GitHub und auf [sponsor.evcc.io](https://sponsor.evcc.io).
+- **Monatliches oder jährliches Sponsoring ausgelaufen:** Prüfe deinen Sponsor-Status bei GitHub oder im Creem-Portal sowie auf [sponsor.evcc.io](https://sponsor.evcc.io).
 - **Formatierungsfehler:** Prüfe, ob du das Token korrekt in die `evcc.yaml` eingetragen hast.
 - **Doppelte Konfiguration:** Falls du das Token sowohl in der Weboberfläche als auch in der `evcc.yaml` eingetragen hast, wird nur das Token aus der `evcc.yaml` verwendet.
   Entferne den Eintrag aus der Datei, wenn du das Token über die Weboberfläche verwalten möchtest.
 - **Token abgelaufen:** Das Token selbst hat eine Ablaufzeit.
   Ist diese überschritten, kannst du dir unter [sponsor.evcc.io](https://sponsor.evcc.io) ein neues ausstellen und das aktuelle ersetzen.
   Du bekommst in der Weboberfläche rechtzeitig eine Warnung, wenn dies erforderlich ist.
-  Hinweis: Wir werden diesen Prozess in Zukunft automatisieren.
 
 Sollten die obigen Schritte nicht helfen, [melde dich bei uns](mailto:info@evcc.io) und wir prüfen das gerne.
 

--- a/src/content/docs/en/sponsorship.mdx
+++ b/src/content/docs/en/sponsorship.mdx
@@ -12,7 +12,7 @@ Our goal is to enable local, cloud-free, privacy-friendly and manufacturer-indep
 The list of supported devices is growing steadily.
 We value an enjoyable user experience while also offering a high degree of flexibility for advanced users.
 
-To ensure the ongoing development, we need your support - financially or through active contribution.
+To ensure the ongoing development, we need your support, either financially or through active contribution.
 
 ## Community Funding 🤘💚
 
@@ -28,6 +28,7 @@ This ensures that the project develops according to the needs of its users and i
 
 There are two ways to get a sponsor token.
 Direct payment comes with a proper EU invoice, downloadable afterwards.
+Before you become a sponsor, use the [test token](#trial) to verify that all your devices work.
 
 <CardGrid>
   <Card title="🩷 GitHub Sponsors">
@@ -43,7 +44,8 @@ Direct payment comes with a proper EU invoice, downloadable afterwards.
   <Card title="💚 Direct via Creem.io">
     No account needed, pay by credit card, Apple Pay or Google Pay, with more payment options on the way.
 
-    - **[One-time €150](https://sponsor.evcc.io)**: The same lifetime sponsor token.
+    - **[Yearly €50](https://sponsor.evcc.io)**: Auto-renewing subscription, cancel anytime.
+    - **[One-time €150](https://sponsor.evcc.io)**: A lifetime sponsor token with unlimited validity.
     - **[Volume discounts](https://sponsor.evcc.io/business)**: Token bundles for electricians and installers.
 
     Your token is delivered by email.
@@ -63,6 +65,8 @@ Significant contributions to the [documentation](https://github.com/evcc-io/docs
 
 As a contributor, we'll issue you an unlimited contributor token.
 [Send us a short email](mailto:info@evcc.io) with your GitHub username.
+
+<a id="trial"></a>
 
 ## Trial Token
 
@@ -91,8 +95,10 @@ If you've entered a lower custom amount (e.g. $4 one-time), no token will be cre
 #### I have a business and want to use evcc commercially. Can I do that?
 
 Yes, that's no problem.
-You can buy sponsor token bundles directly at [sponsor.evcc.io/business](https://sponsor.evcc.io/business), with volume discounts for electricians and installers.
-The tokens are meant for use at your end customers and may not be traded individually.
+Sponsor token bundles are available directly at [sponsor.evcc.io/business](https://sponsor.evcc.io/business), with volume discounts for electricians and installers.
+The tokens are intended for hardware installations you set up for your customers.
+Reselling tokens on their own is not allowed.
+If you want to deliver installations under your own brand, have a look at the [white label options](/en/reference/white-label).
 For custom requirements, [write us an email](mailto:info@evcc.io) and we'll get back to you.
 
 #### Where do I enter my token?
@@ -105,16 +111,18 @@ Remove the entry from `evcc.yaml` to manage the token via the web interface.
 
 #### Can I use my token on multiple installations?
 
-Yes, as long as it's your personal evcc instances, multiple usage is no problem.
-We trust you to be honest about that.
+Yes, you can use your token on up to three instances in the same home, e.g. for testing or special setups.
+See our [terms of service](https://evcc.io/terms) for details.
 
 #### I lost my token. How do I get a new one?
 
-You can view your token(s) at [sponsor.evcc.io](https://sponsor.evcc.io).
+As a GitHub sponsor, you can view your token(s) at [sponsor.evcc.io](https://sponsor.evcc.io).
+If you sponsored directly via Creem, you received your token by email with the subject "Your evcc sponsor token".
+If you can't find that email any more, [contact us](mailto:info@evcc.io) and we'll issue your token again.
 
 #### Can I sell my token or buy a "used" one?
 
-The tokens are personalized and contain your GitHub username.
+The tokens are personalized and contain your GitHub username or email address.
 Please do not sell them to third parties.
 Please do not buy used tokens from third parties via online platforms.
 If you want to support the project, please do so directly.
@@ -128,14 +136,13 @@ We update the test token regularly.
 
 There could be several reasons:
 
-- **Monthly sponsoring expired:** Check your sponsor status at GitHub and [sponsor.evcc.io](https://sponsor.evcc.io).
+- **Monthly or yearly sponsoring expired:** Check your sponsor status at GitHub or in the Creem portal, and at [sponsor.evcc.io](https://sponsor.evcc.io).
 - **Formatting error:** Check if you have correctly entered the token in `evcc.yaml`.
 - **Duplicate configuration:** If you entered the token both in the web interface and in `evcc.yaml`, only the token from `evcc.yaml` is used.
   Remove the entry from the file if you want to manage the token via the web interface.
 - **Token expired:** The token itself has an expiration date.
   If this has passed, you can issue a new one at [sponsor.evcc.io](https://sponsor.evcc.io) and replace the current one.
   You will receive a warning in the web interface in good time when this is necessary.
-  Note: We will automate this process in the future.
 
 If the above does not help, [contact us](mailto:info@evcc.io) and we'll check it out.
 


### PR DESCRIPTION
Adds the new 50 €/year Creem plan to the sponsorship page and recommends verifying setups with the test token before sponsoring.

- Creem card: new yearly €50 subscription option (auto-renewing, cancel anytime)
- Sponsor Tokens intro links to the test token section; explicit `#trial` anchor added in both locales, which also fixes the dangling deep link from the evcc UI sponsor modal
- Business FAQ: clearer token bundle wording (hardware installations, no individual reselling) and a note linking the new white label page
- Lost-token FAQ: GitHub sponsors use sponsor.evcc.io, Creem sponsors find the email ("Your evcc sponsor token" / „Dein evcc Sponsortoken") or contact us for reissue
- Multi-installation FAQ aligned with the terms of service (up to three instances in the same home)
- Token-not-working FAQ covers expired yearly subscriptions
- German cleanups: grammar, „Testtoken", „Contributor-Token", removed outdated future-plans note