### PR TITLE
White label: document EVCC_CUSTOM_THEME

### DIFF
--- a/src/content/docs/de/reference/white-label.mdx
+++ b/src/content/docs/de/reference/white-label.mdx
@@ -37,11 +37,19 @@ Mit dieser Datei sieht die Oberfläche so aus:
   caption="Angepasste Primärfarbe und Schrift"
 />
 
-Ein paar Dinge solltest du beachten:
+Dabei gibt es ein paar Dinge zu beachten:
 
-- Es gibt keine Kompatibilitätsgarantien. Properties und Markup können sich mit jedem Release ändern, prüfe deine Styles daher nach jedem Update.
-- Teste deine Styles im hellen und dunklen Modus.
-- Achte auf ausreichende Kontraste, z. B. bei Text auf deiner Primärfarbe.
+- Es gibt keine Kompatibilitätsgarantien. Properties und Markup können sich mit jedem Release ändern. Eigene Styles sollten daher nach jedem Update geprüft werden, idealerweise schon mit den Nightly Releases.
+- Die Styles sollten im hellen und dunklen Modus funktionieren.
+- Wichtig sind ausreichende Kontraste, z. B. bei Text auf der Primärfarbe.
+
+<a id="theme"></a>
+
+## Standard-Design
+
+`EVCC_CUSTOM_THEME` legt das Design fest, mit dem die Oberfläche startet: `auto` (Standard), `light` oder `dark`.
+Nutzer können das Design weiterhin in den UI-Einstellungen ändern.
+Ihre Auswahl wird im Browser gespeichert und hat immer Vorrang vor dieser Vorgabe.
 
 <a id="brand"></a>
 
@@ -94,14 +102,6 @@ Aus technischen Gründen enthält die E-Mail keine Debug-Details (Konfiguration,
 Bitte deine Nutzer bei Bedarf, die Debug-Datei auf derselben Seite herunterzuladen und an die E-Mail anzuhängen.
 
 Der Hilfe-Dialog zeigt außerdem einen **Kontakt aufnehmen**-Button statt des Links zu den **GitHub Discussions**.
-
-<a id="theme"></a>
-
-## Standard-Design
-
-`EVCC_CUSTOM_THEME` legt das Design fest, mit dem die Oberfläche startet: `auto` (Standard), `light` oder `dark`.
-Nutzer können das Design weiterhin in den UI-Einstellungen ändern.
-Ihre Auswahl wird im Browser gespeichert und hat immer Vorrang vor dieser Vorgabe.
 
 <a id="configuration"></a>
 

--- a/src/content/docs/de/reference/white-label.mdx
+++ b/src/content/docs/de/reference/white-label.mdx
@@ -95,6 +95,14 @@ Bitte deine Nutzer bei Bedarf, die Debug-Datei auf derselben Seite herunterzulad
 
 Der Hilfe-Dialog zeigt außerdem einen **Kontakt aufnehmen**-Button statt des Links zu den **GitHub Discussions**.
 
+<a id="theme"></a>
+
+## Standard-Design
+
+`EVCC_CUSTOM_THEME` legt das Design fest, mit dem die Oberfläche startet: `auto` (Standard), `light` oder `dark`.
+Nutzer können das Design weiterhin in den UI-Einstellungen ändern.
+Ihre Auswahl wird im Browser gespeichert und hat immer Vorrang vor dieser Vorgabe.
+
 <a id="configuration"></a>
 
 ## Konfiguration

--- a/src/content/docs/en/reference/white-label.mdx
+++ b/src/content/docs/en/reference/white-label.mdx
@@ -39,9 +39,17 @@ With this file loaded, the interface looks like this:
 
 A few things to keep in mind:
 
-- There are no compatibility guarantees. Properties and markup may change with any release, so check your styles after each update.
-- Test your styles in light and dark mode.
-- Check for sufficient contrast, e.g. text on your primary colour.
+- There are no compatibility guarantees. Properties and markup may change with any release. Custom styles should be verified after each update, ideally already against the nightly releases.
+- Styles should work in both light and dark mode.
+- Sufficient contrast matters, e.g. text on the primary colour.
+
+<a id="theme"></a>
+
+## Default Theme
+
+`EVCC_CUSTOM_THEME` sets the design the UI starts with: `auto` (default), `light` or `dark`.
+Users can still change the design in the UI settings.
+Their choice is stored in the browser and always wins over this default.
 
 <a id="brand"></a>
 
@@ -94,14 +102,6 @@ For technical reasons the email doesn't include debug details (configuration, lo
 If you need them, ask your users to download the debug file on the same page and attach it to their email.
 
 The help dialog also shows a **Contact us** email button instead of the **GitHub discussions** link.
-
-<a id="theme"></a>
-
-## Default Theme
-
-`EVCC_CUSTOM_THEME` sets the design the UI starts with: `auto` (default), `light` or `dark`.
-Users can still change the design in the UI settings.
-Their choice is stored in the browser and always wins over this default.
 
 <a id="configuration"></a>
 

--- a/src/content/docs/en/reference/white-label.mdx
+++ b/src/content/docs/en/reference/white-label.mdx
@@ -95,6 +95,14 @@ If you need them, ask your users to download the debug file on the same page and
 
 The help dialog also shows a **Contact us** email button instead of the **GitHub discussions** link.
 
+<a id="theme"></a>
+
+## Default Theme
+
+`EVCC_CUSTOM_THEME` sets the design the UI starts with: `auto` (default), `light` or `dark`.
+Users can still change the design in the UI settings.
+Their choice is stored in the browser and always wins over this default.
+
 <a id="configuration"></a>
 
 ## Configuration


### PR DESCRIPTION
pairs with evcc-io/evcc#33042

Documents the new `EVCC_CUSTOM_THEME` variable on the white-label page.

- new Default Theme section (EN and DE)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
