### PR TITLE
Remote Access: mark non-experimental, restructure docs

### DIFF
--- a/src/components/SponsorInfoBox.astro
+++ b/src/components/SponsorInfoBox.astro
@@ -3,19 +3,29 @@ import { renderMarkdown } from "@utils/devices";
 
 interface Props {
   lang: "de" | "en";
+  type?: "device" | "feature";
 }
-const { lang } = Astro.props;
+const { lang, type = "device" } = Astro.props;
 
-const t =
-  lang === "de"
-    ? {
-        title: "Sponsoring",
-        body: "Geräte mit diesem Label erfordern ein Sponsortoken. Mehr zu unserem [Sponsoring-Modell](/de/sponsorship).",
-      }
-    : {
-        title: "Sponsoring",
-        body: "Devices with this badge require a sponsor token. Read more about our [sponsorship model](/en/sponsorship).",
-      };
+const bodies = {
+  de: {
+    device:
+      "Geräte mit diesem Label erfordern ein Sponsortoken. Mehr zu unserem [Sponsoring-Modell](/de/sponsorship).",
+    feature:
+      "Diese Funktion erfordert ein Sponsortoken. Mehr zu unserem [Sponsoring-Modell](/de/sponsorship).",
+  },
+  en: {
+    device:
+      "Devices with this badge require a sponsor token. Read more about our [sponsorship model](/en/sponsorship).",
+    feature:
+      "This feature requires a sponsor token. Read more about our [sponsorship model](/en/sponsorship).",
+  },
+};
+
+const t = {
+  title: "Sponsoring",
+  body: bodies[lang][type],
+};
 ---
 
 <aside class="starlight-aside starlight-aside--tip" aria-label={t.title}>

--- a/src/content/docs/de/features/app.mdx
+++ b/src/content/docs/de/features/app.mdx
@@ -57,10 +57,13 @@ Den Quellcode und Android-APKs findest du im [GitHub-Repository](https://github.
   </a>
 </div>
 
-## Fernzugriff
+## Remotezugriff
 
-Genau wie beim Zugriff über den Browser musst du dich mit der App im gleichen Netzwerk wie deine evcc-Instanz befinden.
-Für die Nutzung aus dem Internet empfehlen wir die Nutzung von VPN-Diensten.
+Als [Sponsor](/de/sponsorship) kannst du für die Nutzung von unterwegs den [Remotezugriff](/de/features/remote-access) verwenden.
+Die Instanz bekommt dabei eine eigene Domain auf `evcc.cloud`, und die App verbindet sich von überall.
+Zur Einrichtung reicht das Scannen eines QR-Codes.
+
+Alternativ funktionieren auch VPN-Dienste.
 Viele Router bringen so eine Funktion mit, aber auch Dienste wie [Tailscale](https://tailscale.com/) oder [ZeroTier](https://zerotier.com/) werden gerne genutzt.
 
 ## URL-Schema
@@ -68,8 +71,3 @@ Viele Router bringen so eine Funktion mit, aber auch Dienste wie [Tailscale](htt
 Die App registriert ein `evcc://`-URL-Schema.
 Damit kannst du per Link oder QR-Code die Servereinrichtung vorausfüllen oder direkt zu einer Seite springen.
 Die verfügbaren Links findest du unter [evcc App](/de/reference/app).
-
-## Ausblick
-
-Mit der nativen App haben wir die Basis für zukünftige Funktionen geschaffen, die mit der Web-UI nicht möglich sind.
-Native Push-Nachrichten oder Plattform-spezifische Features wie Widgets werden früher oder später folgen.

--- a/src/content/docs/de/features/loadmanagement.mdx
+++ b/src/content/docs/de/features/loadmanagement.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Lastmanagement"
 sidebar:
-  order: 11
+  order: 12
 ---
 
 :::caution[Experimentell]

--- a/src/content/docs/de/features/optimizer.mdx
+++ b/src/content/docs/de/features/optimizer.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Optimizer 🧪"
 sidebar:
-  order: 12
+  order: 13
 ---
 
 import Screenshot from "@components/Screenshot.astro";

--- a/src/content/docs/de/features/remote-access.mdx
+++ b/src/content/docs/de/features/remote-access.mdx
@@ -1,62 +1,38 @@
 ---
-title: "Remote Access 🧪"
+title: "Remotezugriff"
 sidebar:
-  order: 13
+  order: 11
 ---
 
 import { Steps } from "@astrojs/starlight/components";
+import SponsorInfoBox from "@components/SponsorInfoBox.astro";
 import statusImg from "@assets/features/remote-access/status.png";
 import clientsImg from "@assets/features/remote-access/clients.png";
 import clientCreatedImg from "@assets/features/remote-access/client-created.png";
 
-:::caution[Experimentell]
-Remote Access befindet sich in Entwicklung.
-Funktionsweise und Konfiguration können sich noch ändern.
-:::
+Mit Remotezugriff erreichst du deine evcc-Instanz auch außerhalb deines Heimnetzes, per [evcc-App](/de/features/app) oder Browser.
+Deine Instanz bekommt dafür eine eigene Domain auf `evcc.cloud`.
+Portfreigabe, DynDNS oder VPN sind nicht nötig, da die Instanz die Verbindung selbst nach außen aufbaut.
 
-Mit Remote Access erreichst du deine lokale evcc-Instanz von unterwegs.
-Jede Instanz bekommt dafür ihre eigene Domain auf `evcc.cloud`.
-Du brauchst weder DynDNS noch eine Portfreigabe in deinem Router.
-
-```mermaid
-flowchart LR
-  subgraph internet [Internet]
-    app["evcc App"]
-    browser["Browser"]
-    proxy["Remote-Proxy<br/><code>___.evcc.cloud</code>"]
-  end
-  app <-- HTTPS --> proxy
-  browser <-- HTTPS --> proxy
-  proxy <-->|"secure websocket<br/><i>permanent</i>"| evcc["evcc-Instanz<br/><code>evcc.local</code>"]
-```
-
-## Wie funktioniert das?
-
-Deine App oder dein Browser verbindet sich mit deiner persönlichen Domain unter `evcc.cloud`.
-Der Remote-Proxy leitet die Anfragen durch einen WebSocket-Tunnel an deine lokale evcc-Instanz weiter.
-Den Tunnel baut deine evcc-Instanz selbst nach außen auf, daher ist kein offener Port in deinem Netzwerk nötig.
+<SponsorInfoBox lang="de" type="feature" />
 
 ## Einrichtung
 
-Remote Access setzt ein aktives [Sponsoring](/de/sponsorship) voraus.
-
 <Steps>
 
-1. Aktiviere die Funktion in der Oberfläche:
-   - **Konfiguration → Experimentell** → aktivieren
-   - **Konfiguration → Remote Access 🧪** → aktivieren
+1. Aktiviere die Funktion unter **Konfiguration → Remotezugriff**.
 
    <img
      src={statusImg.src}
-     alt="Integrations-Übersicht mit aktivem Remote Access"
+     alt="Integrations-Übersicht mit aktivem Remotezugriff"
      style={{ maxWidth: "500px" }}
    />
 
-2. Deine evcc-Instanz registriert sich beim Remote-Proxy und erhält eine eigene Domain, z. B. `swift-dark-crow.evcc.cloud`.
+2. Deine evcc-Instanz verbindet sich mit `evcc.cloud` und erhält eine eigene Domain, z. B. `swift-dark-crow.evcc.cloud`.
 
    <img
      src={clientsImg.src}
-     alt="Remote-Access-Verwaltung mit Domain und Client-Liste"
+     alt="Remotezugriff-Verwaltung mit Domain und Client-Liste"
      style={{ maxWidth: "500px" }}
    />
 
@@ -103,7 +79,7 @@ Alle anderen bleiben verbunden.
 Wiederholte Fehlversuche bei der Anmeldung werden automatisch ausgebremst.
 
 **Umfang des Zugriffs.**
-Die Remote-Access-Zugangsdaten bestehen parallel zu den Sicherheitsmechanismen in evcc selbst.
+Die Remotezugriff-Zugangsdaten bestehen parallel zu den Sicherheitsmechanismen in evcc selbst.
 Sie gewähren ausschließlich Netzwerkzugang zu deiner Instanz, vergleichbar mit dem Zugriff aus deinem lokalen Netzwerk.
 Für Änderungen an der Konfiguration, Backups, Logs oder einen Neustart ist weiterhin das Administrator-Passwort erforderlich.
 
@@ -111,7 +87,23 @@ Für Änderungen an der Konfiguration, Backups, Logs oder einen Neustart ist wei
 Die Registrierung wird gegen `sponsor.evcc.io` geprüft.
 Jeder Sponsor erhält genau eine Domain, die fest mit ihm verknüpft bleibt und nicht erneut vergeben wird.
 
-## Technischer Hintergrund
+## Technische Details
+
+Deine App oder dein Browser verbindet sich mit deiner persönlichen Domain unter `evcc.cloud`.
+Der Remote-Proxy leitet die Anfragen durch einen WebSocket-Tunnel an deine lokale evcc-Instanz weiter.
+Den Tunnel baut deine evcc-Instanz selbst nach außen auf, daher ist kein offener Port in deinem Netzwerk nötig.
+
+```mermaid
+flowchart LR
+  subgraph internet [Internet]
+    app["evcc App"]
+    browser["Browser"]
+    proxy["Remote-Proxy<br/><code>___.evcc.cloud</code>"]
+  end
+  app <-- HTTPS --> proxy
+  browser <-- HTTPS --> proxy
+  proxy <-->|"secure websocket<br/><i>permanent</i>"| evcc["evcc-Instanz<br/><code>evcc.local</code>"]
+```
 
 Beim ersten Aktivieren registriert sich die lokale evcc-Instanz beim Remote-Proxy.
 Im Tausch gegen den Sponsor-Token erhält sie ein Verbindungstoken und eine zufällig vergebene Domain.

--- a/src/content/docs/en/features/app.mdx
+++ b/src/content/docs/en/features/app.mdx
@@ -59,8 +59,11 @@ You can find the source code and Android APKs in the [GitHub repository](https:/
 
 ## Remote Access
 
-Just like when accessing via browser, you need to be on the same network as your evcc instance when using the app.
-For internet access, we recommend using VPN services.
+As a [sponsor](/en/sponsorship), you can use [Remote Access](/en/features/remote-access) to connect on the go.
+The instance gets its own domain on `evcc.cloud`, and the app connects from anywhere.
+Setup is a matter of scanning a QR code.
+
+Alternatively, VPN services work as well.
 Many routers include such functionality, but services like [Tailscale](https://tailscale.com/) or [ZeroTier](https://zerotier.com/) are also commonly used.
 
 ## URL Scheme
@@ -68,8 +71,3 @@ Many routers include such functionality, but services like [Tailscale](https://t
 The app registers an `evcc://` URL scheme.
 Use it to prefill the server setup or jump to a page via a link or QR code.
 See [evcc App](/en/reference/app) for the available links.
-
-## Perspectives
-
-With the native app, we've created the foundation for future features that aren't possible with the Web UI.
-Native push notifications or platform-specific features like widgets will follow sooner or later.

--- a/src/content/docs/en/features/loadmanagement.mdx
+++ b/src/content/docs/en/features/loadmanagement.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Load Management"
 sidebar:
-  order: 11
+  order: 12
 ---
 
 :::caution[Experimental]

--- a/src/content/docs/en/features/optimizer.mdx
+++ b/src/content/docs/en/features/optimizer.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Optimizer 🧪"
 sidebar:
-  order: 12
+  order: 13
 ---
 
 import Screenshot from "@components/Screenshot.astro";

--- a/src/content/docs/en/features/remote-access.mdx
+++ b/src/content/docs/en/features/remote-access.mdx
@@ -1,50 +1,26 @@
 ---
-title: "Remote Access 🧪"
+title: "Remote Access"
 sidebar:
-  order: 13
+  order: 11
 ---
 
 import { Steps } from "@astrojs/starlight/components";
+import SponsorInfoBox from "@components/SponsorInfoBox.astro";
 import statusImg from "@assets/features/remote-access/status.png";
 import clientsImg from "@assets/features/remote-access/clients.png";
 import clientCreatedImg from "@assets/features/remote-access/client-created.png";
 
-:::caution[Experimental]
-Remote Access is in development.
-Both behaviour and configuration may still change.
-:::
+Remote Access lets you reach your evcc instance from outside your home network, via the [evcc app](/en/features/app) or a browser.
+Your instance gets its own domain on `evcc.cloud`.
+Port forwarding, dynamic DNS, or a VPN are not required, because the instance establishes the connection outbound itself.
 
-Remote Access lets you reach your local evcc instance from anywhere.
-Each instance gets its own domain on `evcc.cloud`.
-You don't need dynamic DNS or a port forward in your router.
-
-```mermaid
-flowchart LR
-  subgraph internet [Internet]
-    app["evcc app"]
-    browser["browser"]
-    proxy["Remote Proxy<br/><code>___.evcc.cloud</code>"]
-  end
-  app <-- HTTPS --> proxy
-  browser <-- HTTPS --> proxy
-  proxy <-->|"secure websocket<br/><i>permanent</i>"| evcc["evcc instance<br/><code>evcc.local</code>"]
-```
-
-## How It Works
-
-Your app or browser connects to your personal domain on `evcc.cloud`.
-The Remote Proxy forwards the requests through a WebSocket tunnel to your local evcc instance.
-Your local instance opens that tunnel outbound itself, so no open port in your network is required.
+<SponsorInfoBox lang="en" type="feature" />
 
 ## Setup
 
-Remote Access requires an active [sponsorship](/en/sponsorship).
-
 <Steps>
 
-1. Enable the feature in the user interface:
-   - **Configuration → Experimental** → enable
-   - **Configuration → Remote Access 🧪** → enable
+1. Enable the feature under **Configuration → Remote Access**.
 
    <img
      src={statusImg.src}
@@ -52,7 +28,7 @@ Remote Access requires an active [sponsorship](/en/sponsorship).
      style={{ maxWidth: "500px" }}
    />
 
-2. Your evcc instance registers with the Remote Proxy and receives its own domain, e.g. `swift-dark-crow.evcc.cloud`.
+2. Your evcc instance connects to `evcc.cloud` and receives its own domain, e.g. `swift-dark-crow.evcc.cloud`.
 
    <img
      src={clientsImg.src}
@@ -111,7 +87,23 @@ Changes to the configuration, backups, logs, or a restart still require the admi
 Registration is verified against `sponsor.evcc.io`.
 Each sponsor receives exactly one domain, permanently bound to that sponsor and never reassigned.
 
-## Technical Background
+## Technical Details
+
+Your app or browser connects to your personal domain on `evcc.cloud`.
+The Remote Proxy forwards the requests through a WebSocket tunnel to your local evcc instance.
+Your local instance opens that tunnel outbound itself, so no open port in your network is required.
+
+```mermaid
+flowchart LR
+  subgraph internet [Internet]
+    app["evcc app"]
+    browser["browser"]
+    proxy["Remote Proxy<br/><code>___.evcc.cloud</code>"]
+  end
+  app <-- HTTPS --> proxy
+  browser <-- HTTPS --> proxy
+  proxy <-->|"secure websocket<br/><i>permanent</i>"| evcc["evcc instance<br/><code>evcc.local</code>"]
+```
 
 On first activation, the local evcc instance registers with the Remote Proxy.
 In exchange for the sponsor token, it receives a connection token and a randomly assigned domain.


### PR DESCRIPTION
Remote Access is no longer experimental.

The feature page now leads with what the feature does and how to set it up. Protocol details (tunnel, registration, multiplexing) and the architecture diagram moved into a technical section at the end.

- Remove experimental notice and 🧪 from the title; setup no longer goes through the experimental toggle
- Sponsor requirement shown via SponsorInfoBox (new `type="feature"` variant)
- German page renamed to "Remotezugriff" (matches UI wording)
- App page: remote access as primary option, VPN as alternative; outdated "Perspectives" section removed
- Sidebar: Remote Access placed directly after App