### PR TITLE
Use explicit heading ids instead of anchor elements

### DIFF
--- a/src/content/docs/de/faq.mdx
+++ b/src/content/docs/de/faq.mdx
@@ -20,9 +20,7 @@ Beide Methoden können auch parallel genutzt werden.
 
 Mehr Informationen findest du unter [Einrichtung](/de/installation/configuration).
 
-<a id="ui-migration"></a>
-
-### Ich habe eine evcc.yaml Konfiguration. Wie migriere ich zur Weboberfläche?
+### Ich habe eine evcc.yaml Konfiguration. Wie migriere ich zur Weboberfläche? \{#ui-migration\}
 
 Du kannst beide Konfigurationsmethoden parallel nutzen und schrittweise migrieren.
 
@@ -269,9 +267,7 @@ Das ist leider eine Einschränkung der Herstellerschnittstelle. PSA liefert vera
 
 ## Passwort
 
-<a id="password-reset"></a>
-
-### Ich habe mein Passwort vergessen. Wie kann ich es ändern?
+### Ich habe mein Passwort vergessen. Wie kann ich es ändern? \{#password-reset\}
 
 Das Passwort wird verschlüsselt gespeichert, daher kann es nicht ausgelesen werden.
 Du kannst über die Kommandozeile ein neues Passwort setzen.
@@ -360,7 +356,7 @@ Jetzt beginnt evcc wieder von null an die Vorhersagen zu akkumulieren.
 
 ## Statistische Daten
 
-### Telemetry & Community Daten
+### Telemetry & Community Daten \{#telemetry\}
 
 Auf der [evcc Webseite](https://evcc.io/#live) und im "Auswertung Ladeenergie" Dialog der evcc-UI zeigen wir aggregierte Live-Ladedaten der evcc-Installationen an. Wir sammeln diese Daten auf unserer zentralen api.evcc.io Instanz. Die Teilnahme daran ist selbstverständlich freiwillig.
 

--- a/src/content/docs/de/features/battery.mdx
+++ b/src/content/docs/de/features/battery.mdx
@@ -146,9 +146,7 @@ Dies kann durch den Schnell-Modus, smartes Netzladen, Ladeplanung oder Mindestla
 Der Sperrzustand gilt für den Zeitraum des Schnellladens.
 In dieser Zeit wird die Hausbatterie nicht entladen.
 
-<a id="gridcharge"></a>
-
-### Netzladen
+### Netzladen \{#gridcharge\}
 
 Szenario: Du hast einen dynamischen Stromtarif und möchtest deine Hausbatterie nachts mit günstigem Strom laden.
 Beispielsweise, weil der am Tag erzeugte Überschuss nicht ausreicht.

--- a/src/content/docs/de/installation/configuration.mdx
+++ b/src/content/docs/de/installation/configuration.mdx
@@ -52,9 +52,7 @@ Zusätzlich kannst du verschiedene Dienste und Protokolle einbinden:
 - **Sunny Home Manager**: Integration via SEMP-Protokoll
 - **Externe Begrenzung**: Leistungsbegrenzung durch Netzbetreiber (§ 14a EnWG, § 9 EEG) oder übergeordnete Energiemanagementsysteme
 
-<a id="backup"></a>
-
-### Sichern & Wiederherstellen
+### Sichern & Wiederherstellen \{#backup\}
 
 Die Weboberfläche bietet integrierte Funktionen für Datensicherung:
 

--- a/src/content/docs/de/installation/docker.mdx
+++ b/src/content/docs/de/installation/docker.mdx
@@ -259,9 +259,7 @@ Falls ein neues Image vorhanden ist, startet das folgende Kommando den Container
 sudo docker compose up -d
 ```
 
-<a id="test"></a>
-
-## Testen
+## Testen \{#test\}
 
 Hast du deinen Container erfolgreich erstellt und gestartet, kannst du die evcc Web UI unter `http://<host>:7070` aufrufen.
 `<host>` ist hier die IP-Adresse oder der Hostname des Computers, auf dem der Container läuft.

--- a/src/content/docs/de/installation/linux-image.mdx
+++ b/src/content/docs/de/installation/linux-image.mdx
@@ -69,9 +69,7 @@ Fertig vorkonfiguriert und einfach über die Web UI einzurichten!
 Systemkonfiguration und Updates funktionieren über [Cockpit](#cockpit).
 Melde dich dort einmal an, um das Standard-Linux-Passwort zu ändern.
 
-<a id="wifi"></a>
-
-## WLAN einrichten
+## WLAN einrichten \{#wifi\}
 
 Falls kein Netzwerkkabel vorhanden ist, erstellt der Raspberry Pi einen WLAN-Hotspot für die Ersteinrichtung.
 
@@ -84,9 +82,7 @@ Falls kein Netzwerkkabel vorhanden ist, erstellt der Raspberry Pi einen WLAN-Hot
 
 Die WLAN-Konfiguration kann auch später über [Cockpit](#cockpit) vorgenommen werden.
 
-<a id="cockpit"></a>
-
-## Systemverwaltung via Cockpit
+## Systemverwaltung via Cockpit \{#cockpit\}
 
 Cockpit ist eine grafische Systemverwaltung für Linux.
 Hier kannst du dein System konfigurieren, Updates installieren und Netzwerkeinstellungen ändern.

--- a/src/content/docs/de/installation/linux.mdx
+++ b/src/content/docs/de/installation/linux.mdx
@@ -141,9 +141,7 @@ Mit folgendem Befehl kann man auf eine ältere Version von evcc wechseln:
 sudo apt install evcc=x.xxx.x # Versionsnummer
 ```
 
-<a id="systemd"></a>
-
-## Systemdienst
+## Systemdienst \{#systemd\}
 
 evcc läuft als Systemdienst im Hintergrund. Mit folgenden Befehlen kann dieser Dienst gesteuert werden.
 
@@ -217,9 +215,7 @@ yaml kopieren: `sudo cp /etc/evcc.yaml /home/pi/evcc.yaml.bak`
 
 db kopieren: `sudo cp /var/lib/evcc/evcc.db /home/pi/evcc.db.bak`
 
-<a id="environment-variables"></a>
-
-## Umgebungsvariablen & CLI-Optionen
+## Umgebungsvariablen & CLI-Optionen \{#environment-variables\}
 
 Bei der Installation über APT läuft evcc als systemd-Dienst.
 Du kannst das Verhalten über eine Override-Datei anpassen:
@@ -258,9 +254,7 @@ Alle Parameter aus `evcc.yaml` können als Umgebungsvariable gesetzt werden: `EV
 Eine vollständige Liste aller CLI-Optionen findest du in der [CLI-Dokumentation](/de/reference/cli/evcc).
 :::
 
-<a id="manual"></a>
-
-## Manuelle Installation
+## Manuelle Installation \{#manual\}
 
 Neben dem Debian/Ubuntu APT Paket, stellen wir auch weitere Binaries für Linux bereit.
 

--- a/src/content/docs/de/installation/macos.mdx
+++ b/src/content/docs/de/installation/macos.mdx
@@ -97,9 +97,7 @@ brew services restart evcc
   tail -f /opt/homebrew/var/log/evcc.log
   ```
 
-<a id="manual"></a>
-
-## Manuelle Installation
+## Manuelle Installation \{#manual\}
 
 Hier findest du die Anleitung für die manuelle Installation von evcc auf macOS.
 

--- a/src/content/docs/de/reference/plugins.mdx
+++ b/src/content/docs/de/reference/plugins.mdx
@@ -65,11 +65,7 @@ Der Attributname (z. B. `power`, `enable`, `soc`) bestimmt die Rolle; `source` w
 Jedes Plugin wird entweder in einem **lesenden** oder einem **schreibenden** Kontext verwendet. Einige Parameter sind nur in einem der beiden Modi sinnvoll.
 Die vollständigen Attribut-Listen für Zähler, Wallboxen, Fahrzeuge und Tarife findest du unter [Eigene Geräte](/de/user-defined-devices).
 
-<a id="lesen"></a>
-
-<a id="reading"></a>
-
-### Lesen
+### Lesen \{#reading\}
 
 Beim Lesen von Daten mithilfe eines Plugins können sogenannte _Pipelines_ verwendet werden.
 Damit können Daten aus der Ausgabe des Plugins fein granular extrahiert werden.
@@ -83,9 +79,7 @@ Mögliche Parameter für die Datenextraktion sind:
 - `unpack`: Konvertiert Werte aus anderen Zahlenrepräsentationen, z. B. `hex`.
 - `decode`: Dekodiert Binärformate wie `uint32`, `float32` etc.
 
-<a id="known-errors"></a>
-
-#### Bekannte Fehlerwerte
+#### Bekannte Fehlerwerte \{#known-errors\}
 
 [HTTP](#http)-, [MQTT](#mqtt)- und [Websocket](#websocket)-Plugins können spezielle Fehlerwerte als String zurückgeben.
 evcc erkennt diese und wandelt sie in interne Fehlercodes um, anstatt sie als Daten zu behandeln.
@@ -98,9 +92,7 @@ Das ist z. B. nützlich für eigene Fahrzeugintegrationen, bei denen die Datenqu
 Wenn ein Plugin z. B. den String `ErrAsleep` als Antwort liefert, erzeugt evcc intern den entsprechenden Fehler.
 Das [Error Plugin](#error) nutzt denselben Mechanismus, um einen festen Fehlerwert als Konstante zurückzugeben.
 
-<a id="schreiben"></a>
-
-### Schreiben
+### Schreiben \{#writing\}
 
 Beim Schreiben können Parameter in der Konfiguration durch Platzhalter ersetzt werden.
 Die Daten werden in Form von `${var[:format]}` zur Verfügung gestellt.
@@ -110,9 +102,7 @@ Zusätzlich können sämtliche Funktionen der Go Template Library verwendet werd
 
 ## Plugins
 
-<a id="gpio"></a>
-
-### GPIO <Badge text="lesen" variant="tip" size="small" /> <Badge text="schreiben" variant="caution" size="small" />
+### GPIO <Badge text="lesen" variant="tip" size="small" /> <Badge text="schreiben" variant="caution" size="small" /> \{#gpio\}
 
 Das `gpio` Plugin ermöglicht den direkten Zugriff auf GPIO-Pins (General Purpose Input/Output) unter Linux.
 Es ist besonders für Raspberry Pi und ähnliche Einplatinencomputer geeignet.
@@ -152,9 +142,7 @@ pin: 27 # BCM pin number
 Dieses Plugin funktioniert nur auf Linux-Systemen mit Zugriff auf `/dev/gpiomem`.
 :::
 
-<a id="go"></a>
-
-### Go <Badge text="lesen" variant="tip" size="small" /> <Badge text="schreiben" variant="caution" size="small" />
+### Go <Badge text="lesen" variant="tip" size="small" /> <Badge text="schreiben" variant="caution" size="small" /> \{#go\}
 
 Das `go` Plugin verwendet den [Yaegi](https://github.com/traefik/yaegi) Interpreter, um Go Code zur Laufzeit auszuführen.
 Es ist besonders nützlich für typsichere Berechnungen und komplexe Datenverarbeitungslogik.
@@ -211,9 +199,7 @@ maxcurrent:
     // maxcurrent Variable ist automatisch verfügbar
 ```
 
-<a id="transformations"></a>
-
-#### Input- und Output-Transformationen
+#### Input- und Output-Transformationen \{#transformations\}
 
 Die `go` und `js` Plugins unterstützen `in` und `out` Parameter, um Daten aus anderen Quellen als Variablen im Script zu verwenden bzw. das Ergebnis an andere Plugins weiterzuleiten.
 
@@ -269,9 +255,7 @@ maxcurrent:
         topic: heater/target_power
 ```
 
-<a id="http"></a>
-
-### HTTP <Badge text="lesen" variant="tip" size="small" /> <Badge text="schreiben" variant="caution" size="small" />
+### HTTP <Badge text="lesen" variant="tip" size="small" /> <Badge text="schreiben" variant="caution" size="small" /> \{#http\}
 
 Das `http`-Plugin führt HTTP Aufrufe durch, um Daten zu lesen oder zu aktualisieren.
 Es beinhaltet auch die Fähigkeit, JSON-Datenstrukturen über jq-Abfragen (z. B. für REST-APIs) zu lesen oder einfache Transformationen durchzuführen.
@@ -372,9 +356,7 @@ enable:
   uri: "http://charger/relay/0?turn={{if .enable}}on{{else}}off{{end}}"
 ```
 
-<a id="javascript"></a>
-
-### JavaScript <Badge text="lesen" variant="tip" size="small" /> <Badge text="schreiben" variant="caution" size="small" />
+### JavaScript <Badge text="lesen" variant="tip" size="small" /> <Badge text="schreiben" variant="caution" size="small" /> \{#javascript\}
 
 evcc integriert einen JavaScript Interpreter mit der [Underscore.js](https://underscorejs.org) Bibliothek, welche direkt über `_.` zugreifbar ist, z. B. `_.random(0,5)`.
 Das `js` Plugin kann JavaScript code über den `script` Parameter ausführen. Sehr hilfreich für das schnelle Erstellen von Prototypen:
@@ -401,9 +383,7 @@ maxcurrent:
 
 Das `js` Plugin unterstützt dieselben [Input- und Output-Transformationen](#transformations) (`in`/`out`) wie das `go` Plugin.
 
-<a id="modbus"></a>
-
-### Modbus <Badge text="lesen" variant="tip" size="small" /> <Badge text="schreiben" variant="caution" size="small" />
+### Modbus <Badge text="lesen" variant="tip" size="small" /> <Badge text="schreiben" variant="caution" size="small" /> \{#modbus\}
 
 Das `modbus`-Plugin kann Daten von jedem Modbus-fähigen Gerät oder SunSpec-kompatiblen Wechselrichter lesen.
 Viele Strommessgeräte sind bereits vorkonfiguriert (siehe [MBMD Supported Devices](https://github.com/volkszaehler/mbmd#supported-devices)).
@@ -423,9 +403,7 @@ register:
 
 Schaue in die [Modbus Dokumentation](/de/reference/modbus) für weitere Details.
 
-<a id="mqtt"></a>
-
-### MQTT <Badge text="lesen" variant="tip" size="small" /> <Badge text="schreiben" variant="caution" size="small" />
+### MQTT <Badge text="lesen" variant="tip" size="small" /> <Badge text="schreiben" variant="caution" size="small" /> \{#mqtt\}
 
 Das `mqtt`-Plugin ermöglicht das Lesen von Werten über MQTT-Topics.
 Das ist insbesondere für Strommessgeräte nützlich, z. B. wenn diese ihre Daten bereits über MQTT bereitstellen.
@@ -443,7 +421,7 @@ Das Plugin gibt einen Fehler zurück, wenn innerhalb der `timeout` Dauer kein ne
 Wenn `timeout` nicht gesetzt ist, werden Werte beliebigen Alters akzeptiert, sobald die erste Nachricht empfangen wurde.
 Es wird empfohlen, einen Timeout zu setzen, um zu erkennen, wenn die Quelle keine aktuellen Daten mehr liefert.
 
-Für die Datenextraktion stehen die unter [Lesen](#lesen) beschriebenen Pipeline-Parameter zur Verfügung (`regex`, `jq`, `quote`, etc.).
+Für die Datenextraktion stehen die unter [Lesen](#reading) beschriebenen Pipeline-Parameter zur Verfügung (`regex`, `jq`, `quote`, etc.).
 
 **Beispiel Lesen**:
 
@@ -472,9 +450,7 @@ topic: mbmd/charger/maxcurrent
 payload: ${var:%d}
 ```
 
-<a id="prometheus"></a>
-
-### Prometheus <Badge text="lesen" variant="tip" size="small" />
+### Prometheus <Badge text="lesen" variant="tip" size="small" /> \{#prometheus\}
 
 Das `prometheus` Plugin liest Metriken aus einer Prometheus-Instanz über PromQL-Abfragen.
 Dies ist nützlich, wenn bereits Monitoring-Daten in Prometheus vorliegen, die in evcc verwendet werden sollen.
@@ -514,9 +490,7 @@ energy:
 Die Abfrage muss einen einzelnen numerischen Wert zurückgeben.
 Bei Vektor-Ergebnissen muss genau eine Metrik enthalten sein.
 
-<a id="shell"></a>
-
-### Shell Script <Badge text="lesen" variant="tip" size="small" /> <Badge text="schreiben" variant="caution" size="small" />
+### Shell Script <Badge text="lesen" variant="tip" size="small" /> <Badge text="schreiben" variant="caution" size="small" /> \{#shell\}
 
 Das `script` Plugin führt externe Skripte zum Lesen oder Aktualisieren von Daten aus. Das Plugin ist hilfreich um jede Art von externer Funktionalität einzubinden.
 
@@ -536,9 +510,7 @@ cmd: /home/user/my-script.sh ${enable:%b} # format boolean enable as 0/1
 timeout: 5s
 ```
 
-<a id="speedwire"></a>
-
-### SMA/Speedwire <Badge text="lesen" variant="tip" size="small" />
+### SMA/Speedwire <Badge text="lesen" variant="tip" size="small" /> \{#speedwire\}
 
 Das `sma` Plugin bietet eine Schnittstelle zu SMA Geräten, welche das Speedwire Protokoll beherrschen.
 
@@ -558,15 +530,13 @@ Unterstützte Werte für `value` können in der Diagnoseausgabe über das Komman
 
 Alle möglichen Werte können als Konstanten [hier](https://gitlab.com/bboehmke/sunny/-/blob/master/values.go#L24) gefunden werden (verwende den Namen der Konstante für `value`).
 
-<a id="websocket"></a>
-
-### Websocket <Badge text="lesen" variant="tip" size="small" />
+### Websocket <Badge text="lesen" variant="tip" size="small" /> \{#websocket\}
 
 Das `websocket`-Plugin bietet einen WebSocket-Listener.
 Es beinhaltet auch die Fähigkeit, JSON-Datenstrukturen über jq-ähnliche Abfragen zu lesen oder zu parsen.
 Dies kann z. B. verwendet werden, um Daten von Volkszählers Push Server zu empfangen.
 
-Für die Datenextraktion stehen die unter [Lesen](#lesen) beschriebenen Pipeline-Parameter zur Verfügung (`regex`, `jq`, `quote`, etc.).
+Für die Datenextraktion stehen die unter [Lesen](#reading) beschriebenen Pipeline-Parameter zur Verfügung (`regex`, `jq`, `quote`, etc.).
 
 **Beispiel Lesen**:
 
@@ -580,9 +550,7 @@ timeout: 30s # error if no update received in 30 seconds
 
 ## Helpers
 
-<a id="calc"></a>
-
-### Calc <Badge text="lesen" variant="tip" size="small" />
+### Calc <Badge text="lesen" variant="tip" size="small" /> \{#calc\}
 
 Das `calc` Plugin erlaubt es mehrere Einzelwerte mathematisch weiterzuverarbeiten:
 
@@ -632,9 +600,7 @@ Das `calc` Plugin ist hilfreich um z. B.
 Konstante Hilfswerte (z. B. für Offsets) lassen sich mithilfe des `const` Plugins als Operand erzeugen.
 :::
 
-<a id="combined"></a>
-
-### Combined <Badge text="lesen" variant="tip" size="small" />
+### Combined <Badge text="lesen" variant="tip" size="small" /> \{#combined\}
 
 Das `combined` Status Plugin wird verwendet um gemischte Boolean Status Werte von `Plugged` (angeschlossen) / `Charging` (Laden) in einen evcc-kompatiblen Ladestatus von A..F zu konvertieren.
 Es wird z.b. zusammen mit einer OpenWB MQTT Integration verwendet.
@@ -651,9 +617,7 @@ charging:
   topic: openWB/lp/1/boolChargeStat
 ```
 
-<a id="const"></a>
-
-### Const <Badge text="lesen" variant="tip" size="small" />
+### Const <Badge text="lesen" variant="tip" size="small" /> \{#const\}
 
 Das `const` Plugin gibt einen konstanten Wert zurück.
 Es eignet sich z. B. um in Verbindung mit dem `calc` Plugin feste Korrekturwerte (Offset) auf einen variablen Wert anzuwenden oder auch zur Simulation von Mess- und Statuswerten zu Testzwecken.
@@ -665,9 +629,7 @@ source: const
 value: -16247
 ```
 
-<a id="error"></a>
-
-### Error <Badge text="lesen" variant="tip" size="small" />
+### Error <Badge text="lesen" variant="tip" size="small" /> \{#error\}
 
 Das `error` Plugin gibt immer einen [bekannten Fehlerwert](#known-errors) zurück.
 Es ist nützlich, um ein nicht implementiertes Attribut als explizit nicht verfügbar zu kennzeichnen.
@@ -686,9 +648,7 @@ soc:
   error: ErrNotAvailable
 ```
 
-<a id="convert"></a>
-
-### Convert <Badge text="schreiben" variant="caution" size="small" />
+### Convert <Badge text="schreiben" variant="caution" size="small" /> \{#convert\}
 
 Das `convert` Plugin konvertiert Datentypen beim Schreiben.
 Es wird verwendet, wenn ein Plugin einen anderen Datentyp erwartet als evcc liefert.
@@ -727,9 +687,7 @@ limitsoc:
 
 In diesem Beispiel konvertiert evcc einen Float-Wert wie `85.5` in `85` bevor er an das Modbus-Register geschrieben wird.
 
-<a id="delta"></a>
-
-### Delta <Badge text="schreiben" variant="caution" size="small" />
+### Delta <Badge text="schreiben" variant="caution" size="small" /> \{#delta\}
 
 Das `delta` Plugin wandelt absolute Werte in Änderungswerte (Deltas) um.
 Es wird für Geräte verwendet, die geschriebene Werte zu einem internen Summenwert addieren, anstatt sie direkt zu setzen.
@@ -813,9 +771,7 @@ setmaxpower:
         decode: uint16
 ```
 
-<a id="ignore"></a>
-
-### Ignore <Badge text="schreiben" variant="caution" size="small" />
+### Ignore <Badge text="schreiben" variant="caution" size="small" /> \{#ignore\}
 
 Das `ignore` Plugin unterdrückt spezifische Fehlermeldungen beim Schreiben.
 Es wird verwendet, wenn ein Gerät harmlose Fehler zurückgibt, die ignoriert werden können.
@@ -861,9 +817,7 @@ batterymode:
 
 In diesem Beispiel gibt das Gerät einen harmlosen Modbus-Fehler zurück, der ignoriert wird.
 
-<a id="ifelse"></a>
-
-### IfElse <Badge text="schreiben" variant="caution" size="small" />
+### IfElse <Badge text="schreiben" variant="caution" size="small" /> \{#ifelse\}
 
 Das `ifelse` Plugin führt bedingte Schreibvorgänge mit zwei Zweigen aus.
 Je nach Eingabewert wird entweder das `if` oder das `else` Plugin ausgeführt.
@@ -897,9 +851,7 @@ enable:
     method: POST
 ```
 
-<a id="map"></a>
-
-### Map <Badge text="lesen" variant="tip" size="small" /> <Badge text="schreiben" variant="caution" size="small" />
+### Map <Badge text="lesen" variant="tip" size="small" /> <Badge text="schreiben" variant="caution" size="small" /> \{#map\}
 
 Das `map` Plugin übersetzt Integer-Werte in andere Integer-Werte mithilfe einer Lookup-Tabelle.
 Es wird häufig verwendet, um gerätespezifische Werte in evcc-Standardwerte zu konvertieren und umgekehrt.
@@ -969,9 +921,7 @@ setmode:
       encoding: int16
 ```
 
-<a id="meter-plugin"></a>
-
-### Meter <Badge text="lesen" variant="tip" size="small" />
+### Meter <Badge text="lesen" variant="tip" size="small" /> \{#meter-plugin\}
 
 Das `meter` Plugin ermöglicht es, ein anderes Messgerät als Datenquelle zu verwenden.
 Dies ist nützlich, wenn man ein bestehendes Gerät für mehrere Messwerte verwenden möchte oder wenn man verschiedene Methoden eines Geräts für unterschiedliche Attribute nutzen will.
@@ -1011,9 +961,7 @@ meters:
 
 In diesem Beispiel wird ein Shelly 1PM Gerät als Datenquelle für Leistung und Energie einer Batterie verwendet, während der Ladestand (SoC) über MQTT abgerufen wird.
 
-<a id="sequence"></a>
-
-### Sequence <Badge text="schreiben" variant="caution" size="small" />
+### Sequence <Badge text="schreiben" variant="caution" size="small" /> \{#sequence\}
 
 Das `sequence` Plugin führt mehrere Schreibvorgänge nacheinander aus.
 Alle verschachtelten Plugins erhalten denselben Eingabewert und werden in der definierten Reihenfolge ausgeführt.
@@ -1104,9 +1052,7 @@ batterymode:
 
 Der Wert fließt durch alle Plugins, wobei `switch` unterschiedliche Aktionen basierend auf dem Wert ausführt und `mqtt` am Ende immer benachrichtigt wird.
 
-<a id="sleep"></a>
-
-### Sleep <Badge text="schreiben" variant="caution" size="small" />
+### Sleep <Badge text="schreiben" variant="caution" size="small" /> \{#sleep\}
 
 Das `sleep` Plugin fügt eine Verzögerung ein.
 Wird typischerweise innerhalb eines `sequence` Plugins verwendet, um zeitliche Abstände zwischen Aktionen zu schaffen.
@@ -1133,9 +1079,7 @@ setmode:
       method: POST
 ```
 
-<a id="switch"></a>
-
-### Switch <Badge text="schreiben" variant="caution" size="small" />
+### Switch <Badge text="schreiben" variant="caution" size="small" /> \{#switch\}
 
 Das `switch` Plugin führt bedingte Schreibvorgänge durch, ähnlich einer switch/case-Anweisung in Programmiersprachen.
 Basierend auf dem Eingabewert wird die entsprechende Aktion ausgeführt.
@@ -1179,9 +1123,7 @@ setmode:
         body: "boost"
 ```
 
-<a id="valid"></a>
-
-### Valid <Badge text="lesen" variant="tip" size="small" />
+### Valid <Badge text="lesen" variant="tip" size="small" /> \{#valid\}
 
 Das `valid` Plugin ermöglicht es, Plugin-Werte basierend auf einer booleschen Validierung bereitzustellen.
 Es trennt die Gültigkeit eines Werts von dessen eigenem Inhalt.
@@ -1204,9 +1146,7 @@ value:
 In diesem Beispiel wird der Wert nur verwendet, wenn das `valid` Topic `true` zurückgibt.
 Wenn es `false` zurückgibt, wird der Wert als nicht verfügbar markiert.
 
-<a id="watchdog"></a>
-
-### Watchdog <Badge text="schreiben" variant="caution" size="small" />
+### Watchdog <Badge text="schreiben" variant="caution" size="small" /> \{#watchdog\}
 
 Das `watchdog` Plugin ist ein Wrapper-Plugin, das Schreibvorgänge automatisch in regelmäßigen Abständen wiederholt.
 Manche Geräte (z. B. Batteriespeicher, Wechselrichter) erwarten, dass Steuerbefehle regelmäßig wiederholt werden, um aktiv zu bleiben.

--- a/src/content/docs/de/reference/white-label.mdx
+++ b/src/content/docs/de/reference/white-label.mdx
@@ -8,9 +8,7 @@ import { Tabs, TabItem } from "@astrojs/starlight/components";
 Du kannst deine evcc-Instanz unter eigener Marke ausliefern: mit deinem Logo, deinen Kontaktdaten und deinem Farbschema.
 Diese Seite richtet sich an Installateure und Anbieter, die vorkonfigurierte Geräte oder gehostete Installationen an ihre Kunden liefern.
 
-<a id="custom-css"></a>
-
-## Farben und Schriften
+## Farben und Schriften \{#custom-css\}
 
 Neben Logo und Namen kannst du auch Farben und Schriften an deine Marke anpassen.
 `EVCC_CUSTOM_CSS` verweist auf eine CSS-Datei, die zusätzlich zu den Standard-Styles geladen wird.
@@ -43,9 +41,7 @@ Ein paar Dinge solltest du beachten:
 - Teste deine Styles im hellen und dunklen Modus.
 - Achte auf ausreichende Kontraste, z. B. bei Text auf deiner Primärfarbe.
 
-<a id="brand"></a>
-
-## Markenname und Logo
+## Markenname und Logo \{#brand\}
 
 | Variable                 | Wirkung                        |
 | ------------------------ | ------------------------------ |
@@ -77,9 +73,7 @@ Ein Klick auf den Markennamen im Menü öffnet den Version-Dialog mit deinem Log
   caption="Version-Dialog mit eigenem Logo und Kontaktdaten"
 />
 
-<a id="problem-reports"></a>
-
-## Probleme melden
+## Probleme melden \{#problem-reports\}
 
 Unter **Hilfe benötigt? → Problem melden** können Nutzer Fehler melden und Fragen stellen.
 Standardmäßig öffnet die Seite eine vorbefüllte GitHub Discussion oder ein GitHub Issue.
@@ -95,9 +89,7 @@ Bitte deine Nutzer bei Bedarf, die Debug-Datei auf derselben Seite herunterzulad
 
 Der Hilfe-Dialog zeigt außerdem einen **Kontakt aufnehmen**-Button statt des Links zu den **GitHub Discussions**.
 
-<a id="configuration"></a>
-
-## Konfiguration
+## Konfiguration \{#configuration\}
 
 Jede Einstellung ist eine Umgebungsvariable.
 Dieselben Einstellungen gibt es auch als [CLI-Optionen](/de/reference/cli/evcc#options), z. B. `--custom-brand` für `EVCC_CUSTOM_BRAND`.
@@ -156,17 +148,13 @@ services:
 
 Auch die restliche Konfiguration lässt sich über Umgebungsvariablen setzen: `EVCC_` gefolgt vom Parameternamen aus der `evcc.yaml` in Großbuchstaben, z. B. `EVCC_NETWORK_HOST` oder `EVCC_DATABASE_DSN`.
 
-<a id="custom-image"></a>
-
-## Eigenes Image
+## Eigenes Image \{#custom-image\}
 
 Um ein komplettes SD-Karten-Image mit deinem Branding auszuliefern, forke das Repository [evcc-io/images](https://github.com/evcc-io/images).
 Das Skript [`userpatches/customize-image.sh`](https://github.com/evcc-io/images/blob/main/userpatches/customize-image.sh) konfiguriert evcc während des Image-Builds.
 Im Abschnitt _EVCC SETUP_ schreibt es die systemd-Override-Datei, dort gehören deine `Environment="EVCC_CUSTOM_..."`-Zeilen hin.
 
-<a id="licensing"></a>
-
-## Lizenz
+## Lizenz \{#licensing\}
 
 Das offizielle Binary oder Docker-Image an Kunden auszuliefern oder zu verkaufen ist ausdrücklich in Ordnung.
 Halte dich dabei an die [Sponsoring-Bedingungen](/de/sponsorship) und die [Lizenz](https://github.com/evcc-io/evcc#license).

--- a/src/content/docs/de/sponsorship.mdx
+++ b/src/content/docs/de/sponsorship.mdx
@@ -66,9 +66,7 @@ Auch signifikante Beiträge zur [Dokumentation](https://github.com/evcc-io/docs)
 Als Contributor zum Projekt stellen wir dir gerne ein unbefristetes Unterstützertoken aus.
 Schreib uns dafür [eine kurze Mail](mailto:info@evcc.io) mit deinem GitHub-Namen.
 
-<a id="trial"></a>
-
-## Testtoken
+## Testtoken \{#trial\}
 
 Du setzt evcc zum ersten Mal auf und würdest gerne prüfen, ob alle deine Geräte funktionieren?
 Dafür kannst du das Testtoken hier verwenden.

--- a/src/content/docs/de/user-defined-devices.mdx
+++ b/src/content/docs/de/user-defined-devices.mdx
@@ -73,9 +73,7 @@ features:
 
 Welche Attribut-Namen und Feature-Flags verfügbar sind, hängt vom Gerätetyp ab und steht in den nachfolgenden Abschnitten.
 
-<a id="meter"></a>
-
-## Zähler
+## Zähler \{#meter\}
 
 Stromzähler werden in der Sektion [`meters`](/de/reference/configuration/meters) konfiguriert.
 Zähler unter `meters:` können an verschiedenen Stellen innerhalb der `site` Konfiguration referenziert werden:
@@ -111,9 +109,7 @@ Zur Konvertierung dienen die [Lese-Pipelines](/de/reference/plugins#reading).
 | `currents`     | `[float,float,float]` | nein      | alle          | Phasenströme in A. Zur Erkennung aktiver Phasen.                            |
 | `voltages`     | `[float,float,float]` | nein      | alle          | Phasenspannungen in V. Zur Anschlusserkennung (1p/3p).                      |
 
-<a id="signs-and-directions"></a>
-
-### Vorzeichen und Richtungen
+### Vorzeichen und Richtungen \{#signs-and-directions\}
 
 Was ein positiver `power`-Wert und die beiden Energierichtungen bedeuten, hängt von der Zählerrolle ab:
 
@@ -153,9 +149,7 @@ power:
   jq: .data.tuples[0][1]
 ```
 
-<a id="charger"></a>
-
-## Wallbox
+## Wallbox \{#charger\}
 
 Der Standardtyp `type: custom` deckt Wallboxen mit stufenloser Stromregelung ab.
 Für andere Geräte stehen spezialisierte Charger-Typen unter [Switchsocket](#charger-switchsocket) und [Wärmepumpen](#charger-heating) bereit.
@@ -190,9 +184,7 @@ Für andere Geräte stehen spezialisierte Charger-Typen unter [Switchsocket](#ch
 | `phases1p3p`       | `int`   | nein      | Phasenumschaltung durchführen (erfordert `tos: true`) |
 | `wakeup`           | `bool`  | nein      | Wecke Fahrzeug auf                                    |
 
-<a id="charger-features"></a>
-
-### Features
+### Features \{#charger-features\}
 
 | Feature            | Beschreibung                                                                                                                                                                                                                                              |
 | ------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -258,9 +250,7 @@ enable:
   payload: ON
 ```
 
-<a id="charger-switchsocket"></a>
-
-### Switchsocket
+### Switchsocket \{#charger-switchsocket\}
 
 **`type: switchsocket`**
 
@@ -277,9 +267,7 @@ Vollständige Einrichtung unter [Schaltbare Steckdosen](/de/smartswitches).
 | `enable`       | `bool`  | ja        | Steckdose ein-/ausschalten                                                                              |
 | `standbypower` | `float` | nein      | Schwellwert in W. Darüber: Laden, darunter: Standby. Negativ: statisch (keine Leistungsmessung möglich) |
 
-<a id="charger-heating"></a>
-
-### Wärmepumpen
+### Wärmepumpen \{#charger-heating\}
 
 Für Wärmepumpen und vergleichbare Heizgeräte gibt es eigene Charger-Typen mit jeweils eigenen Attributen.
 Die vollständige Einrichtung ist unter [Wärmepumpen, Heizstäbe](/de/heating) beschrieben.
@@ -339,9 +327,7 @@ Jeder Kontakt wird über einen eigenen Sub-Charger geschaltet, referenziert per 
   </TabItem>
 </Tabs>
 
-<a id="vehicle"></a>
-
-## Fahrzeug
+## Fahrzeug \{#vehicle\}
 
 Fahrzeugparameter können ebenfalls über Plugins ausgelesen werden.
 
@@ -374,9 +360,7 @@ Fahrzeugparameter können ebenfalls über Plugins ausgelesen werden.
 | `capacity` | `float`  | nein      | Batteriekapazität in kWh       |
 | `icon`     | `string` | nein      | Icon in der Benutzeroberfläche |
 
-<a id="vehicle-features"></a>
-
-### Features
+### Features \{#vehicle-features\}
 
 | Feature         | Beschreibung                                                                                                                                                  |
 | --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -420,9 +404,7 @@ onIdentify:
 
 Verfügbare Modi sind: `off`, `now`, `minpv`, `pv`.
 
-<a id="tariff"></a>
-
-## Tarif und Vorhersage
+## Tarif und Vorhersage \{#tariff\}
 
 Ein benutzerdefinierter Tarif bindet eine eigene Wertquelle über den Plugin-Mechanismus an.
 Das Attribut `tariff` legt fest, was die Quelle liefert und in welcher Einheit.
@@ -448,9 +430,7 @@ Die Attribute `price` und `forecast` schließen sich gegenseitig aus. Genau eine
 | `interval`     | `duration` | nein      | Abfrageintervall für `forecast`. Standard `1h`.                                                                                                                                                                   |
 | `cache`        | `duration` | nein      | Cache-Dauer für `price`. Standard `15m`.                                                                                                                                                                          |
 
-<a id="tariff-features"></a>
-
-### Features
+### Features \{#tariff-features\}
 
 | Feature     | Beschreibung                                                                                                                |
 | ----------- | --------------------------------------------------------------------------------------------------------------------------- |
@@ -529,9 +509,7 @@ formula: factor := 1.0; if price < 0 { factor = 0.0 }; factor * 0.07
 
 Zahlt eine feste Einspeisevergütung von 7 ct/kWh, außer wenn der Börsenstrompreis negativ ist.
 
-<a id="external-limit"></a>
-
-## Externe Begrenzung
+## Externe Begrenzung \{#external-limit\}
 
 Eine benutzerdefinierte Integration für die [Externe Begrenzung](/de/external-limit) bindet eine Steuerbox oder ein Energiemanagementsystem an, das nicht durch eine integrierte Integration abgedeckt ist.
 Wähle dazu in der Oberfläche unter **Konfiguration → Externe Begrenzung** die Option **Benutzerdefinierte Integration**.
@@ -624,9 +602,7 @@ limit:
 </TabItem>
 </Tabs>
 
-<a id="external-limit-fnn"></a>
-
-### FNN-Steuerbox
+### FNN-Steuerbox \{#external-limit-fnn\}
 
 Steuerboxen nach FNN-Standard signalisieren Dimmung und Abregelung über separate Schaltkontakte.
 Dimmung des Verbrauchs (W4) und Abregelung der Einspeisung (W3, S2, S1) arbeiten unabhängig voneinander.
@@ -667,9 +643,7 @@ s1:
   pin: 23
 ```
 
-<a id="external-limit-eebus"></a>
-
-### EEBus
+### EEBus \{#external-limit-eebus\}
 
 Die digitale Anbindung über das EEBus-Protokoll.
 Die Steuerbox kommuniziert direkt mit deiner evcc-Instanz und übermittelt das Leistungslimit automatisch.
@@ -690,9 +664,7 @@ type: eebus
 ski: "1234-5678-90AB-CDEF" # SKI der Steuerbox
 ```
 
-<a id="external-limit-custom"></a>
-
-### Custom
+### Custom \{#external-limit-custom\}
 
 Die generische Integration für Steuerungssysteme, die dynamische Limitwerte statt Schaltkontakten liefern.
 Verbrauchslimit und Abregelung der Einspeisung werden über Plugins ausgelesen und arbeiten unabhängig voneinander.
@@ -719,9 +691,7 @@ curtailedPercent:
 productionNominalMax: 10000 # Installierte Generatorleistung (Wp)
 ```
 
-<a id="notification-service"></a>
-
-## Benachrichtigungsdienst
+## Benachrichtigungsdienst \{#notification-service\}
 
 Ein benutzerdefinierter Benachrichtigungsdienst verarbeitet [Benachrichtigungen](/de/notifications) über ein beliebiges [Plugin](/de/reference/plugins) mit Schreibzugriff, z. B. ein Shell-Skript, einen HTTP-Aufruf oder eine MQTT-Nachricht.
 Wähle dazu in der Oberfläche unter **Konfiguration → Benachrichtigungen → Dienste** die Option **Benutzerdefinierter Dienst**.

--- a/src/content/docs/en/faq.mdx
+++ b/src/content/docs/en/faq.mdx
@@ -20,9 +20,7 @@ Both methods can also be used in parallel.
 
 More information can be found under [Configuration](/en/installation/configuration).
 
-<a id="ui-migration"></a>
-
-### I have an evcc.yaml configuration. How do I migrate to the web interface?
+### I have an evcc.yaml configuration. How do I migrate to the web interface? \{#ui-migration\}
 
 You can use both configuration methods in parallel and migrate step by step.
 
@@ -277,9 +275,7 @@ Sadly,
 
 ## Password
 
-<a id="password-reset"></a>
-
-### I forgot my password. How can I reset it?
+### I forgot my password. How can I reset it? \{#password-reset\}
 
 The password is stored encrypted, so it can't be read.
 You can set a new password via the command line.
@@ -368,7 +364,7 @@ Now evcc will start accumulating the forecasts from zero.
 
 ## Statistical Data
 
-### Telemetry & Community Data
+### Telemetry & Community Data \{#telemetry\}
 
 The [evcc Website](https://evcc.io/#live) (and the "Charge Energy Overview" dialog in the evcc UI) shows aggregated live charging data from evcc installations. We collect this data on our central _api.evcc.io_ server - participation is completely voluntary.
 

--- a/src/content/docs/en/features/battery.mdx
+++ b/src/content/docs/en/features/battery.mdx
@@ -144,9 +144,7 @@ This puts the home battery into a locked state when a fast charging process is a
 The blocking state applies for the period of fast charging.
 The home battery is not discharged during this time.
 
-<a id="gridcharge"></a>
-
-### Grid Charging
+### Grid Charging \{#gridcharge\}
 
 Scenario: You have a dynamic electricity tariff and want to charge your home battery with cheap electricity at night.
 For example, because the surplus generated during the day is not enough.

--- a/src/content/docs/en/installation/configuration.mdx
+++ b/src/content/docs/en/installation/configuration.mdx
@@ -52,9 +52,7 @@ Additionally, you can integrate various services and protocols:
 - **Sunny Home Manager**: Integration via SEMP protocol
 - **External Limit**: Power limitation by grid operators (§ 14a EnWG, § 9 EEG) or higher-level energy management systems
 
-<a id="backup"></a>
-
-### Backup & Restore
+### Backup & Restore \{#backup\}
 
 The web interface offers integrated data backup functions:
 

--- a/src/content/docs/en/installation/docker.mdx
+++ b/src/content/docs/en/installation/docker.mdx
@@ -227,9 +227,7 @@ If a new image is available, the following command will restart the container - 
 sudo docker compose up -d
 ```
 
-<a id="test"></a>
-
-## Testing
+## Testing \{#test\}
 
 After successfully creating and starting your container, you can access the evcc Web UI at `http://<host>:7070`.
 `<host>` is the IP address or hostname of the computer running the container.

--- a/src/content/docs/en/installation/linux-image.mdx
+++ b/src/content/docs/en/installation/linux-image.mdx
@@ -69,9 +69,7 @@ Pre-configured and ready to set up via the web UI!
 System configuration and updates work via [Cockpit](#cockpit).
 Log in there once to change the default Linux password.
 
-<a id="wifi"></a>
-
-## Set up WiFi
+## Set up WiFi \{#wifi\}
 
 If no network cable is available, the Raspberry Pi creates a WiFi hotspot for initial setup.
 
@@ -84,9 +82,7 @@ If no network cable is available, the Raspberry Pi creates a WiFi hotspot for in
 
 WiFi configuration can also be done later via [Cockpit](#cockpit).
 
-<a id="cockpit"></a>
-
-## System Management via Cockpit
+## System Management via Cockpit \{#cockpit\}
 
 Cockpit is a graphical system management interface for Linux.
 Here you can configure your system, install updates, and change network settings.

--- a/src/content/docs/en/installation/linux.mdx
+++ b/src/content/docs/en/installation/linux.mdx
@@ -143,9 +143,7 @@ If you need to go backwards for any reason, you can do so with this command:
   sudo apt install evcc=x.xxx.x # Version Number
 ```
 
-<a id="systemd"></a>
-
-## System Service
+## System Service \{#systemd\}
 
 evcc runs as a background system service. Here's some useful commands to control it:
 
@@ -219,9 +217,7 @@ Copy yaml: `sudo cp /etc/evcc.yaml /home/pi/evcc.yaml.bak`
 
 Copy db: `sudo cp /var/lib/evcc/evcc.db /home/pi/evcc.db.bak`
 
-<a id="environment-variables"></a>
-
-## Environment Variables & CLI Options
+## Environment Variables & CLI Options \{#environment-variables\}
 
 When installed via APT, evcc runs as a systemd service.
 You can customize the behavior using an override file:
@@ -260,9 +256,7 @@ All parameters from `evcc.yaml` can be set as environment variables: `EVCC_` + p
 For a complete list of all CLI options, see the [CLI documentation](/en/reference/cli/evcc).
 :::
 
-<a id="manual"></a>
-
-## Manual Installation
+## Manual Installation \{#manual\}
 
 In addition to the Debian/Ubuntu APT package, we also provide other binaries for Linux.
 

--- a/src/content/docs/en/installation/macos.mdx
+++ b/src/content/docs/en/installation/macos.mdx
@@ -97,9 +97,7 @@ brew services restart evcc
   tail -f /opt/homebrew/var/log/evcc.log
   ```
 
-<a id="manual"></a>
-
-## Manual Installation
+## Manual Installation \{#manual\}
 
 Here you'll find instructions for manually installing evcc on macOS.
 

--- a/src/content/docs/en/reference/plugins.mdx
+++ b/src/content/docs/en/reference/plugins.mdx
@@ -65,9 +65,7 @@ The attribute name (e.g. `power`, `enable`, `soc`) determines the role; the `sou
 Each plugin is used in either a **reading** or a **writing** context. Some parameters only make sense in one of the two.
 For the full attribute lists of meters, chargers, vehicles and tariffs, see [user-defined devices](/en/user-defined-devices).
 
-<a id="reading"></a>
-
-### Reading
+### Reading \{#reading\}
 
 When reading data using a plugin, so-called _pipelines_ can be used.
 These allow data to be extracted in a fine-grained manner from the plugin's output.
@@ -81,9 +79,7 @@ Possible parameters for data extraction are:
 - `unpack`: Converts values from other number representations, e.g. `hex`.
 - `decode`: Decodes binary formats like `uint32`, `float32` etc.
 
-<a id="known-errors"></a>
-
-#### Known error values
+#### Known error values \{#known-errors\}
 
 [HTTP](#http), [MQTT](#mqtt), and [Websocket](#websocket) plugins can return special error strings.
 evcc recognises these and converts them into internal error codes instead of treating them as data.
@@ -96,9 +92,7 @@ This is useful e.g. for custom vehicle integrations where the data source knows 
 If a plugin returns the string `ErrAsleep` as its response, evcc generates the corresponding internal error.
 The [Error Plugin](#error) uses the same mechanism to return a fixed error value as a constant.
 
-<a id="writing"></a>
-
-### Writing
+### Writing \{#writing\}
 
 When writing, parameters in the configuration can be replaced by placeholders.
 The data is provided in the form `${var[:format]}`.
@@ -108,9 +102,7 @@ Additionally, all functions of the Go Template Library can be used to perform mo
 
 ## Plugins
 
-<a id="gpio"></a>
-
-### GPIO <Badge text="read" variant="tip" size="small" /> <Badge text="write" variant="caution" size="small" />
+### GPIO <Badge text="read" variant="tip" size="small" /> <Badge text="write" variant="caution" size="small" /> \{#gpio\}
 
 The `gpio` plugin enables direct access to GPIO pins (General Purpose Input/Output) on Linux systems.
 It is particularly suitable for Raspberry Pi and similar single-board computers.
@@ -150,9 +142,7 @@ pin: 27 # BCM pin number
 This plugin only works on Linux systems with access to `/dev/gpiomem`.
 :::
 
-<a id="go"></a>
-
-### Go <Badge text="read" variant="tip" size="small" /> <Badge text="write" variant="caution" size="small" />
+### Go <Badge text="read" variant="tip" size="small" /> <Badge text="write" variant="caution" size="small" /> \{#go\}
 
 The `go` plugin uses the [Yaegi](https://github.com/traefik/yaegi) interpreter to execute Go code at runtime.
 It's particularly useful for type-safe calculations and complex data processing logic.
@@ -209,9 +199,7 @@ maxcurrent:
     // maxcurrent variable is automatically available
 ```
 
-<a id="transformations"></a>
-
-#### Input and Output Transformations
+#### Input and Output Transformations \{#transformations\}
 
 The `go` and `js` plugins support `in` and `out` parameters to use values from other sources as variables in the script or to forward the script result to other plugins.
 
@@ -267,9 +255,7 @@ maxcurrent:
         topic: heater/target_power
 ```
 
-<a id="http"></a>
-
-### HTTP <Badge text="read" variant="tip" size="small" /> <Badge text="write" variant="caution" size="small" />
+### HTTP <Badge text="read" variant="tip" size="small" /> <Badge text="write" variant="caution" size="small" /> \{#http\}
 
 The `http` plugin performs HTTP calls to read or update data.
 It also includes the ability to read or perform simple transformations on JSON data structures via jq queries (e.g. for REST APIs).
@@ -370,9 +356,7 @@ enable:
   uri: "http://charger/relay/0?turn={{if .enable}}on{{else}}off{{end}}"
 ```
 
-<a id="javascript"></a>
-
-### JavaScript <Badge text="read" variant="tip" size="small" /> <Badge text="write" variant="caution" size="small" />
+### JavaScript <Badge text="read" variant="tip" size="small" /> <Badge text="write" variant="caution" size="small" /> \{#javascript\}
 
 evcc integrates a JavaScript interpreter with the [Underscore.js](https://underscorejs.org) library, which is directly accessible via `_.`, e.g. `_.random(0,5)`.
 The `js` plugin can execute JavaScript code via the `script` parameter. Very helpful for rapid prototyping:
@@ -399,9 +383,7 @@ maxcurrent:
 
 The `js` plugin supports the same [input and output transformations](#transformations) (`in`/`out`) as the `go` plugin.
 
-<a id="modbus"></a>
-
-### Modbus <Badge text="read" variant="tip" size="small" /> <Badge text="write" variant="caution" size="small" />
+### Modbus <Badge text="read" variant="tip" size="small" /> <Badge text="write" variant="caution" size="small" /> \{#modbus\}
 
 The `modbus` plugin can read data from any Modbus-capable device or SunSpec-compatible inverter.
 Many power meters are already pre-configured (see [MBMD Supported Devices](https://github.com/volkszaehler/mbmd#supported-devices)).
@@ -421,9 +403,7 @@ register:
 
 See the [Modbus Documentation](/en/reference/modbus) for more details.
 
-<a id="mqtt"></a>
-
-### MQTT <Badge text="read" variant="tip" size="small" /> <Badge text="write" variant="caution" size="small" />
+### MQTT <Badge text="read" variant="tip" size="small" /> <Badge text="write" variant="caution" size="small" /> \{#mqtt\}
 
 The `mqtt` plugin enables reading values via MQTT topics.
 This is particularly useful for power meters, e.g. when they already provide their data via MQTT.
@@ -470,9 +450,7 @@ topic: mbmd/charger/maxcurrent
 payload: ${var:%d}
 ```
 
-<a id="prometheus"></a>
-
-### Prometheus <Badge text="read" variant="tip" size="small" />
+### Prometheus <Badge text="read" variant="tip" size="small" /> \{#prometheus\}
 
 The `prometheus` plugin reads metrics from a Prometheus instance using PromQL queries.
 This is useful when monitoring data is already available in Prometheus and should be used in evcc.
@@ -512,9 +490,7 @@ energy:
 The query must return a single numerical value.
 For vector results, exactly one metric must be included.
 
-<a id="shell"></a>
-
-### Shell Script <Badge text="read" variant="tip" size="small" /> <Badge text="write" variant="caution" size="small" />
+### Shell Script <Badge text="read" variant="tip" size="small" /> <Badge text="write" variant="caution" size="small" /> \{#shell\}
 
 The `script` plugin executes external scripts to read or update data. The plugin is useful for integrating any kind of external functionality.
 
@@ -534,9 +510,7 @@ cmd: /home/user/my-script.sh ${enable:%b} # format boolean enable as 0/1
 timeout: 5s
 ```
 
-<a id="speedwire"></a>
-
-### SMA/Speedwire <Badge text="read" variant="tip" size="small" />
+### SMA/Speedwire <Badge text="read" variant="tip" size="small" /> \{#speedwire\}
 
 The `sma` plugin provides an interface to SMA devices that support the Speedwire protocol.
 
@@ -556,9 +530,7 @@ Supported values for `value` can be found in the diagnostic output using the `ev
 
 All possible values can be found as constants [here](https://gitlab.com/bboehmke/sunny/-/blob/master/values.go#L24) (use the constant name for `value`).
 
-<a id="websocket"></a>
-
-### Websocket <Badge text="read" variant="tip" size="small" />
+### Websocket <Badge text="read" variant="tip" size="small" /> \{#websocket\}
 
 The `websocket` plugin provides a WebSocket listener.
 It also includes the ability to read or parse JSON data structures via jq-like queries.
@@ -578,9 +550,7 @@ timeout: 30s # error if no update received in 30 seconds
 
 ## Helpers
 
-<a id="calc"></a>
-
-### Calc <Badge text="read" variant="tip" size="small" />
+### Calc <Badge text="read" variant="tip" size="small" /> \{#calc\}
 
 The `calc` plugin allows mathematical processing of multiple individual values:
 
@@ -630,9 +600,7 @@ The `calc` plugin is helpful for e.g.
 Constant auxiliary values (e.g. for offsets) can be generated as operands using the `const` plugin.
 :::
 
-<a id="combined"></a>
-
-### Combined <Badge text="read" variant="tip" size="small" />
+### Combined <Badge text="read" variant="tip" size="small" /> \{#combined\}
 
 The `combined` status plugin is used to convert mixed boolean status values of `Plugged` (connected) / `Charging` (charging) into an evcc-compatible charging status of A..F.
 It's used, for example, with an OpenWB MQTT integration.
@@ -649,9 +617,7 @@ charging:
   topic: openWB/lp/1/boolChargeStat
 ```
 
-<a id="const"></a>
-
-### Const <Badge text="read" variant="tip" size="small" />
+### Const <Badge text="read" variant="tip" size="small" /> \{#const\}
 
 The `const` plugin returns a constant value.
 It's suitable, for example, to apply fixed correction values (offset) to a variable value in conjunction with the `calc` plugin or to simulate measurement and status values for testing purposes.
@@ -663,9 +629,7 @@ source: const
 value: -16247
 ```
 
-<a id="error"></a>
-
-### Error <Badge text="read" variant="tip" size="small" />
+### Error <Badge text="read" variant="tip" size="small" /> \{#error\}
 
 The `error` plugin always returns a [known error value](#known-errors).
 It is useful to explicitly mark an unimplemented attribute as not available.
@@ -684,9 +648,7 @@ soc:
   error: ErrNotAvailable
 ```
 
-<a id="convert"></a>
-
-### Convert <Badge text="write" variant="caution" size="small" />
+### Convert <Badge text="write" variant="caution" size="small" /> \{#convert\}
 
 The `convert` plugin converts data types when writing.
 It is used when a plugin expects a different data type than evcc provides.
@@ -725,9 +687,7 @@ limitsoc:
 
 In this example, evcc converts a float value like `85.5` to `85` before writing it to the modbus register.
 
-<a id="delta"></a>
-
-### Delta <Badge text="write" variant="caution" size="small" />
+### Delta <Badge text="write" variant="caution" size="small" /> \{#delta\}
 
 The `delta` plugin converts absolute values to delta/increment values.
 It's used for devices that add written values to an internal sum instead of setting them directly.
@@ -811,9 +771,7 @@ setmaxpower:
         decode: uint16
 ```
 
-<a id="ignore"></a>
-
-### Ignore <Badge text="write" variant="caution" size="small" />
+### Ignore <Badge text="write" variant="caution" size="small" /> \{#ignore\}
 
 The `ignore` plugin suppresses specific error messages when writing.
 It is used when a device returns harmless errors that can be ignored.
@@ -859,9 +817,7 @@ batterymode:
 
 In this example, the device returns a harmless modbus error that is ignored.
 
-<a id="ifelse"></a>
-
-### IfElse <Badge text="write" variant="caution" size="small" />
+### IfElse <Badge text="write" variant="caution" size="small" /> \{#ifelse\}
 
 The `ifelse` plugin performs conditional write operations with two branches.
 Depending on the input value, either the `if` or the `else` plugin is executed.
@@ -895,9 +851,7 @@ enable:
     method: POST
 ```
 
-<a id="map"></a>
-
-### Map <Badge text="read" variant="tip" size="small" /> <Badge text="write" variant="caution" size="small" />
+### Map <Badge text="read" variant="tip" size="small" /> <Badge text="write" variant="caution" size="small" /> \{#map\}
 
 The `map` plugin translates integer values to other integer values using a lookup table.
 It is often used to convert device-specific values to evcc standard values and vice versa.
@@ -967,9 +921,7 @@ setmode:
       encoding: int16
 ```
 
-<a id="meter-plugin"></a>
-
-### Meter <Badge text="read" variant="tip" size="small" />
+### Meter <Badge text="read" variant="tip" size="small" /> \{#meter-plugin\}
 
 The `meter` plugin allows using another meter as a data source.
 This is useful when you want to use an existing device for multiple measurements or when you need different methods of a device for different attributes.
@@ -1009,9 +961,7 @@ meters:
 
 In this example, a Shelly 1PM device is used as a data source for power and energy of a battery, while the state of charge (SoC) is retrieved via MQTT.
 
-<a id="sequence"></a>
-
-### Sequence <Badge text="write" variant="caution" size="small" />
+### Sequence <Badge text="write" variant="caution" size="small" /> \{#sequence\}
 
 The `sequence` plugin executes multiple write operations sequentially.
 All nested plugins receive the same input value and are executed in the defined order.
@@ -1102,9 +1052,7 @@ batterymode:
 
 The value flows through all plugins, with `switch` executing different actions based on the value and `mqtt` always notifying at the end.
 
-<a id="sleep"></a>
-
-### Sleep <Badge text="write" variant="caution" size="small" />
+### Sleep <Badge text="write" variant="caution" size="small" /> \{#sleep\}
 
 The `sleep` plugin adds a delay.
 Typically used within a `sequence` plugin to create time intervals between actions.
@@ -1131,9 +1079,7 @@ setmode:
       method: POST
 ```
 
-<a id="switch"></a>
-
-### Switch <Badge text="write" variant="caution" size="small" />
+### Switch <Badge text="write" variant="caution" size="small" /> \{#switch\}
 
 The `switch` plugin performs conditional write operations, similar to a switch/case statement in programming languages.
 Based on the input value, the corresponding action is executed.
@@ -1177,9 +1123,7 @@ setmode:
         body: "boost"
 ```
 
-<a id="valid"></a>
-
-### Valid <Badge text="read" variant="tip" size="small" />
+### Valid <Badge text="read" variant="tip" size="small" /> \{#valid\}
 
 The `valid` plugin allows providing plugin values based on boolean validation.
 It separates the validity of a value from its actual content.
@@ -1202,9 +1146,7 @@ value:
 In this example, the value is only used when the `valid` topic returns `true`.
 If it returns `false`, the value is marked as unavailable.
 
-<a id="watchdog"></a>
-
-### Watchdog <Badge text="write" variant="caution" size="small" />
+### Watchdog <Badge text="write" variant="caution" size="small" /> \{#watchdog\}
 
 The `watchdog` plugin is a wrapper plugin that automatically repeats write operations at regular intervals.
 Some devices (e.g. battery storage systems, inverters) expect control commands to be repeated regularly to stay active.

--- a/src/content/docs/en/reference/white-label.mdx
+++ b/src/content/docs/en/reference/white-label.mdx
@@ -8,9 +8,7 @@ import { Tabs, TabItem } from "@astrojs/starlight/components";
 You can ship your evcc instance under your own brand: with your logo, your contact details and your colour scheme.
 This page is aimed at installers and vendors who deliver preconfigured devices or hosted installations to their customers.
 
-<a id="custom-css"></a>
-
-## Colours and Fonts
+## Colours and Fonts \{#custom-css\}
 
 Beyond logo and name you can also adjust colours and fonts to match your brand.
 `EVCC_CUSTOM_CSS` points to a CSS file that is loaded in addition to the standard styles.
@@ -43,9 +41,7 @@ A few things to keep in mind:
 - Test your styles in light and dark mode.
 - Check for sufficient contrast, e.g. text on your primary colour.
 
-<a id="brand"></a>
-
-## Brand Name and Logo
+## Brand Name and Logo \{#brand\}
 
 | Variable                 | Effect                             |
 | ------------------------ | ---------------------------------- |
@@ -77,9 +73,7 @@ Clicking the brand name in the menu opens the **Version** dialog with your logo.
   caption="Version dialog with custom logo and contact details"
 />
 
-<a id="problem-reports"></a>
-
-## Problem Reports
+## Problem Reports \{#problem-reports\}
 
 Under **Need Help? → Report a problem** users can report bugs and ask for help.
 By default this opens a prefilled GitHub discussion or GitHub issue.
@@ -95,9 +89,7 @@ If you need them, ask your users to download the debug file on the same page and
 
 The help dialog also shows a **Contact us** email button instead of the **GitHub discussions** link.
 
-<a id="configuration"></a>
-
-## Configuration
+## Configuration \{#configuration\}
 
 Each setting is an environment variable.
 The same settings are also available as [CLI flags](/en/reference/cli/evcc#options), e.g. `--custom-brand` for `EVCC_CUSTOM_BRAND`.
@@ -156,17 +148,13 @@ services:
 
 All other configuration can also be provided via environment variables: `EVCC_` followed by the `evcc.yaml` parameter name in uppercase, e.g. `EVCC_NETWORK_HOST` or `EVCC_DATABASE_DSN`.
 
-<a id="custom-image"></a>
-
-## Custom Image
+## Custom Image \{#custom-image\}
 
 To ship a complete SD card image with your branding, fork the [evcc-io/images](https://github.com/evcc-io/images) repository.
 The [`userpatches/customize-image.sh`](https://github.com/evcc-io/images/blob/main/userpatches/customize-image.sh) script configures evcc during the image build.
 In its _EVCC SETUP_ section it writes the systemd override file, so this is where your `Environment="EVCC_CUSTOM_..."` lines go.
 
-<a id="licensing"></a>
-
-## Licensing
+## Licensing \{#licensing\}
 
 Shipping or selling the official binary or Docker image to your customers is perfectly fine.
 Make sure you follow the [sponsorship conditions](/en/sponsorship) and the [license](https://github.com/evcc-io/evcc#license).

--- a/src/content/docs/en/sponsorship.mdx
+++ b/src/content/docs/en/sponsorship.mdx
@@ -66,9 +66,7 @@ Significant contributions to the [documentation](https://github.com/evcc-io/docs
 As a contributor, we'll issue you an unlimited contributor token.
 [Send us a short email](mailto:info@evcc.io) with your GitHub username.
 
-<a id="trial"></a>
-
-## Trial Token
+## Trial Token \{#trial\}
 
 You want to test evcc and check if all your devices are supported?
 For that, you can use our test token.

--- a/src/content/docs/en/user-defined-devices.mdx
+++ b/src/content/docs/en/user-defined-devices.mdx
@@ -73,9 +73,7 @@ features:
 
 The available attribute names and feature flags differ per device type and are listed in the sections below.
 
-<a id="meter"></a>
-
-## Meter
+## Meter \{#meter\}
 
 Power meters are configured in the [`meters`](/en/reference/configuration/meters) section.
 Meters defined under `meters:` can be referenced from `site`:
@@ -111,9 +109,7 @@ To convert, use the [reading pipelines](/en/reference/plugins#reading).
 | `currents`     | `[float,float,float]` | no       | all           | Phase currents in A. For detecting active phases.           |
 | `voltages`     | `[float,float,float]` | no       | all           | Phase voltages in V. For connection detection (1p/3p).      |
 
-<a id="signs-and-directions"></a>
-
-### Signs and Directions
+### Signs and Directions \{#signs-and-directions\}
 
 What a positive `power` value and the two energy directions mean depends on the meter role:
 
@@ -152,9 +148,7 @@ power:
   jq: .data.tuples[0][1]
 ```
 
-<a id="charger"></a>
-
-## Charger
+## Charger \{#charger\}
 
 The default `type: custom` covers wallboxes with continuous current control.
 For other devices, specialised charger types are described under [Switchsocket](#charger-switchsocket) and [Heat pumps](#charger-heating).
@@ -189,9 +183,7 @@ For other devices, specialised charger types are described under [Switchsocket](
 | `phases1p3p`       | `int`   | no       | Perform phase switching (requires `tos: true`)    |
 | `wakeup`           | `bool`  | no       | Wake up vehicle                                   |
 
-<a id="charger-features"></a>
-
-### Features
+### Features \{#charger-features\}
 
 | Feature            | Description                                                                                                                                                                                                       |
 | ------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -257,9 +249,7 @@ enable:
   payload: ON
 ```
 
-<a id="charger-switchsocket"></a>
-
-### Switchsocket
+### Switchsocket \{#charger-switchsocket\}
 
 **`type: switchsocket`**
 
@@ -276,9 +266,7 @@ Full setup details are under [Smart switches](/en/smartswitches).
 | `enable`       | `bool`  | yes      | Switch socket on/off                                                                     |
 | `standbypower` | `float` | no       | Power threshold in W. Above it: charging; below: standby. Negative: static (no metering) |
 
-<a id="charger-heating"></a>
-
-### Heat pumps
+### Heat pumps \{#charger-heating\}
 
 Heat pumps and similar heating devices use dedicated charger types, each with its own attributes.
 The full setup is described under [Heat pumps, electric heaters](/en/heating).
@@ -338,9 +326,7 @@ Each contact is driven by a separate sub-charger referenced by type, not via plu
   </TabItem>
 </Tabs>
 
-<a id="vehicle"></a>
-
-## Vehicle
+## Vehicle \{#vehicle\}
 
 Vehicle parameters can also be read via plugins.
 
@@ -373,9 +359,7 @@ Vehicle parameters can also be read via plugins.
 | `capacity` | `float`  | no       | Battery capacity in kWh          |
 | `icon`     | `string` | no       | Icon shown in the user interface |
 
-<a id="vehicle-features"></a>
-
-### Features
+### Features \{#vehicle-features\}
 
 | Feature         | Description                                                                                                                                                      |
 | --------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -419,9 +403,7 @@ onIdentify:
 
 Available modes: `off`, `now`, `minpv`, `pv`.
 
-<a id="tariff"></a>
-
-## Tariff and forecast
+## Tariff and forecast \{#tariff\}
 
 A user-defined tariff connects evcc to a custom value source via the plugin mechanism.
 The `tariff` attribute selects what the source represents and which unit the values use.
@@ -447,9 +429,7 @@ Exactly one of `price` or `forecast` must be configured.
 | `interval`     | `duration` | no       | Polling interval for `forecast`. Default `1h`.                                                                                                                                                  |
 | `cache`        | `duration` | no       | Cache duration for `price`. Default `15m`.                                                                                                                                                      |
 
-<a id="tariff-features"></a>
-
-### Features
+### Features \{#tariff-features\}
 
 | Feature     | Description                                                                                    |
 | ----------- | ---------------------------------------------------------------------------------------------- |
@@ -528,9 +508,7 @@ formula: factor := 1.0; if price < 0 { factor = 0.0 }; factor * 0.07
 
 Pays a fixed feed-in tariff of 7 ct/kWh, except when the day-ahead market price is negative.
 
-<a id="external-limit"></a>
-
-## External Limit
+## External Limit \{#external-limit\}
 
 A user-defined integration for the [External Limit](/en/external-limit) feature connects a control box or energy management system that isn't covered by a built-in integration.
 In the UI, pick **User-defined integration** under **Configuration → External Limit**.
@@ -623,9 +601,7 @@ limit:
 </TabItem>
 </Tabs>
 
-<a id="external-limit-fnn"></a>
-
-### FNN Control Box
+### FNN Control Box \{#external-limit-fnn\}
 
 Control boxes following the FNN standard signal dimming and curtailment via separate switch contacts.
 Consumption dimming (W4) and feed-in curtailment (W3, S2, S1) operate independently.
@@ -666,9 +642,7 @@ s1:
   pin: 23
 ```
 
-<a id="external-limit-eebus"></a>
-
-### EEBus
+### EEBus \{#external-limit-eebus\}
 
 The digital connection via the EEBus protocol.
 The control box communicates directly with your evcc instance and automatically transmits the power limit.
@@ -689,9 +663,7 @@ type: eebus
 ski: "1234-5678-90AB-CDEF" # SKI of the control box
 ```
 
-<a id="external-limit-custom"></a>
-
-### Custom
+### Custom \{#external-limit-custom\}
 
 The generic integration for control systems that provide dynamic limit values instead of switch contacts.
 Consumption limit and feed-in curtailment are read via plugins and work independently of each other.
@@ -718,9 +690,7 @@ curtailedPercent:
 productionNominalMax: 10000 # Installed generator power (Wp)
 ```
 
-<a id="notification-service"></a>
-
-## Notification Service
+## Notification Service \{#notification-service\}
 
 A user-defined notification service processes [notification](/en/notifications) messages via any [plugin](/en/reference/plugins) with write access, e.g. a shell script, HTTP request, or MQTT message.
 In the UI, pick **User-defined service** under **Configuration → Notifications → Services**.


### PR DESCRIPTION
pairs with evcc-io/evcc#33160

Headings preceded by `<a id="..."></a>` still got auto-generated, language-dependent slugs (e.g. `#tarif-und-vorhersage` vs `#tariff-and-forecast`), so table of contents links and heading anchors differed per locale. MDX rejects the compact `{#id}` form, but the escaped `\{#id\}` form works and puts the id on the heading itself.

- convert all `<a id>` + heading pairs in non-blog pages to `\{#id\}` (126 headings, de + en)
- add `telemetry` id on the FAQ heading (linked from the evcc UI)
- plugins: unify German `schreiben` id to `writing`, drop `lesen` alias
- update anchor convention in `CLAUDE.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)