### PR TITLE
Add GitHub search hint to search dialog

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -54,6 +54,7 @@ export default defineConfig({
       description: "evcc Dokumentation",
       components: {
         SiteTitle: "./src/components/SiteTitle.astro",
+        Search: "./src/components/Search.astro",
         SocialIcons: "./src/components/SocialIcons.astro",
         LanguageSelect: "./src/components/LanguageSelect.astro",
         ThemeSelect: "./src/components/ThemeSelect.astro",

--- a/src/components/Search.astro
+++ b/src/components/Search.astro
@@ -1,0 +1,49 @@
+---
+// Sticky footer linking the search term to GitHub. Pagefind's prefix fallback
+// ("Weishaupt" → "GoodWe") means search never comes up empty.
+import Default from "@astrojs/starlight/components/Search.astro";
+
+const t =
+  Astro.currentLocale === "de"
+    ? { lead: "Nichts Passendes?", before: "Auf GitHub nach „", after: "“ suchen" }
+    : { lead: "Nothing helpful?", before: "Search GitHub for “", after: "”" };
+---
+
+<Default {...Astro.props} />
+
+<div class="search-repo-hint" hidden>
+  {t.lead}{" "}
+  <a target="_blank">{t.before}<strong data-term></strong>{t.after} →</a>
+</div>
+
+<script>
+  const hint = document.querySelector<HTMLElement>(".search-repo-hint")!;
+  const frame = document.querySelector("site-search .dialog-frame");
+  if (frame) {
+    frame.append(hint);
+    const term = hint.querySelector("[data-term]")!;
+    const link = hint.querySelector("a")!;
+    frame.addEventListener("input", (e) => {
+      const value = (e.target as HTMLInputElement).value.trim();
+      hint.hidden = !value;
+      term.textContent = value;
+      link.href = `https://github.com/search?q=${encodeURIComponent(`repo:evcc-io/evcc ${value}`)}&type=discussions`;
+    });
+  }
+</script>
+
+<style is:global>
+  .search-repo-hint {
+    position: sticky;
+    bottom: -1rem;
+    margin: auto -1rem -1rem;
+    padding: 0.75rem 1rem;
+    border-top: 1px solid var(--sl-color-gray-5);
+    background-color: var(--sl-color-gray-6);
+    color: var(--sl-color-gray-2);
+    font-size: var(--sl-text-sm);
+  }
+  .search-repo-hint a {
+    color: var(--sl-color-text-accent);
+  }
+</style>


### PR DESCRIPTION
ref #1169

Pagefind never returns an empty result list: when no indexed word starts with the search term it falls back to the longest indexed prefix of the term, so "Weishaupt" ends up matching "GoodWe". This is deliberate upstream behaviour (Pagefind v1.0.0, fix for #291) and there is no option to disable it or set a threshold.

Instead, the search dialog now shows a sticky footer with the current term linking to a GitHub discussions search scoped to evcc-io/evcc. For many devices and integrations, discussions or open pull requests exist before anything is documented here. The footer is shown as soon as the input is non-empty, so it also helps when results are technically present but unrelated.


<img width="568" height="1084" alt="mobile" src="https://github.com/user-attachments/assets/ef10cf5c-1afa-4cd2-bfb4-ee9ff8278aea" />

<img width="1277" height="983" alt="desktop" src="https://github.com/user-attachments/assets/15319e05-3277-4186-988d-fd796a1d59df" />

.<img width="1277" height="983" alt="result" src="https://github.com/user-attachments/assets/64eed032-87ea-4934-8c4b-be2ee33deba2" />
