### PR TITLE
Update nightly version example in highlights post

### DIFF
--- a/src/content/docs/de/blog/2026/08/19/highlights-release-process-optimizer-customize.mdx
+++ b/src/content/docs/de/blog/2026/08/19/highlights-release-process-optimizer-customize.mdx
@@ -34,7 +34,7 @@ Damit können wir [Semantic Versioning](https://semver.org/lang/de/) ordentlich 
 
 - **Funktionsreleases** wie <code>0.<u>314</u>.0</code> erscheinen alle zwei bis vier Wochen.
 - **Bugfix-Releases** wie <code>0.314.<u>1</u></code> können wir dazwischen relativ einfach durchführen.
-- Der **Nightly** wie <code>0.315.0<u>-dev+4cc75b1a4</u></code> enthält weiterhin immer den aktuellen Stand des `master`-Branches, also alle Funktionen und Bugfixes.
+- Der **Nightly** wie <code>0.315.0<u>-dev.1787769000</u></code> enthält weiterhin immer den aktuellen Stand des `master`-Branches, also alle Funktionen und Bugfixes.
 
 Die gesamte Entwicklung findet weiterhin im `master` statt.
 Neu ist ein `/backport`-Kommando auf GitHub, mit dem einzelne Pull Requests für das nächste Bugfix-Release übernommen werden können.

--- a/src/content/docs/en/blog/2026/08/19/highlights-release-process-optimizer-customize.mdx
+++ b/src/content/docs/en/blog/2026/08/19/highlights-release-process-optimizer-customize.mdx
@@ -34,7 +34,7 @@ This lets us properly implement [semantic versioning](https://semver.org):
 
 - **Feature releases** like <code>0.<u>314</u>.0</code> arrive every two to four weeks.
 - **Bugfix releases** like <code>0.314.<u>1</u></code> are easy for us to ship in between.
-- The **nightly** like <code>0.315.0<u>-dev+4cc75b1a4</u></code> still always contains the current state of the `master` branch, i.e. all features and bugfixes.
+- The **nightly** like <code>0.315.0<u>-dev.1787769000</u></code> still always contains the current state of the `master` branch, i.e. all features and bugfixes.
 
 All development still happens on `master`.
 New is a `/backport` command on GitHub that picks individual pull requests for the next bugfix release.


### PR DESCRIPTION
evcc-io/evcc#33205 changed the nightly version format from `0.315.0-dev+<commit>` to `0.315.0-dev.<timestamp>`. Updates the example in the release process section of the 2026-08-19 highlights post (EN + DE).