### PR TITLE
Home Assistant: charge status mapping, entity values, add-on → app

### DIFF
--- a/src/content/docs/de/installation/home-assistant.mdx
+++ b/src/content/docs/de/installation/home-assistant.mdx
@@ -8,14 +8,14 @@ import { Tabs, TabItem } from "@astrojs/starlight/components";
 import haConfigUi from "@assets/installation/ha_configuration_ui.webp";
 
 :::note[Wichtig]
-Das evcc Home Assistant Add-on ist eine Community Integration und wird "noch" nicht offiziell von den evcc Maintainern unterstützt.
+Die evcc Home Assistant App ist eine Community Integration und wird "noch" nicht offiziell von den evcc Maintainern unterstützt.
 Der Grund dafür ist, dass im Fehlerfall wichtige Daten nicht einfach bereitgestellt werden können (fehlende `evcc cli`).
 :::
 
 :::caution[Datenmigration]
-Bitte beachte, dass wir seit dem 16.02.2025 mit der Version 0.200.1 die Pfade im Add-on geändert haben, um mit der [Vorgabe](https://developers.home-assistant.io/blog/2023/11/06/public-addon-config/) von Home Assistant konsistent zu sein.
+Bitte beachte, dass wir seit dem 16.02.2025 mit der Version 0.200.1 die Pfade im App geändert haben, um mit der [Vorgabe](https://developers.home-assistant.io/blog/2023/11/06/public-addon-config/) von Home Assistant konsistent zu sein.
 
-Ab sofort werden also folgende Pfade im Add-on verbunden:
+Ab sofort werden also folgende Pfade in der App verbunden:
 
 - `/homeassistant/` -> zeigt in Home Assistant auf `/homeassistant/` bzw. `/config/`.
 - `/config/`-> zeigt in Home Assistant auf `/addon_configs/49686a9f_evcc/`.
@@ -25,12 +25,12 @@ Die Datenbank kopieren wir nur, wenn sie ebenfalls in `/config/` lag. Falls du s
 Den alten Dateien fügen wir `.migrated` an. Diese können dann von dir händisch gelöscht werden.
 :::
 
-Diese Anleitung beschreibt die Installation von evcc als Home Assistant Add-on.
+Diese Anleitung beschreibt die Installation von evcc als Home Assistant App.
 Im Gegensatz zur [Linux-Installation](/de/installation/linux) oder [Docker-Installation](/de/installation/docker) benötigst du hier kein Kommandozeilenwissen.
 
 ## Voraussetzungen
 
-Du benötigst eine Home Assistant Installation mit aktiviertem Add-on Store.
+Du benötigst eine Home Assistant Installation mit aktiviertem App Store.
 Abhängig von deiner Installationsart kann es sein, dass diese Funktion nicht verfügbar ist.
 Siehe [Home Assistant Dokumentation](https://www.home-assistant.io/installation/#advanced-installation-methods) für weitere Informationen.
 
@@ -43,14 +43,14 @@ Siehe [Home Assistant Dokumentation](https://www.home-assistant.io/installation/
 1. Repository automatisch hinzufügen: Klicke auf den nachfolgenden Button und dann auf **Open link**, dann auf **Hinzufügen**.
    [![Open your Home Assistant instance and show the add add-on repository dialog with a specific repository URL pre-filled.](https://my.home-assistant.io/badges/supervisor_add_addon_repository.svg)](https://my.home-assistant.io/redirect/supervisor_add_addon_repository/?repository_url=https%3A%2F%2Fgithub.com%2Fevcc-io%2Fhassio-addon)
 2. Repository manuell hinzufügen:
-   1. Klicke auf **Einstellungen** → **Add-ons** → **Add-on Store**
+   1. Klicke auf **Einstellungen** → **Apps** → **App installieren**
    2. Klicke auf die **drei Punkte** → **Repositories**
    3. Füge die Repository-URL ein und klicke auf **Hinzufügen**
       ```
       https://github.com/evcc-io/hassio-addon
       ```
 3. Webseite neu laden
-4. Finde das Add-on **evcc** und klicke es an
+4. Finde die App **evcc** und klicke sie an
 5. Klicke auf die Schaltfläche **Installieren**
 
   </TabItem>
@@ -62,14 +62,14 @@ Siehe [Home Assistant Dokumentation](https://www.home-assistant.io/installation/
 1. Repository automatisch hinzufügen: Klicke auf den nachfolgenden Button und dann auf **Open link**, dann auf **Hinzufügen**.
    [![Open your Home Assistant instance and show the add add-on repository dialog with a specific repository URL pre-filled.](https://my.home-assistant.io/badges/supervisor_add_addon_repository.svg)](https://my.home-assistant.io/redirect/supervisor_add_addon_repository/?repository_url=https%3A%2F%2Fgithub.com%2Fevcc-io%2Fhassio-addon)
 2. Repository manuell hinzufügen:
-   1. Klicke auf **Einstellungen** → **Add-ons** → **Add-on Store**
+   1. Klicke auf **Einstellungen** → **Apps** → **App installieren**
    2. Klicke auf die **drei Punkte** → **Repositories**
    3. Füge die Repository-URL ein und klicke auf **Hinzufügen**
       ```
       https://github.com/evcc-io/hassio-addon
       ```
 3. Webseite neu laden
-4. Finde das Add-on **evcc (nightly)** und klicke es an
+4. Finde die App **evcc (nightly)** und klicke sie an
 5. Klicke auf die Schaltfläche **Installieren**
 
   </TabItem>
@@ -81,11 +81,11 @@ evcc kann auf zwei Arten konfiguriert werden:
 
 ### Weboberfläche (empfohlen)
 
-Gehe im **evcc** Add-on in den Tab **Information** und aktiviere **In Seitenleiste anzeigen** (evcc UI http://your-ha-instance-ip-address:7070)
+Gehe in der **evcc** App in den Tab **Information** und aktiviere **In Seitenleiste anzeigen** (evcc UI http://your-ha-instance-ip-address:7070)
 
 Gehe zum Tab **Konfiguration** und wähle dein Arbeitsverzeichnis aus (Beispiel):
 
-<img src={haConfigUi.src} alt="Home Assistant Add-on Konfigurations-UI" />
+<img src={haConfigUi.src} alt="Home Assistant App Konfigurations-UI" />
 
 ```sh
 - sqlite_file: /data/evcc.db
@@ -93,7 +93,7 @@ Gehe zum Tab **Konfiguration** und wähle dein Arbeitsverzeichnis aus (Beispiel)
 
 Lasse den Abschnitt Netzwerk unverändert.
 
-Starte das Add-on.
+Starte die App.
 Öffne dann die evcc Oberfläche über die Seitenleiste:
 
 - Du wirst aufgefordert ein Administrator-Passwort zu vergeben
@@ -111,13 +111,13 @@ Gehe zum Tab **Konfiguration** und füge die Konfigurationsdatei zu deinem Arbei
 - sqlite_file: /data/evcc.db
 ```
 
-Lege eine Konfigurationsdatei `evcc.yaml` in deinem Add-on-Stammkonfigurationsordner (`/addon_configs/49686a9f_evcc`) an.
+Lege eine Konfigurationsdatei `evcc.yaml` in deinem App-Stammkonfigurationsordner (`/addon_configs/49686a9f_evcc`) an.
 Falls dieser Ordner noch nicht existiert, erstelle ihn manuell.
 
 Um die Konfigurationsdatei anzulegen bzw. zu editieren, hast du verschiedene Möglichkeiten:
 
 - [Visual Studio Code](https://github.com/hassio-addons/addon-vscode): Wähle das Hamburger-Menü oben links aus und wähle "File", "Open Folder...", select `/addon_configs/49686a9f_evcc`
-- [File Editor](https://github.com/home-assistant/addons/tree/master/configurator): Stelle sicher, dass du die Option "Enforce Basepath" in der Add-on Konfiguration deaktiviert hast, starte das Add-on neu und navigiere nach `/addon_configs/49686a9f_evcc`
+- [File Editor](https://github.com/home-assistant/addons/tree/master/configurator): Stelle sicher, dass du die Option "Enforce Basepath" in der App Konfiguration deaktiviert hast, starte das App neu und navigiere nach `/addon_configs/49686a9f_evcc`
 - [Advanced SSH & Web Terminal](https://github.com/hassio-addons/addon-ssh): Navigiere nach `/addon_configs/49686a9f_evcc` und verwende z. B. nano
 
 Details zur Erstellung der Konfigurationsdatei findest du unter [Einrichtung](/de/installation/configuration).
@@ -131,12 +131,12 @@ Die Aktualisierung auf die neueste Version von evcc ist in den Home Assistant Up
 
 ## Erweiterte Tips
 
-Um die folgenden Funktionen auszuführen, benötigst du SSH Zugriff auf Home Assistant. Diesen kannst du z. B. mit dem oben erwähnten SSH Add-on bekommen.
+Um die folgenden Funktionen auszuführen, benötigst du SSH Zugriff auf Home Assistant. Diesen kannst du z. B. mit der oben erwähnten SSH App bekommen.
 
 - Installiere [Advanced SSH & Web Terminal](https://github.com/hassio-addons/addon-ssh)
-- deaktiviere den "secure mode" in der Add-on Konfiguration
-- Starte das Add-on neu
-- Öffne die Benutzeroberfläche des Add-ons
+- deaktiviere den "secure mode" in der App-Konfiguration
+- Starte die App neu
+- Öffne die Benutzeroberfläche der App
 
 ### Wie komme ich an die evcc Datenbank?
 
@@ -172,18 +172,18 @@ Schließe die Shell im evcc Docker Container wenn du fertig bist:
 exit
 ```
 
-### Wie kann ich meinen externen Adapter/Hat im Home Assistant evcc Addon (Home Assistant OS, Raspberry Pi) verwenden?
+### Wie kann ich meinen externen Adapter/Hat in der Home Assistant evcc App (Home Assistant OS, Raspberry Pi) verwenden?
 
 Wenn sich dein Home Assistant-Gerät in der Nähe deines Zählers (PV, Batterie, Netz, ...) kannst du die Daten auch direkt über Modbus (bspw. USB) abrufen.
 
-Dafür musst du externe Geräte für Home Assistant aktivieren, was auch das evcc-Addon einschließt.
+Dafür musst du externe Geräte für Home Assistant aktivieren, was auch die evcc-App einschließt.
 Kommentiere dafür die Zeile `uart = 1` in der `config.txt` auf der Home Assistant OS Boot-Partition ein.
 
 ```ini title=/config.txt
 uart = 1
 ```
 
-Nach einem Neustart sollte dein Gerät für das evcc-Addon verfügbar sein (wahrscheinlich als `/dev/ttyS0` oder `/dev/ttyUSB`)
+Nach einem Neustart sollte dein Gerät für die evcc-App verfügbar sein (wahrscheinlich als `/dev/ttyS0` oder `/dev/ttyUSB`)
 
 ## Nächster Schritt: Integration
 

--- a/src/content/docs/de/installation/index.mdx
+++ b/src/content/docs/de/installation/index.mdx
@@ -27,7 +27,7 @@ Falls du mehr über die Funktionsweise von Wallboxen und E-Auto-Laden erfahren m
   <NavCard
     to="/de/installation/home-assistant"
     title="Home Assistant"
-    description="Als Add-on über HACS."
+    description="Als App über ein eigenes Repository."
   />
   <NavCard
     to="/de/installation/proxmox"

--- a/src/content/docs/de/smarthome/home-assistant.mdx
+++ b/src/content/docs/de/smarthome/home-assistant.mdx
@@ -9,7 +9,7 @@ evcc ist auf intelligentes Laden und Heizen spezialisiert.
 Beide Systeme ergänzen sich und lassen sich auf verschiedene Arten miteinander verbinden.
 
 :::note
-evcc kann auch als Home Assistant Addon installiert werden. Die Anleitung dafür findest du [hier](/de/installation/home-assistant).
+evcc kann auch als Home Assistant App installiert werden. Die Anleitung dafür findest du [hier](/de/installation/home-assistant).
 :::
 
 ## Visualisieren & Automatisieren
@@ -26,7 +26,7 @@ Hier ein paar Beispiele:
 ### Home Assistant evcc Integration (empfohlen)
 
 Die [ha-evcc](https://github.com/marq24/ha-evcc) Integration von [marq24](https://github.com/marq24) bringt evcc-Daten und -Funktionen direkt in Home Assistant.
-Das funktioniert unabhängig davon, ob du evcc als Home Assistant Addon betreibst oder nicht.
+Das funktioniert unabhängig davon, ob du evcc als Home Assistant App betreibst oder nicht.
 Voraussetzung ist, dass Home Assistant und evcc im gleichen Netzwerk erreichbar sind.
 
 Die Integration stellt alle relevanten evcc-Entitäten bereit: Messwerte, Einstellungen, Ladepunkte und Fahrzeuge.
@@ -54,7 +54,7 @@ evcc bietet eine [REST API](/integrations/rest-api) an.
 
 #### MQTT
 
-Du benötigst einen MQTT-Broker (z. B. [Mosquitto](https://mosquitto.org/), auch als Home Assistant Addon verfügbar).
+Du benötigst einen MQTT-Broker (z. B. [Mosquitto](https://mosquitto.org/), auch als Home Assistant App verfügbar).
 
 Konfiguriere in evcc unter **Konfiguration → MQTT** die Verbindung zum Broker.
 In Home Assistant muss der gleiche Broker und das gleiche Topic konfiguriert sein, damit beide Systeme die Daten austauschen können.
@@ -70,17 +70,6 @@ evcc kann sich direkt mit Home Assistant verbinden und dessen Entitäten (Sensor
 So lassen sich z. B. Geräte in evcc einbinden, die nicht direkt unterstützt werden, wie Zigbee-Smartplugs, Sensoren aus anderen Integrationen oder selbstgebaute Lösungen.
 Solange die Daten als Home Assistant Entität vorliegen, kann evcc damit arbeiten.
 
-### Einrichtung
-
-1. In der evcc-Oberfläche ein neues Gerät anlegen (z. B. **Konfiguration → Zusätzlichen Zähler hinzufügen**)
-2. Als Hersteller „Home Assistant" auswählen
-3. evcc erkennt deine Home Assistant Instanz automatisch im Netzwerk
-4. Autorisierung von evcc in Home Assistant durchführen (neuer Tab)
-5. Den angezeigten Feldern (z. B. „Leistung") Home Assistant Entitäten zuweisen
-   - Du bekommst Vorschläge und Autovervollständigung (z. B. `sensor.inverter_power`)
-   - Entitäten müssen rein numerische Werte liefern (`1234`, nicht `1234 W`)
-   - Um das Vorzeichen zu invertieren, stelle dem Entitätsnamen ein `-` voran (`-sensor.inverter_power`)
-
 ### Unterstützte Gerätetypen
 
 - **[Zähler](/de/meters#home-assistant)** (Netz, PV, Batterie, ...) mit Leistung, Energie, Strömen, Spannungen, SoC
@@ -88,6 +77,69 @@ Solange die Daten als Home Assistant Entität vorliegen, kann evcc damit arbeite
 - **[Schaltbare Steckdosen](/de/smartswitches#home-assistant-switch)** mit einfacher Ein-/Aus-Steuerung (für Smartplugs, Relais)
 - **[Fahrzeuge](/de/vehicles#home-assistant)** mit SoC, Reichweite, Status, Kilometerstand; optional Skripte zum Starten/Stoppen
 - **[Benachrichtigungen](/de/notifications)** unter **Konfiguration → Benachrichtigungen** kannst du evcc-Meldungen über Home Assistant versenden
+
+### Einrichtung
+
+Home Assistant Geräte werden wie jedes andere Gerät in der Konfigurationsoberfläche angelegt.
+
+1. Unter **Konfiguration** ein Gerät hinzufügen, z. B. **Zusätzlichen Zähler hinzufügen**.
+2. Als Hersteller „Home Assistant“ auswählen.
+3. Die eigene Instanz auswählen. Instanzen im lokalen Netzwerk werden automatisch erkannt.
+   Bleibt die Liste leer, z. B. weil Home Assistant in einem anderen Subnetz läuft, kann die Adresse manuell eingetragen werden (`http://homeassistant.local:8123`).
+4. Zugriff autorisieren.
+   Home Assistant öffnet sich in einem neuen Tab, dort anmelden und die Anfrage bestätigen.
+   Der Token wird von deiner evcc-Instanz gespeichert und automatisch erneuert.
+5. Den Feldern jeweils eine Entität zuweisen, z. B. „Leistung“.
+   Du bekommst Autovervollständigung mit den Entitäten deiner Instanz, angeboten werden nur Entitäten, die zum Feld passen.
+6. **Überprüfen & speichern** prüft, ob die Entitäten gelesen werden können.
+
+:::note
+Wenn du evcc innerhalb von Home Assistant als [App](/de/installation/home-assistant) betreibst, wähle in Schritt 3 die Instanz `http://supervisor/core` aus.
+Sie ist bereits autorisiert, Schritt 4 entfällt.
+:::
+
+<a id="entity-values"></a>
+
+### Werte der Entitäten
+
+Jedes Feld erwartet eine bestimmte Art von Wert.
+Eine Entität mit `unknown` oder `unavailable` gilt als vorübergehend nicht verfügbar und wird beim nächsten Update erneut gelesen.
+
+#### Zahlen
+
+Felder für Leistung, Energie, Strom und SoC brauchen eine reine Zahl als Zustand, z. B. `1234`.
+Ein Zustand wie `1234 W` kann nicht gelesen werden, die Einheit gehört in das Attribut `unit_of_measurement` der Entität.
+`W`/`kW` und `Wh`/`kWh`/`MWh` werden automatisch umgerechnet.
+Um das Vorzeichen zu invertieren, stelle dem Entitätsnamen ein `-` voran (`-sensor.inverter_power`).
+
+#### Ein/Aus
+
+Der Freigabe-Zustand einer Wallbox, eine schaltbare Steckdose und ähnliche Felder akzeptieren `on`, `true`, `1`, `active` und `yes` sowie die Gegenstücke `off`, `false`, `0`, `inactive` und `no`.
+
+<a id="charge-status"></a>
+
+#### Ladestatus
+
+Wallboxen und Fahrzeuge brauchen eine Status-Entität, die meldet, ob das Fahrzeug getrennt, verbunden oder am Laden ist.
+Diese Zustände werden ohne weitere Konfiguration erkannt:
+
+| Status | Bedeutung | Zustände                                                                                       |
+| ------ | --------- | ---------------------------------------------------------------------------------------------- |
+| **A**  | getrennt  | `a`, `disconnected`, `not_plugged`                                                             |
+| **B**  | verbunden | `b`, `connected`, `plugged`, `starting`, `stopped`, `paused`, `complete`, `charging_completed` |
+| **C**  | lädt      | `c`, `charging`                                                                                |
+
+Viele Integrationen verwenden eigene Bezeichnungen.
+Meldet die Entität einen Zustand, der nicht in der Tabelle steht, zeigt das Log den Rohwert zusammen mit der Entität an.
+Dieser Wert gehört in das passende Feld **Zustände für Status A/B/C** in den erweiterten Optionen des Geräts.
+Mehrere Werte werden durch Kommas getrennt, Groß- und Kleinschreibung spielt keine Rolle.
+
+```yaml
+statusB: charging_stopped, charging_error
+statusC: instant_charging
+```
+
+Ein `binary_sensor` als Status-Entität braucht ebenfalls eine explizite Zuordnung, z. B. `statusA: off` und `statusC: on`.
 
 ## Weitere Ressourcen (Videos)
 

--- a/src/content/docs/en/installation/home-assistant.mdx
+++ b/src/content/docs/en/installation/home-assistant.mdx
@@ -8,15 +8,15 @@ import { Tabs, TabItem } from "@astrojs/starlight/components";
 import haConfigUi from "@assets/installation/ha_configuration_ui.webp";
 
 :::note
-The evcc Home Assistant addon is a community integration and is not officially supported by the evcc maintainers.
+The evcc Home Assistant app is a community integration and is not officially supported by the evcc maintainers.
 
 The reason for this is that important data cannot simply be made available in the event of an error (missing `evcc cli`).
 :::
 
 :::caution[Datamigration]
-Please note that since February 16, 2025, with version 0.200.1, we have changed the paths in the addon to be consistent with the [guidelines](https://developers.home-assistant.io/blog/2023/11/06/public-addon-config/) of Home Assistant.
+Please note that since February 16, 2025, with version 0.200.1, we have changed the paths in the app to be consistent with the [guidelines](https://developers.home-assistant.io/blog/2023/11/06/public-addon-config/) of Home Assistant.
 
-From now on, the following paths are mapped in the addon:
+From now on, the following paths are mapped in the app:
 
 - `/homeassistant/` -> points to `/homeassistant/` or `/config/` in Home Assistant.
 - `/config/` -> points to `/addon_configs/49686a9f_evcc/` in Home Assistant.
@@ -26,12 +26,12 @@ We will only copy the database if it was also located in `/config/`. If you had 
 We will append `.migrated` to the old files. These can then be manually deleted by you.
 :::
 
-This guide describes the installation of evcc as a Home Assistant addon.
+This guide describes the installation of evcc as a Home Assistant app.
 Unlike the [Linux installation](/en/installation/linux) or [Docker installation](/en/installation/docker), you don't need command line knowledge here.
 
 ## Prerequisites
 
-You need a Home Assistant installation with the Addon Store enabled.
+You need a Home Assistant installation with the app store enabled.
 Depending on your installation type, this feature might not be available.
 See [Home Assistant Documentation](https://www.home-assistant.io/installation/#advanced-installation-methods) for more information.
 
@@ -44,14 +44,14 @@ See [Home Assistant Documentation](https://www.home-assistant.io/installation/#a
 1. Automatically add repository: Click on the following button and then on **Open link**, then on **Add**.
    [![Open your Home Assistant instance and show the add add-on repository dialog with a specific repository URL pre-filled.](https://my.home-assistant.io/badges/supervisor_add_addon_repository.svg)](https://my.home-assistant.io/redirect/supervisor_add_addon_repository/?repository_url=https%3A%2F%2Fgithub.com%2Fevcc-io%2Fhassio-addon)
 2. Manually add repository:
-   1. Click on **Settings** → **Addons** → **Add-on Store**
+   1. Click on **Settings** → **Apps** → **Install app**
    2. Click on the **three dots** → **Repositories**
    3. Add the repository URL and click **Add**
       ```
       https://github.com/evcc-io/hassio-addon
       ```
 3. Reload the webpage
-4. Find the **evcc** addon and click on it
+4. Find the **evcc** app and click on it
 5. Click on the **INSTALL** button
 
   </TabItem>
@@ -63,14 +63,14 @@ See [Home Assistant Documentation](https://www.home-assistant.io/installation/#a
 1. Automatically add repository: Click on the following button and then on **Open link**, then on **Add**.
    [![Open your Home Assistant instance and show the add add-on repository dialog with a specific repository URL pre-filled.](https://my.home-assistant.io/badges/supervisor_add_addon_repository.svg)](https://my.home-assistant.io/redirect/supervisor_add_addon_repository/?repository_url=https%3A%2F%2Fgithub.com%2Fevcc-io%2Fhassio-addon)
 2. Manually add repository:
-   1. Click on **Settings** → **Addons** → **Add-on Store**
+   1. Click on **Settings** → **Apps** → **Install app**
    2. Click on the **three dots** → **Repositories**
    3. Add the repository URL and click **Add**
       ```
       https://github.com/evcc-io/hassio-addon
       ```
 3. Reload the webpage
-4. Find the **evcc (nightly)** addon and click on it
+4. Find the **evcc (nightly)** app and click on it
 5. Click on the **INSTALL** button
 
   </TabItem>
@@ -82,11 +82,11 @@ evcc can be configured in two ways:
 
 ### Web Interface (recommended)
 
-Go to the **Information** tab in the **evcc** addon and activate **Show in sidebar** (evcc UI http://your-ha-instance-ip-address:7070)
+Go to the **Information** tab in the **evcc** app and activate **Show in sidebar** (evcc UI http://your-ha-instance-ip-address:7070)
 
 Go to the **Configuration** tab and select your working directory (example):
 
-<img src={haConfigUi.src} alt="Home Assistant addon configuration UI" />
+<img src={haConfigUi.src} alt="Home Assistant app configuration UI" />
 
 ```sh
 - sqlite_file: /data/evcc.db
@@ -94,7 +94,7 @@ Go to the **Configuration** tab and select your working directory (example):
 
 Leave the Network section unchanged.
 
-Start the addon.
+Start the app.
 Then open the evcc interface via the sidebar:
 
 - You'll be prompted to set an administrator password
@@ -112,13 +112,13 @@ Go to the **Configuration** tab and add the configuration file to your working d
 - sqlite_file: /data/evcc.db
 ```
 
-Create an evcc configuration file `evcc.yaml` in your addon root configuration folder (`/addon_configs/49686a9f_evcc`).
+Create an evcc configuration file `evcc.yaml` in your app root configuration folder (`/addon_configs/49686a9f_evcc`).
 If this folder does not exist, create it manually.
 
 To create or edit the configuration file, you have several options:
 
 - [Visual Studio Code](https://github.com/hassio-addons/addon-vscode): Select the hamburger menu in the top left and choose "File", "Open Folder...", select `/addon_configs/49686a9f_evcc`
-- [File Editor](https://github.com/home-assistant/addons/tree/master/configurator): Make sure you have disabled the "Enforce Basepath" option in the addon configuration, restart the addon and navigate to `/addon_configs/49686a9f_evcc`
+- [File Editor](https://github.com/home-assistant/addons/tree/master/configurator): Make sure you have disabled the "Enforce Basepath" option in the app configuration, restart the app and navigate to `/addon_configs/49686a9f_evcc`
 - [Advanced SSH & Web Terminal](https://github.com/hassio-addons/addon-ssh): Navigate to `/addon_configs/49686a9f_evcc` and use e.g. nano
 
 See [Configuration](/en/installation/configuration) for details on creating the configuration file.
@@ -132,12 +132,12 @@ The update to the latest version of evcc is integrated into the Home Assistant u
 
 ## Advanced Tips
 
-To perform the following functions, you need SSH access to Home Assistant. You can get this, for example, with the above-mentioned SSH Addon.
+To perform the following functions, you need SSH access to Home Assistant. You can get this, for example, with the above-mentioned SSH app.
 
 - Install [Advanced SSH & Web Terminal](https://github.com/hassio-addons/addon-ssh)
-- Disable the "secure mode" in the Addon configuration
-- Restart the Addon
-- Open the Addon user interface
+- Disable the "secure mode" in the app configuration
+- Restart the app
+- Open the app user interface
 
 ### How do I access the evcc database?
 
@@ -173,18 +173,18 @@ Close the shell in the evcc Docker container if you are done:
 exit
 ```
 
-### How can I use my external adapter / HAT in the Home Assistant evcc addon (Home Assistant OS, Raspberry Pi)?
+### How can I use my external adapter / HAT in the Home Assistant evcc app (Home Assistant OS, Raspberry Pi)?
 
 If your Home Assistant device is close to your meter (solar, battery, grid, ...) you can also retrieve the data directly via Modbus (e.g. USB).
 
-To do this, you need to enable external devices for Home Assistant, which also includes the evcc addon.
+To do this, you need to enable external devices for Home Assistant, which also includes the evcc app.
 To do this, uncomment the line `uart = 1` in the `config.txt` file on the Home Assistant OS boot partition.
 
 ```ini title=/config.txt
 uart = 1
 ```
 
-After a restart, your device should be available to the evcc addon (probably as `/dev/ttyS0` or `/dev/ttyUSB`)
+After a restart, your device should be available to the evcc app (probably as `/dev/ttyS0` or `/dev/ttyUSB`)
 
 ## Next Step: Integration
 

--- a/src/content/docs/en/installation/index.mdx
+++ b/src/content/docs/en/installation/index.mdx
@@ -27,7 +27,7 @@ If you want to learn more about how wallboxes and EV charging work, first check 
   <NavCard
     to="/en/installation/home-assistant"
     title="Home Assistant"
-    description="As add-on via HACS."
+    description="As app from a custom repository."
   />
   <NavCard
     to="/en/installation/proxmox"

--- a/src/content/docs/en/smarthome/home-assistant.mdx
+++ b/src/content/docs/en/smarthome/home-assistant.mdx
@@ -9,7 +9,7 @@ evcc specialises in smart charging and heating.
 Both systems complement each other and can be connected in different ways.
 
 :::note
-evcc can also be installed as a Home Assistant Addon. You can find the instructions [here](/en/installation/home-assistant).
+evcc can also be installed as a Home Assistant App. You can find the instructions [here](/en/installation/home-assistant).
 :::
 
 ## Visualise & Automate
@@ -26,7 +26,7 @@ Here are some examples:
 ### Home Assistant evcc Integration (Recommended)
 
 The [ha-evcc](https://github.com/marq24/ha-evcc) integration by [marq24](https://github.com/marq24) brings evcc data and functions directly into Home Assistant.
-This works regardless of whether you run evcc as a Home Assistant addon or not.
+This works regardless of whether you run evcc as a Home Assistant app or not.
 The only requirement is that Home Assistant and evcc are reachable on the same network.
 
 The integration provides all relevant evcc entities: measurements, settings, charging points, and vehicles.
@@ -54,7 +54,7 @@ evcc offers a [REST API](/integrations/rest-api).
 
 #### MQTT
 
-You need an MQTT broker (e.g. [Mosquitto](https://mosquitto.org/), also available as a Home Assistant addon).
+You need an MQTT broker (e.g. [Mosquitto](https://mosquitto.org/), also available as a Home Assistant app).
 
 Configure the broker connection in evcc under **Configuration → MQTT**.
 The same broker and topic must be configured in Home Assistant so that both systems can exchange data.
@@ -70,17 +70,6 @@ evcc can connect directly to Home Assistant and use its entities (sensors, switc
 This allows you to integrate devices into evcc that are not natively supported, e.g. Zigbee smart plugs, sensors from other integrations, or DIY solutions.
 As long as the data is available as a Home Assistant entity, evcc can work with it.
 
-### Setup
-
-1. Add a new device in the evcc UI (e.g. **Configuration → Add additional meter**)
-2. Select "Home Assistant" as the manufacturer
-3. evcc will automatically discover your Home Assistant instance on the network
-4. Authorise evcc in Home Assistant (new tab)
-5. Assign Home Assistant entities to the presented fields (e.g. "Power")
-   - You'll get suggestions and autocomplete (e.g. `sensor.inverter_power`)
-   - Entities must return pure numeric values (`1234`, not `1234 W`)
-   - To invert the sign, prepend `-` to the entity name (`-sensor.inverter_power`)
-
 ### Supported Device Types
 
 - **[Meters](/en/meters#home-assistant)** (grid, solar, battery, ...) with power, energy, currents, voltages, SoC
@@ -88,6 +77,69 @@ As long as the data is available as a Home Assistant entity, evcc can work with 
 - **[Smart switches](/en/smartswitches#home-assistant-switch)** with simple on/off control (for smart plugs, relays)
 - **[Vehicles](/en/vehicles#home-assistant)** with SoC, range, status, odometer; optionally scripts for start/stop
 - **[Notifications](/en/notifications)** under **Configuration → Notifications** you can send evcc messages via Home Assistant
+
+### Setup
+
+Home Assistant devices are added like any other device in the configuration UI.
+
+1. Go to **Configuration** and add a device, e.g. **Add additional meter**.
+2. Select "Home Assistant" as the manufacturer.
+3. Pick your instance. Instances in the local network are discovered automatically.
+   If the list stays empty, e.g. because Home Assistant runs in a different subnet, enter the address manually (`http://homeassistant.local:8123`).
+4. Authorise the access.
+   Home Assistant opens in a new tab where you log in and confirm the request.
+   The token is stored by your evcc instance and renewed automatically.
+5. Assign an entity to each field, e.g. "Power".
+   You get autocomplete with the entities of your instance, and only entities that fit the field are offered.
+6. **Validate & save** checks whether the entities can be read.
+
+:::note
+If you're running evcc inside Home Assistant as an [App](/en/installation/home-assistant), pick the `http://supervisor/core` instance in step 3.
+It's authorised already, so step 4 is skipped.
+:::
+
+<a id="entity-values"></a>
+
+### Entity Values
+
+Each field expects a certain kind of value.
+An entity reporting `unknown` or `unavailable` counts as temporarily not available and is read again on the next update.
+
+#### Numbers
+
+Power, energy, current and SoC fields need a plain number as state, e.g. `1234`.
+A state such as `1234 W` can't be read, the unit belongs into the entity's `unit_of_measurement` attribute.
+`W`/`kW` and `Wh`/`kWh`/`MWh` are converted automatically.
+To invert the sign, prepend `-` to the entity name (`-sensor.inverter_power`).
+
+#### On/Off
+
+The enabled state of a charger, a smart switch and similar fields accept `on`, `true`, `1`, `active` and `yes`, as well as their counterparts `off`, `false`, `0`, `inactive` and `no`.
+
+<a id="charge-status"></a>
+
+#### Charge Status
+
+Chargers and vehicles need a status entity that reports whether the vehicle is disconnected, connected or charging.
+These states are understood out of the box:
+
+| Status | Meaning      | States                                                                                         |
+| ------ | ------------ | ---------------------------------------------------------------------------------------------- |
+| **A**  | disconnected | `a`, `disconnected`, `not_plugged`                                                             |
+| **B**  | connected    | `b`, `connected`, `plugged`, `starting`, `stopped`, `paused`, `complete`, `charging_completed` |
+| **C**  | charging     | `c`, `charging`                                                                                |
+
+Many integrations use their own wording.
+If the entity reports a state that isn't in the table, the log shows the raw value together with the entity name.
+Add that value to the matching **States for status A/B/C** field in the advanced options of the device.
+Multiple values are separated by commas, upper and lower case don't matter.
+
+```yaml
+statusB: charging_stopped, charging_error
+statusC: instant_charging
+```
+
+A `binary_sensor` as status entity also needs an explicit mapping, e.g. `statusA: off` and `statusC: on`.
 
 ## Further Resources (Videos)
 


### PR DESCRIPTION
Closes #1135

Documents the configurable Home Assistant charge status values from evcc-io/evcc#32136 and reworks the surrounding Home Assistant docs.

**Charge status** (new section on the smart home page): the built-in state mapping as a table, how to extend it via the `statusA/B/C` fields, and the note that a `binary_sensor` status entity now needs an explicit mapping since `on`/`off` are no longer built in.

**Entity values**: what the entities behind numeric and on/off fields have to deliver, including unit handling (`unit_of_measurement`, `W`/`kW`, `Wh`/`kWh`/`MWh`) and `unknown`/`unavailable`.

**Setup**: the instance discovery, manual address entry and authorisation steps were only listed as bare keywords before. The app case is a note now.

**Add-on → app**: Home Assistant renamed add-ons to apps in 2026.2, including the UI path (**Settings → Apps → Install app**). Prose and click paths follow, paths and repository URLs (`/addon_configs/…`, `hassio-addon`) stay as they are. The install card claimed the app comes via HACS, which was never the case.

Two things worth a second pair of eyes: the German UI labels („Apps", „App installieren") are guesses since Home Assistant's translations aren't public, and the evcc store listing may still call itself an add-on.
