### PR TITLE
Curtailment devices: document new device class

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@ Device pages are generated from YAML templates that are synchronised with the ma
 
 Most content is **manually written**, except for:
 
-- **Device list pages** — `chargers`, `meters`, `vehicles`, `smartswitches`, `heating`, `tariffs` — rendered by routes under `src/pages/[lang]/` using `src/utils/devices.ts` against the YAML templates.
+- **Device list pages** — `chargers`, `meters`, `vehicles`, `smartswitches`, `heating`, `tariffs`, `external-limit` (hems integrations + curtailment devices), `notifications` — rendered by routes under `src/pages/[lang]/` using `src/utils/devices.ts` against the YAML templates.
 - **Device detail pages** — same routes, one per template.
 - **CLI reference** — `reference/cli/*.md` generated from the main evcc repository (English only, German falls back automatically).
 - **REST API** — generated from `public/openapi.yaml` by `starlight-openapi`.
@@ -38,7 +38,7 @@ YAML device templates organised by:
 
 - Channel: `nightly/` and `release/`
 - Language: `de/`, `en/`
-- Category: `charger/`, `meter/`, `vehicle/`, `tariff/`
+- Category: `charger/`, `meter/`, `vehicle/`, `tariff/`, `hems/`, `curtailer/`, `messenger/`
 
 The nightly/release toggle in the UI switches which collection is used at runtime.
 

--- a/src/components/UserDefinedHint.astro
+++ b/src/components/UserDefinedHint.astro
@@ -1,7 +1,7 @@
 ---
 interface Props {
   lang: "de" | "en";
-  kind?: "device" | "tariff" | "hems" | "messenger";
+  kind?: "device" | "tariff" | "hems" | "messenger" | "curtailer";
   /** When set, the hint also points at the nightly version of the list. */
   nightlyHref?: string;
 }
@@ -17,7 +17,9 @@ const userDefinedAnchor =
       ? `${userDefinedUrl}#external-limit`
       : kind === "messenger"
         ? `${userDefinedUrl}#notification-service`
-        : userDefinedUrl;
+        : kind === "curtailer"
+          ? `${userDefinedUrl}#curtailer`
+          : userDefinedUrl;
 
 const featureRequest =
   lang === "de"

--- a/src/components/features.ts
+++ b/src/components/features.ts
@@ -64,7 +64,7 @@ const descriptions: Record<string, Partial<Record<Lang, string>>> = {
   },
   curtail: {
     de: "Wechselrichter-Erzeugung kann reduziert werden (bspw. § 9 EEG). Siehe [Externe Begrenzung](/de/external-limit).",
-    en: "Inverter production can be reduced (e.g. § 9 EEG). See [External Limit](/en/external-limit).",
+    en: "Inverter production can be reduced (e.g. § 9 EEG). See [External Limit](/en/external-limit#curtailment-devices).",
   },
   ocpp: {
     de: "Kommunikation über das offene OCPP-Protokoll.",

--- a/src/components/intros/CurtailmentDevicesIntro.astro
+++ b/src/components/intros/CurtailmentDevicesIntro.astro
@@ -1,0 +1,50 @@
+---
+interface Props {
+  lang: "de" | "en";
+}
+const { lang } = Astro.props;
+---
+
+{lang === "de" ? (
+  <>
+    <p>
+      Die Abregelung wirkt auf die Wechselrichter.
+      Die meisten Wechselrichter werden über ihre PV-Zähler-Konfiguration abgeregelt.
+      Sie sind auf der Seite <a href="/de/meters">PV, Batterie, Netz, Zähler</a> mit „Abregelbar“ markiert und benötigen keine weitere Einrichtung.
+    </p>
+    <p>
+      Gibt es mehrere Wechselrichter oder einen eigenen <strong>Einspeisebegrenzer</strong> wie den SMA Sunny Home Manager 2.0, legst du dafür einen Einspeisebegrenzer an.
+      Das Gleiche gilt, wenn sich der Wechselrichter nicht über seine Zähler-Konfiguration abregeln lässt.
+      Bei mehreren Wechselrichtern muss das Limit am führenden Wechselrichter gesetzt werden (z.&nbsp;B. SolarEdge).
+      Das Abregelungssignal wird als Prozentwert gleichermaßen an alle abregelbaren Zähler und Einspeisebegrenzer übergeben.
+      Jedes Gerät setzt ihn bezogen auf seine eigene Nennleistung um.
+      Die <strong>Installierte Generatorleistung</strong> eines Einspeisebegrenzers muss deshalb die gesamte Anlage abdecken.
+    </p>
+    <p>
+      Die Einrichtung erfolgt über <strong>Konfiguration → Netzanschluss → Einspeisebegrenzung hinzufügen</strong>.
+      Die Schaltfläche erscheint, sobald ein PV-Zähler konfiguriert ist.
+      Ein Einspeisebegrenzer wird erst aktiv, wenn eine der oben aufgeführten <a href="#integrations">Integrationen</a> ein Einspeiselimit signalisiert.
+    </p>
+  </>
+) : (
+  <>
+    <p>
+      Curtailment acts on the inverters.
+      Most inverters are curtailed through their solar meter configuration.
+      They are marked <strong>Curtailable</strong> on the <a href="/en/meters">PV, Battery, Grid, Meter</a> page and need no additional setup.
+    </p>
+    <p>
+      If there are several inverters or a dedicated feed-in limiter such as the SMA Sunny Home Manager 2.0, set up a separate <strong>curtailment device</strong>.
+      The same applies when the inverter can't be curtailed through its meter configuration.
+      With several inverters, the limit has to be written to the leader inverter (e.g. SolarEdge).
+      The curtailment signal is passed as a percentage to all curtailable meters and curtailment devices alike.
+      Each device applies it relative to its own nominal power.
+      The <strong>Installed generator power</strong> of the curtailment device therefore has to cover the whole installation.
+    </p>
+    <p>
+      Curtailment devices are set up via <strong>Configuration → Grid → Add curtailment device</strong>.
+      The button appears once a solar meter is configured.
+      A curtailment device only becomes active when one of the <a href="#integrations">integrations</a> above signals a feed-in limit.
+    </p>
+  </>
+)}

--- a/src/components/intros/ExternalLimitIntro.astro
+++ b/src/components/intros/ExternalLimitIntro.astro
@@ -48,6 +48,7 @@ const { lang } = Astro.props;
         <p>
           Die Abregelung wird nur für ausgewählte Wechselrichter unterstützt.
           Unterstützte Geräte sind in der <a href="/de/meters">Geräteübersicht</a> mit „Abregelbar" markiert.
+          Geräte, die ausschließlich die Einspeisung begrenzen, findest du unter <a href="#curtailment-devices">Einspeisebegrenzer</a>.
         </p>
       </div>
     </aside>
@@ -123,6 +124,7 @@ const { lang } = Astro.props;
         <p>
           Curtailment is only supported for selected inverters.
           Supported devices are marked with "Curtailable" in the <a href="/en/meters">device overview</a>.
+          Devices that only provide feed-in limitation are listed under <a href="#curtailment-devices">Curtailment</a>.
         </p>
       </div>
     </aside>

--- a/src/components/lists/ExternalLimitList.astro
+++ b/src/components/lists/ExternalLimitList.astro
@@ -4,6 +4,7 @@ import StarlightPage from "@astrojs/starlight/components/StarlightPage.astro";
 import DeviceCardList from "@components/DeviceCardList.astro";
 import ExternalLimitIntro from "@components/intros/ExternalLimitIntro.astro";
 import ExternalLimitOutro from "@components/intros/ExternalLimitOutro.astro";
+import CurtailmentDevicesIntro from "@components/intros/CurtailmentDevicesIntro.astro";
 import UserDefinedHint from "@components/UserDefinedHint.astro";
 import ChannelListNav from "@components/ChannelListNav.astro";
 import { sortDevices, collectionName, nightlyPageHead } from "@utils/devices";
@@ -18,6 +19,8 @@ const isNightly = channel === "nightly";
 
 const coll = await getCollection(collectionName("hems", lang, channel) as any);
 const devices = sortDevices(coll as any);
+const curtailerColl = await getCollection(collectionName("curtailers", lang, channel) as any);
+const curtailers = sortDevices(curtailerColl as any);
 const basePath = `/${lang}${isNightly ? "/nightly" : ""}/external-limit`;
 
 const title =
@@ -38,6 +41,7 @@ const headings =
         { depth: 2, slug: "setup", text: "Einrichtung" },
         { depth: 3, slug: "eebus-pairing", text: "Pairing bei EEBus-Integrationen" },
         { depth: 2, slug: "integrations", text: "Integrationen" },
+        { depth: 2, slug: "curtailment-devices", text: "Einspeisebegrenzer" },
         { depth: 2, slug: "how-it-works", text: "Funktionsweise" },
         { depth: 2, slug: "logging", text: "Protokollierung" },
         { depth: 2, slug: "additional-consumers", text: "Steuerung weiterer Verbraucher" },
@@ -50,6 +54,7 @@ const headings =
         { depth: 2, slug: "setup", text: "Setup" },
         { depth: 3, slug: "eebus-pairing", text: "Pairing for EEBus Integrations" },
         { depth: 2, slug: "integrations", text: "Integrations" },
+        { depth: 2, slug: "curtailment-devices", text: "Curtailment" },
         { depth: 2, slug: "how-it-works", text: "How It Works" },
         { depth: 2, slug: "logging", text: "Logging" },
         { depth: 2, slug: "additional-consumers", text: "Controlling Additional Consumers" },
@@ -77,6 +82,16 @@ const frontmatter = {
   />
   {channel === "release" && (
     <UserDefinedHint lang={lang} kind="hems" nightlyHref={`/${lang}/nightly/external-limit`} />
+  )}
+  <h2 id="curtailment-devices">{lang === "de" ? "Einspeisebegrenzer" : "Curtailment"}</h2>
+  <CurtailmentDevicesIntro lang={lang} />
+  <DeviceCardList devices={curtailers as any} lang={lang} basePath={basePath} />
+  {channel === "release" && (
+    <UserDefinedHint
+      lang={lang}
+      kind="curtailer"
+      nightlyHref={`/${lang}/nightly/external-limit#curtailment-devices`}
+    />
   )}
   <ExternalLimitOutro lang={lang} />
 </StarlightPage>

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -109,6 +109,8 @@ export const collections = {
   "hems-en": deviceCollection("en", "hems"),
   "messengers-de": deviceCollection("de", "messenger"),
   "messengers-en": deviceCollection("en", "messenger"),
+  "curtailers-de": deviceCollection("de", "curtailer"),
+  "curtailers-en": deviceCollection("en", "curtailer"),
   "chargers-nightly-de": deviceCollection("de", "charger", "nightly"),
   "chargers-nightly-en": deviceCollection("en", "charger", "nightly"),
   "meters-nightly-de": deviceCollection("de", "meter", "nightly"),
@@ -121,4 +123,6 @@ export const collections = {
   "hems-nightly-en": deviceCollection("en", "hems", "nightly"),
   "messengers-nightly-de": deviceCollection("de", "messenger", "nightly"),
   "messengers-nightly-en": deviceCollection("en", "messenger", "nightly"),
+  "curtailers-nightly-de": deviceCollection("de", "curtailer", "nightly"),
+  "curtailers-nightly-en": deviceCollection("en", "curtailer", "nightly"),
 };

--- a/src/content/docs/de/installation/configuration.mdx
+++ b/src/content/docs/de/installation/configuration.mdx
@@ -32,7 +32,7 @@ Die Weboberfläche ist der einfachste und schnellste Weg, evcc einzurichten.
 Im Konfigurationsbereich kannst du folgende Komponenten einrichten:
 
 - **Ladepunkte & Heizungen** (empfohlen): Wallboxen und Wärmepumpen
-- **Netzanschluss** (empfohlen): Hauszähler und Stromtarife – wichtig für korrektes Energiemanagement
+- **Netzanschluss** (empfohlen): Hauszähler, Stromtarife und Einspeisebegrenzer – wichtig für korrektes Energiemanagement
 - **PV & Batterie** (optional): Solaranlagen und Batteriespeicher
 - **Fahrzeuge** (optional): Fahrzeugintegrationen für Akkugröße und Ladestand, ermöglicht intelligenteres Laden
 

--- a/src/content/docs/de/reference/configuration/curtailers.md
+++ b/src/content/docs/de/reference/configuration/curtailers.md
@@ -1,0 +1,48 @@
+---
+title: "curtailers"
+sidebar:
+  order: 6
+---
+
+_Curtailers_ (Einspeisebegrenzer) ist eine Liste von Geräten, die ausschließlich die Einspeisung der PV-Anlage auf Anforderung des Netzbetreibers begrenzen (§ 9 EEG).
+Die meisten Wechselrichter werden über ihren Eintrag unter [`meters`](/de/reference/configuration/meters) abgeregelt und benötigen kein separates Gerät.
+Ein eigener Einspeisebegrenzer wird nur benötigt, wenn der Wechselrichter nicht über seine Zähler-Konfiguration abgeregelt werden kann, für den SMA Sunny Home Manager 2.0 oder für Anlagen mit mehreren Wechselrichtern, bei denen das Limit am führenden Wechselrichter gesetzt werden muss.
+Hintergrund und die Liste der unterstützten Geräte findest du unter [Externe Begrenzung](/de/external-limit#curtailment-devices).
+
+Einspeisebegrenzer werden über [`site.curtailers`](/de/reference/configuration/site#curtailers) referenziert.
+Sie werden erst aktiv, wenn die [`hems`](/de/reference/configuration/hems)-Integration ein Einspeiselimit signalisiert.
+Das Limit wird als Prozentwert der installierten Generatorleistung gleichermaßen an alle abregelbaren `pv`-Zähler und Einspeisebegrenzer übergeben.
+
+**Beispiel**:
+
+```yaml
+curtailers:
+  - name: my_curtailer
+    type: template
+    template: solaredge
+    modbus: tcpip
+    host: 192.168.0.10
+    port: 1502
+    id: 1
+    productionnominalmax: 15000 # installierte Generatorleistung der gesamten Anlage (Wp)
+
+site:
+  curtailers:
+    - my_curtailer
+```
+
+---
+
+## Erforderliche Parameter
+
+### `name`
+
+Eindeutiger Name des Geräts.
+Wird als Referenz in [`site.curtailers`](/de/reference/configuration/site#curtailers) verwendet.
+
+---
+
+### `type`
+
+- `template`: Eines der [unterstützten Geräte](/de/external-limit#curtailment-devices). Die Geräteseite zeigt den vollständigen Konfigurationsblock.
+- `custom`: [Benutzerdefiniertes Gerät](/de/user-defined-devices#curtailer) mit den Plugins `curtail` und `curtailed`.

--- a/src/content/docs/de/reference/configuration/eebus.md
+++ b/src/content/docs/de/reference/configuration/eebus.md
@@ -1,7 +1,7 @@
 ---
 title: "eebus"
 sidebar:
-  order: 13
+  order: 14
 ---
 
 :::tip[Empfehlung]

--- a/src/content/docs/de/reference/configuration/hems.md
+++ b/src/content/docs/de/reference/configuration/hems.md
@@ -1,7 +1,7 @@
 ---
 title: "hems"
 sidebar:
-  order: 7
+  order: 8
 ---
 
 Unter `hems` wird die externe Steuerung von Verbrauchsleistung und Einspeisung konfiguriert.
@@ -9,7 +9,8 @@ Dies wird z. B. für die Umsetzung von § 14a EnWG oder § 9 EEG benötigt.
 Details zu Hintergrund und Einrichtung findest du unter [Externe Begrenzung](/de/external-limit).
 
 :::note[Hinweis]
-Abregelung und das Dimmen steuerbarer Verbraucher wirken direkt am Gerät, dafür sind keine Stromkreise erforderlich.
+Die Abregelung wirkt direkt auf die abregelbaren `pv`-Zähler und [Einspeisebegrenzer](/de/reference/configuration/curtailers), das Dimmen direkt auf die steuerbaren Verbraucher.
+Dafür sind keine Stromkreise erforderlich.
 Damit das Verbrauchslimit auf Ladepunkte wirkt, müssen Stromkreise im [Lastmanagement](/de/features/loadmanagement) eingerichtet sein.
 Ein aktives Limit begrenzt dann den obersten Stromkreis.
 :::

--- a/src/content/docs/de/reference/configuration/index.md
+++ b/src/content/docs/de/reference/configuration/index.md
@@ -128,6 +128,12 @@ _Meters_ (Hausinstallation) ist eine Liste von Geräten welche verschiedene Stro
 
 [Weiterlesen...](/de/reference/configuration/meters)
 
+### Curtailers
+
+_Curtailers_ (Einspeisebegrenzer) sind Geräte, die ausschließlich die Einspeisung der PV-Anlage auf Anforderung des Netzbetreibers begrenzen (§ 9 EEG), z. B. der SMA Sunny Home Manager 2.0 oder der führende Wechselrichter einer Anlage mit mehreren Wechselrichtern.
+
+[Weiterlesen...](/de/reference/configuration/curtailers)
+
 ### Vehicles
 
 Um die Ladung auf einen bestimmten Ladestand (Soc) in EVs zu begrenzen, können hier die vorhandenen Fahrzeuge und Online Zugangsdaten angegeben werden.

--- a/src/content/docs/de/reference/configuration/influx.md
+++ b/src/content/docs/de/reference/configuration/influx.md
@@ -1,7 +1,7 @@
 ---
 title: "influx"
 sidebar:
-  order: 15
+  order: 16
 ---
 
 Definiert die Influx Konfiguration, um Daten in Influx zu schreiben.

--- a/src/content/docs/de/reference/configuration/interval.md
+++ b/src/content/docs/de/reference/configuration/interval.md
@@ -1,7 +1,7 @@
 ---
 title: "interval"
 sidebar:
-  order: 9
+  order: 10
 ---
 
 Definiert das zeitliche Interval, in welchem neue Werte von allen Messgeräten gelesen werden und die Ladeströme der Wallboxen neu geregelt wird.

--- a/src/content/docs/de/reference/configuration/log.md
+++ b/src/content/docs/de/reference/configuration/log.md
@@ -1,7 +1,7 @@
 ---
 title: "log, levels"
 sidebar:
-  order: 10
+  order: 11
 ---
 
 ## `log`

--- a/src/content/docs/de/reference/configuration/messaging.md
+++ b/src/content/docs/de/reference/configuration/messaging.md
@@ -1,7 +1,7 @@
 ---
 title: "messaging"
 sidebar:
-  order: 12
+  order: 13
 ---
 
 Der Abschnitt `messaging` konfiguriert [Benachrichtigungen](/de/notifications) über Ladevorgänge per Diensten wie Telegram, Pushover, ntfy oder E-Mail.

--- a/src/content/docs/de/reference/configuration/modbusproxy.md
+++ b/src/content/docs/de/reference/configuration/modbusproxy.md
@@ -1,7 +1,7 @@
 ---
 title: "modbusproxy"
 sidebar:
-  order: 17
+  order: 18
 ---
 
 _modbusproxy_ ist eine Liste von Geräten welche für Drittsysteme via Modbus TCP im Netzwerk freigeben werden.

--- a/src/content/docs/de/reference/configuration/mqtt.md
+++ b/src/content/docs/de/reference/configuration/mqtt.md
@@ -1,7 +1,7 @@
 ---
 title: "mqtt"
 sidebar:
-  order: 14
+  order: 15
 ---
 
 Stellt die Konnektivität mit einem MQTT-Broker her.

--- a/src/content/docs/de/reference/configuration/site.mdx
+++ b/src/content/docs/de/reference/configuration/site.mdx
@@ -30,6 +30,8 @@ site:
       - myconsumer1 # regular consumer, recorded for consumption statistics
     ext:
       - myext1 # for data logging, load management, etc.
+  curtailers:
+    - my_curtailer # curtailment device reference
   residualPower: 100
 ```
 
@@ -192,6 +194,20 @@ oder
 ext:
   - myext1 # first ext meter reference
   - myext2 # second ext meter reference
+```
+
+### `curtailers`
+
+Einspeisebegrenzer aus der [`curtailers`](/de/reference/configuration/curtailers)-Konfiguration, die die Einspeisung auf Anforderung des Netzbetreibers begrenzen (§ 9 EEG).
+Sie werden zusammen mit den abregelbaren `pv`-Zählern angesteuert, wenn die [`hems`](/de/reference/configuration/hems)-Integration ein Limit signalisiert.
+
+**Mögliche Werte**: Eine Liste von Werten eines `name` Parameters in der [`curtailers`](/de/reference/configuration/curtailers) Konfiguration.
+
+**Beispiel**:
+
+```yaml
+curtailers:
+  - my_curtailer # curtailment device reference
 ```
 
 ### `residualPower`

--- a/src/content/docs/de/reference/configuration/sponsortoken.md
+++ b/src/content/docs/de/reference/configuration/sponsortoken.md
@@ -1,7 +1,7 @@
 ---
 title: "sponsortoken"
 sidebar:
-  order: 16
+  order: 17
 ---
 
 `sponsortoken` definiert ein Token das auf [https://sponsor.evcc.io](https://sponsor.evcc.io) vergeben wird.

--- a/src/content/docs/de/reference/configuration/tariffs.md
+++ b/src/content/docs/de/reference/configuration/tariffs.md
@@ -1,7 +1,7 @@
 ---
 title: "tariffs"
 sidebar:
-  order: 11
+  order: 12
 ---
 
 Hier kannst du deinen Energietarif und gegebenenfalls deine Einspeisevergütung angeben.

--- a/src/content/docs/de/reference/configuration/telemetry.mdx
+++ b/src/content/docs/de/reference/configuration/telemetry.mdx
@@ -1,7 +1,7 @@
 ---
 title: "telemetry"
 sidebar:
-  order: 16
+  order: 17
 ---
 
 import SponsorshipRequired from "@components/SponsorshipRequired.astro";

--- a/src/content/docs/de/reference/configuration/uri.md
+++ b/src/content/docs/de/reference/configuration/uri.md
@@ -1,7 +1,7 @@
 ---
 title: "network"
 sidebar:
-  order: 8
+  order: 9
 ---
 
 Defines the IP address or hostname and port on which the web interface should be accessed.

--- a/src/content/docs/de/reference/configuration/vehicles.mdx
+++ b/src/content/docs/de/reference/configuration/vehicles.mdx
@@ -1,7 +1,7 @@
 ---
 title: "vehicles"
 sidebar:
-  order: 6
+  order: 7
 ---
 
 import { Tabs, TabItem } from "@astrojs/starlight/components";

--- a/src/content/docs/de/user-defined-devices.mdx
+++ b/src/content/docs/de/user-defined-devices.mdx
@@ -90,6 +90,7 @@ Zähler unter `meters:` können an verschiedenen Stellen innerhalb der `site` Ko
 Nicht alle Zählerrollen unterstützen alle Attribute:
 
 - `limitsoc` und `batterymode` werden ausschließlich für Batteriezähler genutzt (referenziert in `site.battery`).
+- `curtail` und `curtailed` werden gemeinsam für `pv`-Zähler verwendet, die eine Abregelung der Einspeisung unterstützen (§ 9 EEG).
 - `currents`, `voltages` und `powers` sind Phasen-Attribute, die mit genau drei Plugin-Konfigurationen (als YAML-Array) konfiguriert werden müssen und für Netzzähler (`grid`) und Wallboxen (`charge`) verwendet werden können.
 
 Plugins müssen den richtigen Datentyp zurückliefern.
@@ -103,12 +104,12 @@ Zur Konvertierung dienen die [Lese-Pipelines](/de/reference/plugins#reading).
 | `energy`       | `float`               | nein      | alle          | Zählerstand in kWh                                                          |
 | `returnenergy` | `float`               | nein      | alle          | Zählerstand in Gegenrichtung in kWh (siehe unten)                           |
 | `maxpower`     | `int`                 | nein      | `pv` (hybrid) | Maximale AC-Leistung in W                                                   |
+| `curtailed`    | `int`                 | nein      | `pv`          | Aktuelles Einspeiselimit in % (0 bis 100). Nur zusammen mit `curtail`.      |
 | `soc`          | `int`                 | nein      | `battery`     | Ladestand in %                                                              |
 | `capacity`     | `float`               | nein      | `battery`     | Kapazität in kWh                                                            |
 | `powers`       | `[float,float,float]` | nein      | alle          | Phasenleistungen in W. Zur Vorzeichenerkennung bei vorzeichenlosen Strömen. |
 | `currents`     | `[float,float,float]` | nein      | alle          | Phasenströme in A. Zur Erkennung aktiver Phasen.                            |
 | `voltages`     | `[float,float,float]` | nein      | alle          | Phasenspannungen in V. Zur Anschlusserkennung (1p/3p).                      |
-| `curtailed`    | `int`                 | nein      | `pv`          | Aktuelles Einspeiselimit in % (0 bis 100). Nur zusammen mit `curtail`.      |
 
 ### Vorzeichen und Richtungen \{#signs-and-directions\}
 

--- a/src/content/docs/de/user-defined-devices.mdx
+++ b/src/content/docs/de/user-defined-devices.mdx
@@ -6,7 +6,7 @@ tableOfContents:
 
 import { Tabs, TabItem } from "@astrojs/starlight/components";
 
-Beim Anlegen einer Wallbox, eines Heizgeräts, eines Netzzählers, einer Batterie, einer PV-Anlage, eines weiteren Verbrauchers, eines Fahrzeugs, eines Tarifs oder eines Benachrichtigungsdienstes lässt sich in der Geräteliste der Eintrag **Benutzerdefiniertes Gerät** wählen und eine eigene Logik auf Basis des [Plugin-Systems](/de/reference/plugins) beschreiben.
+Beim Anlegen einer Wallbox, eines Heizgeräts, eines Netzzählers, einer Batterie, einer PV-Anlage, eines weiteren Verbrauchers, eines Fahrzeugs, eines Tarifs, eines Einspeisebegrenzers oder eines Benachrichtigungsdienstes lässt sich in der Geräteliste der Eintrag **Benutzerdefiniertes Gerät** wählen und eine eigene Logik auf Basis des [Plugin-Systems](/de/reference/plugins) beschreiben.
 
 So lassen sich auch Geräte einbinden, die nicht von einem eingebauten Template abgedeckt sind, z. B. die aktuelle Leistung über einen HTTP-Endpunkt lesen oder einen Zielstrom per Modbus schreiben.
 
@@ -108,6 +108,7 @@ Zur Konvertierung dienen die [Lese-Pipelines](/de/reference/plugins#reading).
 | `powers`       | `[float,float,float]` | nein      | alle          | Phasenleistungen in W. Zur Vorzeichenerkennung bei vorzeichenlosen Strömen. |
 | `currents`     | `[float,float,float]` | nein      | alle          | Phasenströme in A. Zur Erkennung aktiver Phasen.                            |
 | `voltages`     | `[float,float,float]` | nein      | alle          | Phasenspannungen in V. Zur Anschlusserkennung (1p/3p).                      |
+| `curtailed`    | `int`                 | nein      | `pv`          | Aktuelles Einspeiselimit in % (0 bis 100). Nur zusammen mit `curtail`.      |
 
 ### Vorzeichen und Richtungen \{#signs-and-directions\}
 
@@ -133,10 +134,11 @@ Echte Zählerstände liefern genauere Langzeitstatistiken.
 
 ### Schreib-Attribute
 
-| Attribut      | Typ   | Erfordert | Kontext   | Beschreibung                                                                                                                                          |
-| ------------- | ----- | --------- | --------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `limitsoc`    | `int` | nein      | `battery` | Setze Ladeziel für Batterie in %. Das Ladeziel wird aus den konfigurierten `MinSoc`, `MaxSoc` und dem aktuellen Ladestand (Attribut `soc`) berechnet. |
-| `batterymode` | `int` | nein      | `battery` | Setze Lademodus direkt (1: normal, 2: hold, 3: charge)                                                                                                |
+| Attribut      | Typ   | Erfordert | Kontext   | Beschreibung                                                                                                                                                    |
+| ------------- | ----- | --------- | --------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `limitsoc`    | `int` | nein      | `battery` | Setze Ladeziel für Batterie in %. Das Ladeziel wird aus den konfigurierten `MinSoc`, `MaxSoc` und dem aktuellen Ladestand (Attribut `soc`) berechnet.           |
+| `batterymode` | `int` | nein      | `battery` | Setze Lademodus direkt (1: normal, 2: hold, 3: charge)                                                                                                          |
+| `curtail`     | `int` | nein      | `pv`      | Setze Einspeiselimit in % der Nennleistung der Erzeugung (0 bis 100, `100` = kein Limit). Nur zusammen mit `curtailed`. Siehe [Einspeisebegrenzer](#curtailer). |
 
 ### Beispiel
 
@@ -690,6 +692,60 @@ curtailedPercent:
   topic: hems/curtail/percent # Erlaubte Einspeisung in Prozent, 100 = keine Abregelung
 productionNominalMax: 10000 # Installierte Generatorleistung (Wp)
 ```
+
+## Einspeisebegrenzer \{#curtailer\}
+
+Ein benutzerdefinierter Einspeisebegrenzer begrenzt die Einspeisung der PV-Anlage auf Anforderung des Netzbetreibers (§ 9 EEG), wenn der Wechselrichter nicht über seine [Zähler](#meter)-Konfiguration abgeregelt werden kann.
+Wähle dazu in der Oberfläche unter **Konfiguration → Netzanschluss → Einspeisebegrenzung hinzufügen** die Option **Benutzerdefiniertes Gerät**.
+Siehe auch die [`curtailers`-Konfigurationsreferenz](/de/reference/configuration/curtailers) und [Externe Begrenzung](/de/external-limit#curtailment-devices).
+
+Das Gerät erhält die erlaubte Einspeisung in Prozent der installierten Generatorleistung und muss sie am Wechselrichter umsetzen.
+`100` bedeutet kein Limit.
+
+### Attribute
+
+| Attribut    | Typ    | Erforderlich | Beschreibung                                                                                                                                                |
+| ----------- | ------ | ------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `curtail`   | Plugin | ja           | Setzt das Einspeiselimit in % der Nennleistung der Erzeugung (0 bis 100). Muss Schreibzugriff unterstützen.                                                 |
+| `curtailed` | Plugin | ja           | Liest das aktuelle Einspeiselimit in %. Kann das Gerät es nicht liefern, wird das [`error`](/de/reference/plugins#error)-Plugin verwendet (siehe Beispiel). |
+
+### Beispiele
+
+<Tabs>
+<TabItem label="HTTP">
+
+```yaml
+curtail:
+  source: http
+  uri: http://inverter.local/api/limit?percent={{ .curtail }}
+  method: POST
+curtailed:
+  source: http
+  uri: http://inverter.local/api/limit
+  jq: .percent
+```
+
+</TabItem>
+<TabItem label="Modbus">
+
+Der Wechselrichter kann sein Limit nicht zurückmelden, `curtailed` liefert daher `ErrNotAvailable` und das Limit wird bei jeder Änderung geschrieben.
+
+```yaml
+curtail:
+  source: modbus
+  uri: 192.168.0.10:502
+  id: 1
+  register:
+    type: writesingle
+    address: 40016
+    encoding: uint16
+curtailed:
+  source: error
+  error: ErrNotAvailable
+```
+
+</TabItem>
+</Tabs>
 
 ## Benachrichtigungsdienst \{#notification-service\}
 

--- a/src/content/docs/en/installation/configuration.mdx
+++ b/src/content/docs/en/installation/configuration.mdx
@@ -32,7 +32,7 @@ The web interface is the easiest and fastest way to set up evcc.
 In the configuration area, you can set up the following components:
 
 - **Charging points & Heaters** (recommended): Wallboxes and heat pumps
-- **Grid** (recommended): Grid connection meter and electricity tariffs – important for proper energy management
+- **Grid** (recommended): Grid connection meter, electricity tariffs and curtailment devices – important for proper energy management
 - **Solar & Battery** (optional): Solar systems and battery storage
 - **Vehicles** (optional): Vehicle integrations for battery capacity and state of charge, enables smarter charging
 

--- a/src/content/docs/en/reference/configuration/curtailers.md
+++ b/src/content/docs/en/reference/configuration/curtailers.md
@@ -1,0 +1,48 @@
+---
+title: "curtailers"
+sidebar:
+  order: 6
+---
+
+_Curtailers_ (curtailment devices) is a list of devices that only limit the feed-in of the solar installation on request of the grid operator (§ 9 EEG).
+Most inverters are curtailed through their [`meters`](/en/reference/configuration/meters) entry and don't need a separate device.
+A curtailment device is only required when the inverter can't be curtailed via its meter configuration, for the SMA Sunny Home Manager 2.0, or for systems with several inverters where the limit has to be written to the leader inverter.
+For background and the list of supported devices see [External Limit](/en/external-limit#curtailment-devices).
+
+Curtailment devices are referenced from [`site.curtailers`](/en/reference/configuration/site#curtailers).
+They only become active when the [`hems`](/en/reference/configuration/hems) integration signals a feed-in limit.
+The limit is passed as a percentage of the installed generator power to all curtailable `pv` meters and curtailment devices alike.
+
+**For example**:
+
+```yaml
+curtailers:
+  - name: my_curtailer
+    type: template
+    template: solaredge
+    modbus: tcpip
+    host: 192.168.0.10
+    port: 1502
+    id: 1
+    productionnominalmax: 15000 # installed generator power of the whole installation (Wp)
+
+site:
+  curtailers:
+    - my_curtailer
+```
+
+---
+
+## Required Parameters
+
+### `name`
+
+Unique name of the device.
+Used as reference in [`site.curtailers`](/en/reference/configuration/site#curtailers).
+
+---
+
+### `type`
+
+- `template`: One of the [supported devices](/en/external-limit#curtailment-devices). The device page shows the complete configuration block.
+- `custom`: [User-defined device](/en/user-defined-devices#curtailer) with the `curtail` and `curtailed` plugins.

--- a/src/content/docs/en/reference/configuration/eebus.md
+++ b/src/content/docs/en/reference/configuration/eebus.md
@@ -1,7 +1,7 @@
 ---
 title: "eebus"
 sidebar:
-  order: 13
+  order: 14
 ---
 
 :::tip[Recommendation]

--- a/src/content/docs/en/reference/configuration/hems.md
+++ b/src/content/docs/en/reference/configuration/hems.md
@@ -1,7 +1,7 @@
 ---
 title: "hems"
 sidebar:
-  order: 7
+  order: 8
 ---
 
 The `hems` section configures external control of consumption and feed-in power.
@@ -9,7 +9,8 @@ This is used e.g. for implementing German § 14a EnWG or § 9 EEG regulations.
 For background and setup details, see [External Limit](/en/external-limit).
 
 :::note[Note]
-Curtailment and dimming of controllable consumers act directly on the device, no circuit configuration is required.
+Curtailment acts directly on the curtailable `pv` meters and [curtailment devices](/en/reference/configuration/curtailers), dimming acts directly on the controllable consumers.
+No circuit configuration is required for either.
 To apply the consumption limit to charging points, circuits must be set up in [Load Management](/en/features/loadmanagement).
 An active limit then caps the top-level circuit.
 :::

--- a/src/content/docs/en/reference/configuration/index.md
+++ b/src/content/docs/en/reference/configuration/index.md
@@ -136,6 +136,12 @@ include:
 - Charging current of EV (if the charger does not support this directly)
 - Power flow of house battery(ies)
 
+### Curtailers
+
+[Curtailers](/en/reference/configuration/curtailers) are devices that only limit the feed-in of the solar
+installation on request of the grid operator (§ 9 EEG), e.g. the SMA Sunny Home Manager 2.0 or the leader
+inverter of a system with several inverters.
+
 ### Vehicles
 
 To limit the state of charge (SoC) of EVs to a specific level, you can specify

--- a/src/content/docs/en/reference/configuration/influx.md
+++ b/src/content/docs/en/reference/configuration/influx.md
@@ -1,7 +1,7 @@
 ---
 title: "influx"
 sidebar:
-  order: 15
+  order: 16
 ---
 
 Defines the configuration required to write data to Influx.

--- a/src/content/docs/en/reference/configuration/interval.md
+++ b/src/content/docs/en/reference/configuration/interval.md
@@ -1,7 +1,7 @@
 ---
 title: "interval"
 sidebar:
-  order: 9
+  order: 10
 ---
 
 Defines the time interval at which new values are read from all measurement devices and the charging currents of the chargers are re-regulated.

--- a/src/content/docs/en/reference/configuration/log.md
+++ b/src/content/docs/en/reference/configuration/log.md
@@ -1,7 +1,7 @@
 ---
 title: "log, levels"
 sidebar:
-  order: 10
+  order: 11
 ---
 
 ## `log`

--- a/src/content/docs/en/reference/configuration/messaging.md
+++ b/src/content/docs/en/reference/configuration/messaging.md
@@ -1,7 +1,7 @@
 ---
 title: "messaging"
 sidebar:
-  order: 12
+  order: 13
 ---
 
 The `messaging` section configures [notifications](/en/notifications) about charging sessions via services like Telegram, Pushover, ntfy, or email.

--- a/src/content/docs/en/reference/configuration/modbusproxy.md
+++ b/src/content/docs/en/reference/configuration/modbusproxy.md
@@ -1,7 +1,7 @@
 ---
 title: "modbusproxy"
 sidebar:
-  order: 17
+  order: 18
 ---
 
 The `modbusproxy` setting is a list of devices that are exposed for third-party systems via Modbus TCP on the network.

--- a/src/content/docs/en/reference/configuration/mqtt.md
+++ b/src/content/docs/en/reference/configuration/mqtt.md
@@ -1,7 +1,7 @@
 ---
 title: "mqtt"
 sidebar:
-  order: 14
+  order: 15
 ---
 
 Establishes connectivity with an MQTT broker.

--- a/src/content/docs/en/reference/configuration/site.mdx
+++ b/src/content/docs/en/reference/configuration/site.mdx
@@ -30,6 +30,8 @@ site:
       - myconsumer1 # regular consumer, recorded for consumption statistics
     ext:
       - myext1 # for data logging, load management, etc.
+  curtailers:
+    - my_curtailer # curtailment device reference
   residualPower: 100
 ```
 
@@ -190,6 +192,20 @@ or
 ext:
   - myext1 # first ext meter reference
   - myext2 # second ext meter reference
+```
+
+### `curtailers`
+
+Curtailment devices from the [`curtailers`](/en/reference/configuration/curtailers) configuration that limit feed-in on request of the grid operator (§ 9 EEG).
+They are applied together with the curtailable `pv` meters when the [`hems`](/en/reference/configuration/hems) integration signals a limit.
+
+**Possible values**: A list of values of a `name` parameter in the [`curtailers`](/en/reference/configuration/curtailers) configuration.
+
+**Example**:
+
+```yaml
+curtailers:
+  - my_curtailer # curtailment device reference
 ```
 
 ### `residualPower`

--- a/src/content/docs/en/reference/configuration/sponsortoken.md
+++ b/src/content/docs/en/reference/configuration/sponsortoken.md
@@ -1,7 +1,7 @@
 ---
 title: "sponsortoken"
 sidebar:
-  order: 16
+  order: 17
 ---
 
 `sponsortoken` defines a token that is provided on [https://sponsor.evcc.io](https://sponsor.evcc.io).

--- a/src/content/docs/en/reference/configuration/tariffs.md
+++ b/src/content/docs/en/reference/configuration/tariffs.md
@@ -1,7 +1,7 @@
 ---
 title: "tariffs"
 sidebar:
-  order: 11
+  order: 12
 ---
 
 You can specify your energy tariff and, if applicable, your feed-in tariff.

--- a/src/content/docs/en/reference/configuration/telemetry.mdx
+++ b/src/content/docs/en/reference/configuration/telemetry.mdx
@@ -1,7 +1,7 @@
 ---
 title: "telemetry"
 sidebar:
-  order: 16
+  order: 17
 ---
 
 import SponsorshipRequired from "@components/SponsorshipRequired.astro";

--- a/src/content/docs/en/reference/configuration/uri.md
+++ b/src/content/docs/en/reference/configuration/uri.md
@@ -1,7 +1,7 @@
 ---
 title: "network"
 sidebar:
-  order: 8
+  order: 9
 ---
 
 Defines the IP address or hostname and port on which the web interface should be accessed.

--- a/src/content/docs/en/reference/configuration/vehicles.mdx
+++ b/src/content/docs/en/reference/configuration/vehicles.mdx
@@ -1,7 +1,7 @@
 ---
 title: "vehicles"
 sidebar:
-  order: 6
+  order: 7
 ---
 
 import { Tabs, TabItem } from "@astrojs/starlight/components";

--- a/src/content/docs/en/user-defined-devices.mdx
+++ b/src/content/docs/en/user-defined-devices.mdx
@@ -90,6 +90,7 @@ Meters defined under `meters:` can be referenced from `site`:
 Not all meter roles support all attributes:
 
 - `limitsoc` and `batterymode` are used exclusively for battery meters (referenced from `site.battery`).
+- `curtail` and `curtailed` are used together for `pv` meters that support feed-in curtailment (§ 9 EEG).
 - `currents`, `voltages` and `powers` are phase attributes that must be configured with exactly three plugin entries each (as a YAML array) and apply to grid meters (`grid`) and wallboxes (`charge`).
 
 Return the correct data type from each plugin.
@@ -103,12 +104,12 @@ To convert, use the [reading pipelines](/en/reference/plugins#reading).
 | `energy`       | `float`               | no       | all           | Meter reading in kWh                                                 |
 | `returnenergy` | `float`               | no       | all           | Meter reading in reverse direction in kWh (see below)                |
 | `maxpower`     | `int`                 | no       | `pv` (hybrid) | Maximum AC power in W                                                |
+| `curtailed`    | `int`                 | no       | `pv`          | Current feed-in limit in % (0 to 100). Only together with `curtail`. |
 | `soc`          | `int`                 | no       | `battery`     | State of charge in %                                                 |
 | `capacity`     | `float`               | no       | `battery`     | Capacity in kWh                                                      |
 | `powers`       | `[float,float,float]` | no       | all           | Phase powers in W. For sign detection of unsigned currents.          |
 | `currents`     | `[float,float,float]` | no       | all           | Phase currents in A. For detecting active phases.                    |
 | `voltages`     | `[float,float,float]` | no       | all           | Phase voltages in V. For connection detection (1p/3p).               |
-| `curtailed`    | `int`                 | no       | `pv`          | Current feed-in limit in % (0 to 100). Only together with `curtail`. |
 
 ### Signs and Directions \{#signs-and-directions\}
 

--- a/src/content/docs/en/user-defined-devices.mdx
+++ b/src/content/docs/en/user-defined-devices.mdx
@@ -6,7 +6,7 @@ tableOfContents:
 
 import { Tabs, TabItem } from "@astrojs/starlight/components";
 
-When creating a charger, heater, grid meter, battery, solar system, other consumer, vehicle, tariff or notification service, you can pick the **User-defined device** option from the device type list and describe your own logic based on the [plugin system](/en/reference/plugins).
+When creating a charger, heater, grid meter, battery, solar system, other consumer, vehicle, tariff, curtailment device or notification service, you can pick the **User-defined device** option from the device type list and describe your own logic based on the [plugin system](/en/reference/plugins).
 
 That way you can integrate devices that aren't covered by a built-in template, e.g. read the current power from an HTTP endpoint, or write a target current via Modbus.
 
@@ -97,17 +97,18 @@ To convert, use the [reading pipelines](/en/reference/plugins#reading).
 
 ### Read attributes
 
-| Attribute      | Type                  | Required | Context       | Description                                                 |
-| -------------- | --------------------- | -------- | ------------- | ----------------------------------------------------------- |
-| `power`        | `float`               | yes      | all           | Current power in W                                          |
-| `energy`       | `float`               | no       | all           | Meter reading in kWh                                        |
-| `returnenergy` | `float`               | no       | all           | Meter reading in reverse direction in kWh (see below)       |
-| `maxpower`     | `int`                 | no       | `pv` (hybrid) | Maximum AC power in W                                       |
-| `soc`          | `int`                 | no       | `battery`     | State of charge in %                                        |
-| `capacity`     | `float`               | no       | `battery`     | Capacity in kWh                                             |
-| `powers`       | `[float,float,float]` | no       | all           | Phase powers in W. For sign detection of unsigned currents. |
-| `currents`     | `[float,float,float]` | no       | all           | Phase currents in A. For detecting active phases.           |
-| `voltages`     | `[float,float,float]` | no       | all           | Phase voltages in V. For connection detection (1p/3p).      |
+| Attribute      | Type                  | Required | Context       | Description                                                          |
+| -------------- | --------------------- | -------- | ------------- | -------------------------------------------------------------------- |
+| `power`        | `float`               | yes      | all           | Current power in W                                                   |
+| `energy`       | `float`               | no       | all           | Meter reading in kWh                                                 |
+| `returnenergy` | `float`               | no       | all           | Meter reading in reverse direction in kWh (see below)                |
+| `maxpower`     | `int`                 | no       | `pv` (hybrid) | Maximum AC power in W                                                |
+| `soc`          | `int`                 | no       | `battery`     | State of charge in %                                                 |
+| `capacity`     | `float`               | no       | `battery`     | Capacity in kWh                                                      |
+| `powers`       | `[float,float,float]` | no       | all           | Phase powers in W. For sign detection of unsigned currents.          |
+| `currents`     | `[float,float,float]` | no       | all           | Phase currents in A. For detecting active phases.                    |
+| `voltages`     | `[float,float,float]` | no       | all           | Phase voltages in V. For connection detection (1p/3p).               |
+| `curtailed`    | `int`                 | no       | `pv`          | Current feed-in limit in % (0 to 100). Only together with `curtail`. |
 
 ### Signs and Directions \{#signs-and-directions\}
 
@@ -136,6 +137,7 @@ Real meter readings give more accurate long-term statistics.
 | ------------- | ----- | -------- | --------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `limitsoc`    | `int` | no       | `battery` | Set charging target for battery in %. The charging target is calculated from the configured `MinSoc`, `MaxSoc` and the current state of charge (attribute `soc`). |
 | `batterymode` | `int` | no       | `battery` | Set charging mode directly (1: normal, 2: hold, 3: charge)                                                                                                        |
+| `curtail`     | `int` | no       | `pv`      | Set feed-in limit in % of the nominal production power (0 to 100, `100` = no limit). Only together with `curtailed`. See [Curtailment Device](#curtailer).        |
 
 ### Example
 
@@ -689,6 +691,60 @@ curtailedPercent:
   topic: hems/curtail/percent # Allowed feed-in in percent, 100 = no curtailment
 productionNominalMax: 10000 # Installed generator power (Wp)
 ```
+
+## Curtailment Device \{#curtailer\}
+
+A user-defined curtailment device limits the feed-in of the solar installation on request of the grid operator (§ 9 EEG) when the inverter can't be curtailed through its [meter](#meter) configuration.
+In the UI, pick **User-defined device** under **Configuration → Grid → Add curtailment device**.
+See also the [`curtailers` configuration reference](/en/reference/configuration/curtailers) and [External Limit](/en/external-limit#curtailment-devices).
+
+The device receives the allowed feed-in as a percentage of the installed generator power and has to apply it on the inverter.
+`100` means no limit.
+
+### Attributes
+
+| Attribute   | Type   | Required | Description                                                                                                                               |
+| ----------- | ------ | -------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| `curtail`   | plugin | yes      | Sets the feed-in limit in % of the nominal production power (0 to 100). Must support write access.                                        |
+| `curtailed` | plugin | yes      | Reads the current feed-in limit in %. If the device can't report it, use the [`error`](/en/reference/plugins#error) plugin (see example). |
+
+### Examples
+
+<Tabs>
+<TabItem label="HTTP">
+
+```yaml
+curtail:
+  source: http
+  uri: http://inverter.local/api/limit?percent={{ .curtail }}
+  method: POST
+curtailed:
+  source: http
+  uri: http://inverter.local/api/limit
+  jq: .percent
+```
+
+</TabItem>
+<TabItem label="Modbus">
+
+The inverter can't report its limit, so `curtailed` returns `ErrNotAvailable` and the limit is written whenever it changes.
+
+```yaml
+curtail:
+  source: modbus
+  uri: 192.168.0.10:502
+  id: 1
+  register:
+    type: writesingle
+    address: 40016
+    encoding: uint16
+curtailed:
+  source: error
+  error: ErrNotAvailable
+```
+
+</TabItem>
+</Tabs>
 
 ## Notification Service \{#notification-service\}
 

--- a/src/pages/[lang]/external-limit/[slug].astro
+++ b/src/pages/[lang]/external-limit/[slug].astro
@@ -2,10 +2,14 @@
 import DeviceDetailLayout from "@components/DeviceDetailLayout.astro";
 import { deviceDetailPaths, featuresFor, buildCodeBlocks, templateEditUrl } from "@utils/devices";
 
-export const getStaticPaths = () =>
-  deviceDetailPaths({ prefix: "hems", urlType: "external-limit", channel: "release" });
+// hems integrations and curtailment devices share the external-limit URL space
+export const getStaticPaths = async () => [
+  ...(await deviceDetailPaths({ prefix: "hems", urlType: "external-limit", channel: "release" })),
+  ...(await deviceDetailPaths({ prefix: "curtailers", urlType: "external-limit", channel: "release" })),
+];
 
 const { entry, lang, counterpartHref } = Astro.props as any;
+const kind: "hems" | "curtailer" = entry.collection.startsWith("curtailers") ? "curtailer" : "hems";
 ---
 
 <DeviceDetailLayout
@@ -14,8 +18,8 @@ const { entry, lang, counterpartHref } = Astro.props as any;
   channel="release"
   type="external-limit"
   categoryLabel={lang === "de" ? "Externe Begrenzung" : "External Limit"}
-  features={featuresFor("hems", entry, lang)}
-  codeBlocks={buildCodeBlocks(entry, "hems")}
-  editUrl={templateEditUrl(entry, "hems")}
+  features={featuresFor(kind, entry, lang)}
+  codeBlocks={buildCodeBlocks(entry, kind)}
+  editUrl={templateEditUrl(entry, kind)}
   counterpartHref={counterpartHref}
 />

--- a/src/pages/[lang]/nightly/external-limit/[slug].astro
+++ b/src/pages/[lang]/nightly/external-limit/[slug].astro
@@ -2,10 +2,14 @@
 import DeviceDetailLayout from "@components/DeviceDetailLayout.astro";
 import { deviceDetailPaths, featuresFor, buildCodeBlocks, templateEditUrl } from "@utils/devices";
 
-export const getStaticPaths = () =>
-  deviceDetailPaths({ prefix: "hems", urlType: "external-limit", channel: "nightly" });
+// hems integrations and curtailment devices share the external-limit URL space
+export const getStaticPaths = async () => [
+  ...(await deviceDetailPaths({ prefix: "hems", urlType: "external-limit", channel: "nightly" })),
+  ...(await deviceDetailPaths({ prefix: "curtailers", urlType: "external-limit", channel: "nightly" })),
+];
 
 const { entry, lang, counterpartHref } = Astro.props as any;
+const kind: "hems" | "curtailer" = entry.collection.startsWith("curtailers") ? "curtailer" : "hems";
 ---
 
 <DeviceDetailLayout
@@ -14,8 +18,8 @@ const { entry, lang, counterpartHref } = Astro.props as any;
   channel="nightly"
   type="external-limit"
   categoryLabel={lang === "de" ? "Externe Begrenzung" : "External Limit"}
-  features={featuresFor("hems", entry, lang)}
-  codeBlocks={buildCodeBlocks(entry, "hems")}
-  editUrl={templateEditUrl(entry, "hems")}
+  features={featuresFor(kind, entry, lang)}
+  codeBlocks={buildCodeBlocks(entry, kind)}
+  editUrl={templateEditUrl(entry, kind)}
   counterpartHref={counterpartHref}
 />

--- a/src/utils/devices.ts
+++ b/src/utils/devices.ts
@@ -61,6 +61,7 @@ export const CODE_PREAMBLES: Record<string, string> = {
   temperature: "tariffs:\n    temperature:",
   hems: "hems:",
   messenger: "messaging:\n  services:",
+  curtailer: "curtailers:\n    - name: my_curtailer",
 };
 
 const TRANSLATIONS_DE: Record<string, string> = {
@@ -299,7 +300,8 @@ export function featuresFor(
     | "smartswitch"
     | "heating"
     | "hems"
-    | "messenger",
+    | "messenger"
+    | "curtailer",
   entry: DeviceEntry,
   lang: "de" | "en",
 ): string[] {
@@ -336,7 +338,13 @@ export type Channel = "release" | "nightly";
  */
 export function collectionName(
   prefix:
-    "chargers" | "meters" | "vehicles" | "tariffs" | "hems" | "messengers",
+    | "chargers"
+    | "meters"
+    | "vehicles"
+    | "tariffs"
+    | "hems"
+    | "messengers"
+    | "curtailers",
   lang: "de" | "en",
   channel: Channel,
 ): string {
@@ -355,7 +363,14 @@ export const nightlyPageHead = [
 /** Link to the device's source template in the evcc repo (undefined if none). */
 export function templateEditUrl(
   entry: DeviceEntry,
-  dir: "charger" | "meter" | "vehicle" | "tariff" | "hems" | "messenger",
+  dir:
+    | "charger"
+    | "meter"
+    | "vehicle"
+    | "tariff"
+    | "hems"
+    | "messenger"
+    | "curtailer",
 ): string | undefined {
   return entry.data.template
     ? `https://github.com/evcc-io/evcc/tree/master/templates/definition/${dir}/${entry.data.template}.yaml`
@@ -372,7 +387,8 @@ export function buildCodeBlocks(
     | "heating"
     | "tariff"
     | "hems"
-    | "messenger",
+    | "messenger"
+    | "curtailer",
 ): string[] {
   const render = (entry.data.render as any[]) ?? [];
   if (type === "hems") {
@@ -417,7 +433,13 @@ export function buildCodeBlocks(
  */
 export async function deviceDetailPaths(opts: {
   prefix:
-    "chargers" | "meters" | "vehicles" | "tariffs" | "hems" | "messengers";
+    | "chargers"
+    | "meters"
+    | "vehicles"
+    | "tariffs"
+    | "hems"
+    | "messengers"
+    | "curtailers";
   /** URL segment, e.g. "smartswitches" (may differ from the collection prefix). */
   urlType: string;
   channel: Channel;


### PR DESCRIPTION
Closes #1166, documents evcc-io/evcc#32416, supersedes #1173

Adds documentation for the new curtailment device class. The device list lives as a section on the External Limit page next to the hems integrations, since curtailment devices only act on a § 9 EEG signal from one of those integrations.

- External Limit page: new section "Curtailment" / „Einspeisebegrenzer“ with intro, device list from the `curtailer` templates and a user-defined hint; detail pages share the external-limit URL space
- New `curtailers` page in the evcc.yaml reference, `site.curtailers` on the site page, cross-links from index and hems pages
- User-defined devices: new curtailment device section with `curtail`/`curtailed` plugins and HTTP/Modbus examples; meter attributes gain `curtail`/`curtailed` for pv meters
- Content collections and helpers wired for the `curtailer` template category (nightly only until the next release sync)

🤖 Generated with [Claude Code](https://claude.com/claude-code)